### PR TITLE
a11y: form labels + prop.astro mock contrast

### DIFF
--- a/src/components/demos/ApaPracticaDemo.tsx
+++ b/src/components/demos/ApaPracticaDemo.tsx
@@ -424,6 +424,7 @@ function FeatureSlider({
         min={min}
         max={max}
         step={step}
+        aria-label={`${label} (${unit})`}
         style={{ width: '100%', accentColor: color, height: '6px' }}
       />
     </div>

--- a/src/components/demos/BitsXMaratoDemo.tsx
+++ b/src/components/demos/BitsXMaratoDemo.tsx
@@ -298,6 +298,7 @@ function DiameterExplorer({ t }: { t: typeof TRANSLATIONS.en }) {
           value={mm}
           onChange={(e) => setMm(Number(e.target.value))}
           style={{ width: '100%', accentColor: zone.color }}
+          aria-label="Aorta diameter (mm)"
         />
       </div>
 

--- a/src/components/demos/JSBachDemo.tsx
+++ b/src/components/demos/JSBachDemo.tsx
@@ -227,6 +227,7 @@ export default function JSBachDemo({ lang = 'en' }: { lang?: Lang }) {
           onChange={(e) => setCode(e.target.value)}
           onKeyDown={handleKeyDown}
           spellCheck={false}
+          aria-label={t.codeEditor}
         />
         <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
           <button style={{ ...styles.button, ...styles.primaryBtn }} onClick={run}>

--- a/src/components/demos/MPIDSDemo.tsx
+++ b/src/components/demos/MPIDSDemo.tsx
@@ -402,8 +402,11 @@ export default function MPIDSDemo({ lang = 'en' }: { lang?: Lang }) {
 
         <div style={s.row}>
           <span style={s.label}>{t.random}</span>
-          <label style={s.label}>N=</label>
+          <label style={s.label} htmlFor="mpids-random-n">
+            N=
+          </label>
           <input
+            id="mpids-random-n"
             type="number"
             min={3}
             max={300}
@@ -411,8 +414,11 @@ export default function MPIDSDemo({ lang = 'en' }: { lang?: Lang }) {
             onChange={(e) => setRandomN(Math.min(300, Math.max(3, +e.target.value)))}
             style={s.input}
           />
-          <label style={s.label}>p=</label>
+          <label style={s.label} htmlFor="mpids-random-p">
+            p=
+          </label>
           <input
+            id="mpids-random-p"
             type="number"
             min={0.01}
             max={1}
@@ -427,8 +433,11 @@ export default function MPIDSDemo({ lang = 'en' }: { lang?: Lang }) {
         </div>
 
         <div style={s.row}>
-          <span style={s.label}>{t.upload}</span>
+          <label style={s.label} htmlFor="mpids-upload">
+            {t.upload}
+          </label>
           <input
+            id="mpids-upload"
             type="file"
             accept=".txt"
             onChange={handleFileUpload}

--- a/src/components/demos/PhaseTransitionsDemo.tsx
+++ b/src/components/demos/PhaseTransitionsDemo.tsx
@@ -505,6 +505,7 @@ export default function PhaseTransitionsDemo({ lang = 'en' }: { lang?: Lang }) {
                 value={gridSide}
                 onChange={(e) => setGridSide(+e.target.value)}
                 style={s.slider}
+                aria-label={t.gridSide}
               />
               <span style={s.value}>
                 {gridSide}×{gridSide} = {t.nodesCount.replace('{0}', String(gridSide * gridSide))}
@@ -521,6 +522,7 @@ export default function PhaseTransitionsDemo({ lang = 'en' }: { lang?: Lang }) {
                 value={nodeCount}
                 onChange={(e) => setNodeCount(+e.target.value)}
                 style={s.slider}
+                aria-label={t.nodes}
               />
               <span style={s.value}>{nodeCount}</span>
               <span style={s.label}>{family === 'binomial' ? 'p:' : 'r:'}</span>
@@ -532,6 +534,7 @@ export default function PhaseTransitionsDemo({ lang = 'en' }: { lang?: Lang }) {
                 value={param}
                 onChange={(e) => setParam(+e.target.value)}
                 style={s.slider}
+                aria-label={family === 'binomial' ? 'p (edge probability)' : 'r (radius)'}
               />
               <span style={s.value}>{param.toFixed(2)}</span>
             </>
@@ -585,6 +588,7 @@ export default function PhaseTransitionsDemo({ lang = 'en' }: { lang?: Lang }) {
             value={percProb}
             onChange={(e) => setPercProb(+e.target.value)}
             style={s.slider}
+            aria-label={t.retention}
           />
           <span style={s.value}>{percProb.toFixed(2)}</span>
         </div>

--- a/src/components/demos/Pro2Demo.tsx
+++ b/src/components/demos/Pro2Demo.tsx
@@ -388,6 +388,7 @@ export default function Pro2Demo({ lang = 'en' }: { lang?: Lang }) {
             <input
               style={{ ...styles.input, width: '80px' }}
               placeholder="e.g. F"
+              aria-label="Species ID"
               value={newId}
               onChange={(e) => setNewId(e.target.value)}
               maxLength={8}
@@ -395,6 +396,7 @@ export default function Pro2Demo({ lang = 'en' }: { lang?: Lang }) {
             <input
               style={{ ...styles.input, flex: 1, minWidth: '150px' }}
               placeholder="e.g. AACTGCTTGA"
+              aria-label={t.geneSequence}
               value={newGene}
               onChange={(e) => setNewGene(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && addSpecies()}
@@ -403,10 +405,12 @@ export default function Pro2Demo({ lang = 'en' }: { lang?: Lang }) {
               <label
                 style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}
                 title={t.kmerTooltip}
+                htmlFor="pro2-k"
               >
                 k=
               </label>
               <input
+                id="pro2-k"
                 type="number"
                 style={{ ...styles.input, width: '55px' }}
                 value={k}

--- a/src/components/demos/SbcDemo.tsx
+++ b/src/components/demos/SbcDemo.tsx
@@ -371,6 +371,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                   min={0}
                   max={120}
                   value={age}
+                  aria-label={`Traveler ${i + 1} age`}
                   style={{ ...s.input, width: '80px' }}
                   onChange={(e) => {
                     const n = [...ages];
@@ -429,6 +430,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={30}
                 value={daysMin}
+                aria-label={t.minDays}
                 style={s.input}
                 onChange={(e) => setDaysMin(Math.max(1, Math.min(30, Number(e.target.value))))}
               />
@@ -444,6 +446,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={60}
                 value={daysMax}
+                aria-label={t.maxDays}
                 style={s.input}
                 onChange={(e) => setDaysMax(Math.max(1, Math.min(60, Number(e.target.value))))}
               />
@@ -464,6 +467,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={14}
                 value={daysPerCityMin}
+                aria-label={t.minDaysCity}
                 style={s.input}
                 onChange={(e) =>
                   setDaysPerCityMin(Math.max(1, Math.min(14, Number(e.target.value))))
@@ -481,6 +485,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={14}
                 value={daysPerCityMax}
+                aria-label={t.maxDaysCity}
                 style={s.input}
                 onChange={(e) =>
                   setDaysPerCityMax(Math.max(1, Math.min(14, Number(e.target.value))))
@@ -503,6 +508,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={10}
                 value={citiesMin}
+                aria-label={t.minCities}
                 style={s.input}
                 onChange={(e) => setCitiesMin(Math.max(1, Math.min(10, Number(e.target.value))))}
               />
@@ -518,6 +524,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                 min={1}
                 max={10}
                 value={citiesMax}
+                aria-label={t.maxCities}
                 style={s.input}
                 onChange={(e) => setCitiesMax(Math.max(1, Math.min(10, Number(e.target.value))))}
               />
@@ -533,6 +540,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
               max={10000}
               step={100}
               value={budget}
+              aria-label={t.budget}
               style={{ width: '100%', accentColor: 'var(--accent-start)' }}
               onChange={(e) => setBudget(Number(e.target.value))}
             />

--- a/src/components/demos/caim/PageRankTab.tsx
+++ b/src/components/demos/caim/PageRankTab.tsx
@@ -84,10 +84,11 @@ export default function PageRankTab({ lang }: Props) {
       {/* Controls */}
       <div style={styles.controls}>
         <div style={styles.controlGroup}>
-          <label style={styles.label}>
+          <label style={styles.label} htmlFor="caim-pr-damping">
             {t.damping}: <strong>{damping.toFixed(2)}</strong>
           </label>
           <input
+            id="caim-pr-damping"
             type="range"
             min={0.1}
             max={0.99}
@@ -98,8 +99,11 @@ export default function PageRankTab({ lang }: Props) {
           />
         </div>
         <div style={styles.controlGroup}>
-          <label style={styles.label}>{t.initStrategy}</label>
+          <label style={styles.label} htmlFor="caim-pr-init">
+            {t.initStrategy}
+          </label>
           <select
+            id="caim-pr-init"
             value={initStrategy}
             onChange={(e) => setInitStrategy(e.target.value as InitStrategy)}
             style={styles.select}

--- a/src/components/demos/caim/ZipfTab.tsx
+++ b/src/components/demos/caim/ZipfTab.tsx
@@ -95,9 +95,12 @@ export default function ZipfTab({ lang }: Props) {
           </div>
         </div>
         <div style={{ ...styles.controlGroup, flex: 1, minWidth: 200 }}>
-          <label style={styles.label}>{t.customText}</label>
+          <label style={styles.label} htmlFor="caim-zipf-custom">
+            {t.customText}
+          </label>
           <div style={{ display: 'flex', gap: '0.4rem' }}>
             <textarea
+              id="caim-zipf-custom"
               value={customText}
               onChange={(e) => setCustomText(e.target.value)}
               placeholder={t.customPlaceholder}

--- a/src/pages/demos/jsbach.astro
+++ b/src/pages/demos/jsbach.astro
@@ -1,7 +1,7 @@
 ---
 import DemoLayout from '../../layouts/DemoLayout.astro';
 import DemoHeader from '../../components/DemoHeader.astro';
-import JSBachDemo from '../../components/demos/JSBachDemo';
+import JSBachDemo from '../../components/demos/JsbachDemo';
 import { getLangFromUrl, useTranslations } from '../../i18n/utils';
 import { getDemo } from '../../i18n/demo';
 

--- a/src/pages/demos/prop.astro
+++ b/src/pages/demos/prop.astro
@@ -505,11 +505,13 @@ const t = useTranslations(lang);
     color: #fff;
   }
 
+  /* Bumped from Bootstrap defaults (#0d6efd, #198754) which gave 2.95:1 /
+     2.93:1 against the dark mock chrome — below WCAG AA 4.5:1. */
   .text-accent {
-    color: #0d6efd;
+    color: #7aaeff;
   }
   .text-success {
-    color: #198754;
+    color: #39d680;
   }
 
   .mock-table-responsive {
@@ -571,8 +573,8 @@ const t = useTranslations(lang);
   }
 
   .mock-btn-outline {
-    color: #0d6efd;
-    border-color: #0d6efd;
+    color: #7aaeff;
+    border-color: #7aaeff;
   }
 
   .mock-btn-primary {


### PR DESCRIPTION
## Summary

Second batch from the axe-core audit. Two distinct fix types:

### Form labels (critical-impact)

Added explicit/implicit labels via `aria-label` or `htmlFor` to inputs that axe flagged as critical `label` violations across 8 demos:

| Demo | What changed |
|---|---|
| [JsbachDemo](src/components/demos/JsbachDemo.tsx) | code editor `<textarea>` |
| [MPIDSDemo](src/components/demos/MPIDSDemo.tsx) | random N/p number inputs, file upload |
| [Pro2Demo](src/components/demos/Pro2Demo.tsx) | species ID, gene sequence, k-mer inputs |
| [ApaPracticaDemo](src/components/demos/ApaPracticaDemo.tsx) | feature slider range inputs |
| [PhaseTransitionsDemo](src/components/demos/PhaseTransitionsDemo.tsx) | gridSide / nodes / param / retention sliders |
| [BitsXMaratoDemo](src/components/demos/BitsXMaratoDemo.tsx) | aorta diameter slider |
| [SbcDemo](src/components/demos/SbcDemo.tsx) | traveler ages, days/cities, budget |
| [caim/PageRankTab](src/components/demos/caim/PageRankTab.tsx) | damping slider, init strategy select |
| [caim/ZipfTab](src/components/demos/caim/ZipfTab.tsx) | custom text textarea |

### prop.astro mock browser contrast

The mock recommendation app uses Bootstrap-fixed colors that fail WCAG AA on the dark mock chrome. Bumped to higher-contrast variants while preserving the Bootstrap aesthetic:

| Token | Before | After | Contrast on `#2b3035` |
|---|---|---|---|
| `.text-accent` | `#0d6efd` | `#7aaeff` | 2.95:1 → **5.91:1** |
| `.text-success` | `#198754` | `#39d680` | 2.93:1 → **7.04:1** |
| `.mock-btn-outline` | `#0d6efd` | `#7aaeff` | (same as above) |

### Bonus fix

`jsbach.astro` imported `JSBachDemo` but the file is [JsbachDemo.tsx](src/components/demos/JsbachDemo.tsx). Worked on Windows (case-insensitive FS) but `astro check` flagged it. Fixed the import — would have eventually broken on Linux CI builds.

## Verification

- `npm run check` (astro check / TS): 0 errors
- `npm run lint`: 0 errors
- `npm run format:check`: clean
- `npm test`: 589/589 passing
- a11y test still excluded from CI matrix per PR #69; will be re-enabled in a future PR once the audit is complete

## What's still TODO across follow-up PRs

- Per-theme accent text usage across the 13 themes
- Long-tail inline accent-on-white styles
- `link-in-text-block` and `scrollable-region-focusable` violations from a few demos
- Re-enable the a11y job once clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)