### PR TITLE
a11y: partial contrast wins from axe-core audit

### DIFF
--- a/src/components/demos/ApaPracticaDemo.tsx
+++ b/src/components/demos/ApaPracticaDemo.tsx
@@ -254,7 +254,7 @@ function KnnCanvas({ t, log }: { t: typeof TRANSLATIONS.en; log: ReturnType<type
             </span>
           </span>
         ) : (
-          <span style={{ color: 'var(--border-color-hover)' }}>{t.clickToPlot}</span>
+          <span style={{ color: 'var(--text-muted)' }}>{t.clickToPlot}</span>
         )}
       </div>
     </div>
@@ -407,7 +407,13 @@ function FeatureSlider({
         <span style={{ fontSize: '0.82rem', fontWeight: 600, color: 'var(--text-primary)' }}>
           {label}
         </span>
-        <span style={{ fontSize: '0.82rem', fontFamily: 'ui-monospace, monospace', color }}>
+        <span
+          style={{
+            fontSize: '0.82rem',
+            fontFamily: 'ui-monospace, monospace',
+            color: 'var(--text-primary)',
+          }}
+        >
           {value} <span style={{ color: 'var(--text-muted)', fontSize: '0.72rem' }}>{unit}</span>
         </span>
       </div>
@@ -437,7 +443,7 @@ function FeatureImportance({ t }: { t: typeof TRANSLATIONS.en }) {
               width: 36,
               fontSize: '0.78rem',
               fontWeight: 700,
-              color: f.color,
+              color: 'var(--text-primary)',
               textAlign: 'right',
             }}
           >
@@ -475,7 +481,7 @@ function FeatureImportance({ t }: { t: typeof TRANSLATIONS.en }) {
           </span>
         </div>
       ))}
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.68rem', color: 'var(--border-color-hover)' }}>
+      <p style={{ margin: '0.25rem 0 0', fontSize: '0.68rem', color: 'var(--text-muted)' }}>
         {t.featNote}
       </p>
     </div>
@@ -520,7 +526,7 @@ export default function ApaPracticaDemo({ lang = 'en' }: { lang?: Lang }) {
             {t.mlPipeline}
           </div>
           <span style={{ fontSize: '0.82rem', color: 'var(--text-muted)' }}>{t.course}</span>
-          <span style={{ fontSize: '0.82rem', color: 'var(--border-color-hover)' }}>·</span>
+          <span style={{ fontSize: '0.82rem', color: 'var(--text-muted)' }}>·</span>
           <span style={{ fontSize: '0.82rem', color: 'var(--text-muted)' }}>
             {t.with}{' '}
             <a

--- a/src/components/demos/BitsXMaratoDemo.tsx
+++ b/src/components/demos/BitsXMaratoDemo.tsx
@@ -350,7 +350,7 @@ function DiameterExplorer({ t }: { t: typeof TRANSLATIONS.en }) {
         </p>
       </div>
 
-      <p style={{ margin: '0.5rem 0 0', fontSize: '0.68rem', color: 'var(--border-color-hover)' }}>
+      <p style={{ margin: '0.5rem 0 0', fontSize: '0.68rem', color: 'var(--text-muted)' }}>
         {t.diamNote}
       </p>
     </div>

--- a/src/components/demos/TfgPolypDemo.tsx
+++ b/src/components/demos/TfgPolypDemo.tsx
@@ -183,7 +183,7 @@ function ModelComparison({ t }: { t: typeof TRANSLATIONS.en }) {
           style={{
             margin: 'auto 0 auto auto',
             fontSize: '0.68rem',
-            color: 'var(--border-color-hover)',
+            color: 'var(--text-muted)',
           }}
         >
           {t.sort}
@@ -265,7 +265,7 @@ function ModelComparison({ t }: { t: typeof TRANSLATIONS.en }) {
         })}
       </div>
 
-      <p style={{ margin: '0.75rem 0 0', fontSize: '0.68rem', color: 'var(--border-color-hover)' }}>
+      <p style={{ margin: '0.75rem 0 0', fontSize: '0.68rem', color: 'var(--text-muted)' }}>
         {t.allModels}
       </p>
     </div>
@@ -666,7 +666,7 @@ function CycleGanVisualizer({ t }: { t: typeof TRANSLATIONS.en }) {
         </div>
       </div>
 
-      <p style={{ margin: '0.6rem 0 0', fontSize: '0.68rem', color: 'var(--border-color-hover)' }}>
+      <p style={{ margin: '0.6rem 0 0', fontSize: '0.68rem', color: 'var(--text-muted)' }}>
         {t.cgNote}
       </p>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -63,7 +63,8 @@ html[data-theme='light'] {
 
   --text-primary: #18181b;
   --text-secondary: #3f3f46;
-  --text-muted: #71717a;
+  /* #52525b on #f1f5f9 = 7.07:1 (was #71717a = 4.41:1, below WCAG AA 4.5:1) */
+  --text-muted: #52525b;
 
   --accent-start: #4f46e5;
   --accent-end: #9333ea;


### PR DESCRIPTION
## Summary

First batch of fixes from running the all-themes axe-core audit (`e2e/a11y.spec.ts`). Three high-leverage changes:

### 1. Light theme `--text-muted: #71717a → #52525b`

The 4.41:1 contrast on `.explore-tags li` / `.prevnext-tags li` (shown on every demo) failed WCAG AA by 0.09. New value gives **7.07:1**.

This single CSS variable fix eliminates the most common violation across the entire site.

### 2. `--border-color-hover` misused as text

In [ApaPracticaDemo.tsx](src/components/demos/ApaPracticaDemo.tsx), [BitsXMaratoDemo.tsx](src/components/demos/BitsXMaratoDemo.tsx), [TfgPolypDemo.tsx](src/components/demos/TfgPolypDemo.tsx), the border-color token was applied as text color (1.47:1) on helper labels and footnotes. Replaced with `--text-muted`.

### 3. apa-practica feature labels stop using accent colors as text

Pastel colors (`#34d399`, `#38bdf8`, `#a78bfa`) work as bar fills / slider accents but fail 4.5:1 as text on white. Switched the labels to `--text-primary`; the colors still drive the bar gradient and slider `accentColor`.

## What's NOT in this PR

The audit catches a long tail of issues that don't fit one batch:

- Per-theme accent-text usage across 14 themes
- prop.astro mock browser uses hardcoded Bootstrap colors (`#0d6efd`, `#198754`)
- Form labels missing on 8 demos (mpids, jsbach, caim, sbc-ia, pro2, apa-practica, phase-transitions)
- Long-tail inline accent-on-white styles in various demos

The a11y job is still excluded from CI matrix from PR #69. Follow-up PRs should land each chunk and finally re-enable the gate.

## Test plan

- [ ] Visual regression check on `/`, `/demos/apa-practica`, `/demos/tfg-polyps`, `/demos/bitsx-marato` in light theme
- [ ] Confirm bar fills + slider accents still match in apa-practica
- [ ] `npm test` (vitest unit suite) still green
- [ ] `npm run build` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)