### PR TITLE
fix(demos): use demo.metaTitle ?? demo.title in tfg-polyps

### DIFF
--- a/src/pages/demos/tfg-polyps.astro
+++ b/src/pages/demos/tfg-polyps.astro
@@ -11,7 +11,7 @@ const demo = getDemo('tfg-polyps', lang);
 ---
 
 <DemoLayout
-  title={metaTitle}
+  title={demo.metaTitle ?? demo.title}
   description={demo.metaDescription}
   slug="tfg-polyps"
 >


### PR DESCRIPTION
Hotfix: the Pages build on main is failing with `metaTitle is not defined` in `src/pages/demos/tfg-polyps.astro` (see run https://github.com/cuberhaus/PersonalPortfolio/actions/runs/24910235841).

Line 14 referenced a bare `metaTitle` instead of `demo.metaTitle`. Updated to `demo.metaTitle ?? demo.title` to match the pattern used in `apa-practica.astro`, `bitsx-marato.astro`, and `joc-eda.astro`.