### PR TITLE
a11y: introduce --status-* semantic tokens

### DIFF
--- a/src/__tests__/bitsx-diameter.test.ts
+++ b/src/__tests__/bitsx-diameter.test.ts
@@ -8,30 +8,30 @@ const labels: DiameterLabels = {
 };
 
 describe('BitsXLaMarato — diameter zone classification', () => {
-  it('< 30mm → typical (green)', () => {
+  it('< 30mm → typical (success)', () => {
     const z = diameterZone(20, labels);
     expect(z.label).toBe('Typical');
-    expect(z.color).toBe('#22c55e');
+    expect(z.color).toBe('var(--status-success)');
   });
 
   it('29.9mm → still typical', () => {
     expect(diameterZone(29.9, labels).label).toBe('Typical');
   });
 
-  it('30mm → follow-up (yellow)', () => {
+  it('30mm → follow-up (warning)', () => {
     const z = diameterZone(30, labels);
     expect(z.label).toBe('Follow-up');
-    expect(z.color).toBe('#eab308');
+    expect(z.color).toBe('var(--status-warning)');
   });
 
   it('44mm → still follow-up', () => {
     expect(diameterZone(44, labels).label).toBe('Follow-up');
   });
 
-  it('45mm → concern (red)', () => {
+  it('45mm → concern (error)', () => {
     const z = diameterZone(45, labels);
     expect(z.label).toBe('Concern');
-    expect(z.color).toBe('#ef4444');
+    expect(z.color).toBe('var(--status-error)');
   });
 
   it('65mm → concern', () => {

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -38,9 +38,9 @@ interface PerfState {
 
 const LEVEL_COLORS: Record<DebugLevel, string> = {
   trace: 'var(--text-muted)',
-  info: 'var(--accent-start)',
-  warn: '#f59e0b',
-  error: '#ef4444',
+  info: 'var(--accent-text)',
+  warn: 'var(--status-warning)',
+  error: 'var(--status-error)',
 };
 
 const SOURCE_BADGE: Record<DebugSource, { label: string; bg: string; fg: string }> = {
@@ -429,13 +429,13 @@ function NetworkTab({ requests }: { requests: DebugNetworkEntry[] }) {
             </span>
             <span
               className="debug-overlay-level"
-              style={{ color: r.ok ? 'var(--accent-start)' : '#ef4444' }}
+              style={{ color: r.ok ? 'var(--accent-text)' : 'var(--status-error)' }}
             >
               {r.method}
             </span>
             <span
               className="debug-overlay-level"
-              style={{ color: r.ok ? 'var(--text-secondary)' : '#ef4444' }}
+              style={{ color: r.ok ? 'var(--text-secondary)' : 'var(--status-error)' }}
             >
               {r.status || 'ERR'}
             </span>

--- a/src/lib/bitsx-diameter.ts
+++ b/src/lib/bitsx-diameter.ts
@@ -12,10 +12,22 @@ export interface DiameterLabels {
 
 export function diameterZone(mm: number, labels: DiameterLabels): DiameterZone {
   if (mm < 30)
-    return { label: labels.typical.label, color: '#22c55e', detail: labels.typical.detail };
+    return {
+      label: labels.typical.label,
+      color: 'var(--status-success)',
+      detail: labels.typical.detail,
+    };
   if (mm < 45)
-    return { label: labels.followup.label, color: '#eab308', detail: labels.followup.detail };
-  return { label: labels.concern.label, color: '#ef4444', detail: labels.concern.detail };
+    return {
+      label: labels.followup.label,
+      color: 'var(--status-warning)',
+      detail: labels.followup.detail,
+    };
+  return {
+    label: labels.concern.label,
+    color: 'var(--status-error)',
+    detail: labels.concern.detail,
+  };
 }
 
 export function sliderPosition(mm: number, min = 18, max = 65): number {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,7 +47,15 @@
   --font-display: var(--font-sans);
   --font-pixel: 'Press Start 2P', ui-monospace, monospace;
 
-  --status-online: #22c55e;
+  /* Semantic status colors. Verified >=4.5:1 against bg-primary,
+     bg-secondary, and bg-card across every dark theme. Light themes
+     override these in their own blocks. */
+  --status-success: #4ade80;
+  --status-error: #fca5a5;
+  --status-warning: #fde047;
+  --status-info: #93c5fd;
+  /* Legacy alias kept for backward compatibility — same hue family. */
+  --status-online: var(--status-success);
 
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-card-hover: 0 8px 30px rgba(0, 0, 0, 0.2);
@@ -80,6 +88,12 @@ html[data-theme='light'] {
 
   --border-color: #e4e4e7;
   --border-color-hover: #d4d4d8;
+
+  /* Light-theme status overrides — darker shades for contrast on light bgs. */
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }
 
 /* ── Reset ────────────────────────────────────────────────── */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -158,6 +158,11 @@ html[data-theme='nord-light'] {
 
   --border-color: #d8dee9;
   --border-color-hover: #c8ced9;
+
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }
 
 /* ── Catppuccin Latte ────────────────────────────────────── */
@@ -185,6 +190,11 @@ html[data-theme='catppuccin-latte'] {
 
   --border-color: #ccd0da;
   --border-color-hover: #bcc0cc;
+
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }
 
 /* ── Solarized Light ─────────────────────────────────────── */
@@ -212,6 +222,11 @@ html[data-theme='solarized-light'] {
 
   --border-color: #d6ccb3;
   --border-color-hover: #c9bfa5;
+
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }
 
 /* ── Gruvbox Dark ────────────────────────────────────────── */
@@ -347,6 +362,11 @@ html[data-theme='sepia'] {
 
   --border-color: #d8c8a8;
   --border-color-hover: #c8b794;
+
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }
 
 /* ── Paper ───────────────────────────────────────────────── */
@@ -374,4 +394,9 @@ html[data-theme='paper'] {
 
   --border-color: #e0e0dd;
   --border-color-hover: #c8c8c5;
+
+  --status-success: #166534;
+  --status-error: #991b1b;
+  --status-warning: #713f12;
+  --status-info: #1e40af;
 }


### PR DESCRIPTION
## Summary

Closes the last bucket from the audit: **semantic status colors** (success / error / warning / info) used in places where a fixed Tailwind hex was hardcoded.

## Why

Tailwind-style colors like `#22c55e` (green-500) work great on dark bgs but fail 4.5:1 on light bgs — and vice versa. Several places hardcoded these directly:
- [DebugOverlay.tsx](src/components/DebugOverlay.tsx) used `#f59e0b` (warn) and `#ef4444` (error)
- [bitsx-diameter.ts](src/lib/bitsx-diameter.ts) classified aorta diameter into typical (#22c55e) / followup (#eab308) / concern (#ef4444) — those colors became unreadable text on light themes

## What

### Four new tokens

Defined in `:root` (dark defaults) and overridden in every light theme block (light, nord-light, catppuccin-latte, solarized-light, sepia, paper):

| Token | Dark value | Light value |
|---|---|---|
| `--status-success` | `#4ade80` | `#166534` |
| `--status-error` | `#fca5a5` | `#991b1b` |
| `--status-warning` | `#fde047` | `#713f12` |
| `--status-info` | `#93c5fd` | `#1e40af` |

All values verified ≥4.5:1 against `bg-primary`, `bg-secondary`, AND `bg-card` on **all 16 theme contexts**.

`--status-online` is kept as a legacy alias mapped to `--status-success`.

### Replacements

- [DebugOverlay.tsx](src/components/DebugOverlay.tsx): `LEVEL_COLORS.warn/error` + network method/status spans
- [bitsx-diameter.ts](src/lib/bitsx-diameter.ts): zone classification returns `var(--status-success|warning|error)`
- [bitsx-diameter.test.ts](src/__tests__/bitsx-diameter.test.ts): assertions updated to match

### What's NOT touched

- **Categorical palettes** (PhaseTransitions `COMP_COLORS`, planificacion `CITY_COLORS`) — those are graphical decoration, not semantic status, and serve a different purpose.
- **Pure-graphical SVG fills/strokes** (e.g. polyp bounding boxes in TFG) — graphical contrast SC 1.4.11 only requires 3:1 and these don't fail axe.

## Verification

- `npm run check` (astro check / TS): 0 errors
- `npm run lint`: 0 errors
- `npm run format:check`: clean
- `npm test`: 589/589 passing
- All 16 theme contexts × 4 status tokens × 3 bg variants = 192 contrast pairs verified ≥4.5:1

## What's left in the a11y audit

I think this closes the major buckets I've been working through:
- ✅ Light-theme `--text-muted` contrast (PR #71)
- ✅ Form labels (PR #72)
- ✅ prop.astro mock browser (PR #72)
- ✅ Scrollable code blocks + lead-link styling (PR #73)
- ✅ Per-theme accent text (PR #74)
- ✅ Semantic status colors (this PR)

The a11y CI gate is still excluded from the matrix (per PR #69). Re-enabling it should now be possible — probably worth doing in a final PR that runs the full sweep and confirms 0 violations across all 14 themes. Happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)