### PR TITLE
a11y: scrollable code blocks + lead-paragraph link styling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,12 @@ export default [
       'jsx-a11y/anchor-is-valid': 'warn',
       'jsx-a11y/media-has-caption': 'warn',
       'jsx-a11y/iframe-has-title': 'warn',
+      // Allow tabIndex on <pre>, <div>, <section> when used to make a
+      // scrollable region focusable (axe rule scrollable-region-focusable).
+      'jsx-a11y/no-noninteractive-tabindex': [
+        'error',
+        { tags: ['div', 'section', 'pre'], roles: ['tabpanel'] },
+      ],
       'react-hooks/rules-of-hooks': 'warn',
       'react-hooks/exhaustive-deps': 'warn',
     },

--- a/src/components/DemoHeader.astro
+++ b/src/components/DemoHeader.astro
@@ -113,4 +113,19 @@ const labels = Array.isArray(githubLabel) ? githubLabel : [githubLabel];
   .demo-hdr-lead :global(strong) {
     color: var(--text-primary, #e4e4e7);
   }
+
+  /* Inline links in lead copy must be visually distinguishable from
+     surrounding text to satisfy WCAG SC 1.4.1. Use --text-primary for
+     contrast with --text-secondary, plus an underline. */
+  .demo-hdr-lead :global(a) {
+    color: var(--text-primary);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .demo-hdr-lead :global(a:hover),
+  .demo-hdr-lead :global(a:focus-visible) {
+    color: var(--accent-start);
+  }
 </style>

--- a/src/components/demos/ApaPracticaDemo.tsx
+++ b/src/components/demos/ApaPracticaDemo.tsx
@@ -846,6 +846,8 @@ export default function ApaPracticaDemo({ lang = 'en' }: { lang?: Lang }) {
           {t.runLocal}
         </summary>
         <pre
+          tabIndex={0}
+          aria-label="Run locally — shell commands"
           style={{
             margin: '0.75rem 0 0',
             padding: '1rem',

--- a/src/components/demos/DesastresIADemo.tsx
+++ b/src/components/demos/DesastresIADemo.tsx
@@ -751,6 +751,8 @@ export default function DesastresIADemo({ lang = 'en' }: { lang?: Lang }) {
                     {t.compact} {formatAssign(runOut.initial)} → {formatAssign(runOut.final)}
                   </p>
                   <pre
+                    tabIndex={0}
+                    aria-label="Optimization log"
                     style={{
                       margin: 0,
                       maxHeight: 140,

--- a/src/components/demos/PlanificacionDemo.tsx
+++ b/src/components/demos/PlanificacionDemo.tsx
@@ -524,6 +524,8 @@ export default function PlanificacionDemo({ lang = 'en' }: { lang?: Lang }) {
             </a>
           </div>
           <pre
+            tabIndex={0}
+            aria-label="PDDL domain"
             style={{
               margin: 0,
               padding: '0.85rem',
@@ -569,6 +571,8 @@ export default function PlanificacionDemo({ lang = 'en' }: { lang?: Lang }) {
             </a>
           </div>
           <pre
+            tabIndex={0}
+            aria-label="PDDL problem"
             style={{
               margin: 0,
               padding: '0.85rem',


### PR DESCRIPTION
## Summary

Third batch from the axe-core audit. Two distinct issue types from the CI artifact.

### scrollable-region-focusable

Code blocks with `overflow-x: auto` need `tabIndex={0}` so keyboard-only users can scroll them with arrow keys. Added to:

- [PlanificacionDemo](src/components/demos/PlanificacionDemo.tsx) — PDDL domain + problem viewer
- [ApaPracticaDemo](src/components/demos/ApaPracticaDemo.tsx) — "run locally" shell snippet
- [DesastresIADemo](src/components/demos/DesastresIADemo.tsx) — optimization log

Each gets a descriptive `aria-label` so screen readers announce what's inside.

### link-in-text-block

Inline links inside `.demo-hdr-lead` were:
1. Colored `#9333ea` (`--accent-end`) — only **1.94:1** against the surrounding `#3f3f46` body text (need 3:1)
2. Had no underline to differentiate from surrounding text

Added in [DemoHeader.astro](src/components/DemoHeader.astro):

```css
.demo-hdr-lead :global(a) {
  color: var(--text-primary);     /* high contrast */
  text-decoration: underline;
  text-decoration-thickness: 1px;
  text-underline-offset: 2px;
}

.demo-hdr-lead :global(a:hover),
.demo-hdr-lead :global(a:focus-visible) {
  color: var(--accent-start);
}
```

### eslint config

Added `jsx-a11y/no-noninteractive-tabindex` with `{ tags: ['div', 'section', 'pre'] }` so the rule no longer blocks the legitimate scrollable-region-focusable pattern that axe **requires** above.

## What's still TODO

The biggest remaining bucket is **per-theme accent contrast**. Quick audit shows the following themes have accent colors that fail 4.5:1 contrast against `--bg-primary` or `--bg-secondary`:

| Theme | Failing combo |
|---|---|
| nord | accent-end on both bgs |
| nord-light | both accents on both bgs |
| catppuccin-latte | accent-end on both bgs |
| solarized-light | both accents on both bgs |
| gruvbox-dark | accent-end on bg-secondary |
| sepia | accent-start on both bgs |
| paper | accent-start on bg-secondary |

Fixing this properly requires introducing a separate `--accent-text` token per theme that's a darker/lighter shade of the accent for use as plain text (vs. the gradient/decoration accent). That's a token refactor across 14 themes — its own PR.

## Verification

- `npm run check` (astro check / TS): 0 errors
- `npm run lint`: 0 errors
- `npm run format:check`: clean
- `npm test`: 589/589 passing
- a11y job still excluded from CI per PR #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)