### PR TITLE
fix: revert JsbachDemo casing + narrow rootBlock for TS strict

### DIFF
--- a/src/__tests__/theme-contrast.test.ts
+++ b/src/__tests__/theme-contrast.test.ts
@@ -84,10 +84,11 @@ function contrastRatio(fg: string, bg: string) {
 }
 
 const blocks = parseBlocks(ALL_CSS);
-const root = blocks.find((b) => b.name === 'default-dark');
-if (!root) {
+const rootBlock = blocks.find((b) => b.name === 'default-dark');
+if (!rootBlock) {
   throw new Error('Could not parse :root variables from global.css');
 }
+const root: Block = rootBlock;
 
 /**
  * Resolve a token in a given theme: prefer the theme block's own value,

--- a/src/pages/demos/jsbach.astro
+++ b/src/pages/demos/jsbach.astro
@@ -1,7 +1,7 @@
 ---
 import DemoLayout from '../../layouts/DemoLayout.astro';
 import DemoHeader from '../../components/DemoHeader.astro';
-import JSBachDemo from '../../components/demos/JsbachDemo';
+import JSBachDemo from '../../components/demos/JSBachDemo';
 import { getLangFromUrl, useTranslations } from '../../i18n/utils';
 import { getDemo } from '../../i18n/demo';
 


### PR DESCRIPTION
PR #72 changed `JSBachDemo` -> `JsbachDemo` thinking the file was lowercase, but the file is actually `JSBachDemo.tsx` (capital B and S). Worked on Windows (case-insensitive FS) but failed astro check once it actually validated module resolution.

Also: theme-contrast.test.ts had a `root` const that TS couldn't narrow through `.find().<throw if undefined>` pattern. Reassigned to a typed local so the rest of the file sees Block, not Block|undefined.