### PR TITLE
fix(a11y): close remaining axe failures from CI run #25921467876

### DIFF
--- a/src/__tests__/theme-contrast.test.ts
+++ b/src/__tests__/theme-contrast.test.ts
@@ -32,7 +32,7 @@ const ALL_CSS = GLOBAL_CSS + '\n' + THEMES_CSS;
 const TEXT_TOKENS = ['text-secondary', 'text-muted', 'accent-text'] as const;
 const STATUS_TOKENS = ['status-success', 'status-error', 'status-warning', 'status-info'] as const;
 const FG_TOKENS = [...TEXT_TOKENS, ...STATUS_TOKENS] as const;
-const BG_TOKENS = ['bg-primary', 'bg-secondary', 'bg-card'] as const;
+const BG_TOKENS = ['bg-primary', 'bg-secondary', 'bg-card', 'bg-card-hover'] as const;
 
 const WCAG_AA = 4.5;
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -80,7 +80,11 @@
     padding: 0.1rem 0.3rem;
     border: 1px solid var(--border-color);
     border-radius: 3px;
-    background: var(--bg-surface, rgba(255, 255, 255, 0.05));
+    /* Use a defined background token; the previous fallback rgba(...,
+       0.05) made contrast against the kbd's text unpredictable across
+       themes. */
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
     line-height: 1;
   }
 

--- a/src/components/demos/BitsXMaratoDemo.tsx
+++ b/src/components/demos/BitsXMaratoDemo.tsx
@@ -199,7 +199,7 @@ function SimulatedInference({ t }: { t: typeof TRANSLATIONS.en }) {
                 fontWeight: 600,
                 fontSize: '0.82rem',
                 cursor: 'pointer',
-                background: 'var(--border-color)',
+                background: 'var(--bg-secondary)',
                 color: 'var(--text-primary)',
               }}
             >
@@ -233,7 +233,7 @@ function SimulatedInference({ t }: { t: typeof TRANSLATIONS.en }) {
         <div
           style={{
             height: 5,
-            background: 'var(--border-color)',
+            background: 'var(--bg-secondary)',
             borderRadius: 3,
             overflow: 'hidden',
             marginTop: '0.5rem',

--- a/src/components/demos/DesastresIADemo.tsx
+++ b/src/components/demos/DesastresIADemo.tsx
@@ -453,7 +453,7 @@ export default function DesastresIADemo({ lang = 'en' }: { lang?: Lang }) {
                       fontSize: '0.72rem',
                       fontWeight: 700,
                       fontFamily: 'ui-monospace, monospace',
-                      color: h.active ? 'var(--accent-start)' : 'var(--text-muted)',
+                      color: h.active ? 'var(--accent-text)' : 'var(--text-muted)',
                     }}
                   >
                     {h.name}

--- a/src/components/demos/DraculinDemo.tsx
+++ b/src/components/demos/DraculinDemo.tsx
@@ -64,7 +64,7 @@ const s = {
     background: 'linear-gradient(135deg, var(--accent-start), var(--accent-end))',
     color: 'var(--text-primary)',
   },
-  secondaryBtn: { background: 'var(--border-color)', color: 'var(--text-secondary)' },
+  secondaryBtn: { background: 'var(--bg-secondary)', color: 'var(--text-secondary)' },
   input: {
     background: 'var(--bg-secondary)',
     border: '1px solid var(--border-color)',
@@ -531,7 +531,7 @@ function StatsTab({ t }: { t: typeof TRANSLATIONS.en }) {
                     ? '1px solid var(--accent-end)'
                     : '1px solid var(--border-color)',
                   borderRadius: '0.25rem',
-                  color: isPeriod ? 'var(--accent-end)' : 'var(--text-secondary)',
+                  color: isPeriod ? 'var(--accent-text)' : 'var(--text-secondary)',
                   padding: '0.35rem',
                   fontSize: '0.75rem',
                   cursor: 'pointer',

--- a/src/components/demos/JSBachDemo.tsx
+++ b/src/components/demos/JSBachDemo.tsx
@@ -54,7 +54,7 @@ const styles = {
     color: 'var(--text-primary)',
   },
   secondaryBtn: {
-    background: 'var(--border-color)',
+    background: 'var(--bg-secondary)',
     color: 'var(--text-secondary)',
   },
   output: {

--- a/src/components/demos/MPIDSDemo.tsx
+++ b/src/components/demos/MPIDSDemo.tsx
@@ -78,7 +78,7 @@ const s = {
     padding: '0.6rem 1.25rem',
     borderRadius: 8,
     border: 'none',
-    background: 'var(--border-color)',
+    background: 'var(--bg-secondary)',
     color: 'var(--text-muted)',
     cursor: 'not-allowed',
     fontSize: '0.9rem',

--- a/src/components/demos/PlanificacionDemo.tsx
+++ b/src/components/demos/PlanificacionDemo.tsx
@@ -476,7 +476,7 @@ export default function PlanificacionDemo({ lang = 'en' }: { lang?: Lang }) {
         >
           {t.extensions.map((e) => (
             <div key={e.name} style={{ marginBottom: '0.25rem' }}>
-              <strong style={{ color: e.active ? 'var(--accent-start)' : 'var(--text-muted)' }}>
+              <strong style={{ color: e.active ? 'var(--accent-text)' : 'var(--text-muted)' }}>
                 {e.name}:
               </strong>{' '}
               <span style={{ color: e.active ? 'var(--text-primary)' : 'var(--text-muted)' }}>

--- a/src/components/demos/Pro2Demo.tsx
+++ b/src/components/demos/Pro2Demo.tsx
@@ -66,7 +66,7 @@ const styles = {
     color: 'var(--text-primary)',
   },
   secondaryBtn: {
-    background: 'var(--border-color)',
+    background: 'var(--bg-secondary)',
     color: 'var(--text-secondary)',
   },
   dangerBtn: {

--- a/src/components/demos/SPMatriculasDemo.tsx
+++ b/src/components/demos/SPMatriculasDemo.tsx
@@ -145,7 +145,7 @@ const s = {
   progressOuter: {
     width: '100%',
     height: '8px',
-    background: 'var(--border-color)',
+    background: 'var(--bg-secondary)',
     borderRadius: '4px',
     overflow: 'hidden',
     marginTop: '0.5rem',

--- a/src/components/demos/SbcDemo.tsx
+++ b/src/components/demos/SbcDemo.tsx
@@ -44,7 +44,7 @@ const s = {
     background: 'linear-gradient(135deg, var(--accent-start), var(--accent-end))',
     color: 'var(--text-primary)',
   },
-  secondaryBtn: { background: 'var(--border-color)', color: 'var(--text-secondary)' },
+  secondaryBtn: { background: 'var(--bg-secondary)', color: 'var(--text-secondary)' },
   input: {
     background: 'var(--bg-secondary)',
     border: '1px solid var(--border-color)',
@@ -78,7 +78,7 @@ const s = {
   progressBar: {
     height: '4px',
     borderRadius: '2px',
-    background: 'var(--border-color)',
+    background: 'var(--bg-secondary)',
     marginBottom: '1.5rem',
     overflow: 'hidden' as const,
   },

--- a/src/components/demos/TendaDemo.tsx
+++ b/src/components/demos/TendaDemo.tsx
@@ -102,7 +102,7 @@ const styles = {
     background: 'linear-gradient(135deg, var(--accent-start), var(--accent-end))',
     color: 'var(--text-primary)',
   },
-  secondaryBtn: { background: 'var(--border-color)', color: 'var(--text-secondary)' },
+  secondaryBtn: { background: 'var(--bg-secondary)', color: 'var(--text-secondary)' },
   table: {
     width: '100%',
     borderCollapse: 'collapse' as const,

--- a/src/components/demos/TfgPolypDemo.tsx
+++ b/src/components/demos/TfgPolypDemo.tsx
@@ -173,7 +173,7 @@ function ModelComparison({ t }: { t: typeof TRANSLATIONS.en }) {
                 metric === m
                   ? 'color-mix(in srgb, var(--accent-start) 10%, transparent)'
                   : 'var(--bg-card-hover)',
-              color: metric === m ? 'var(--accent-start)' : 'var(--text-secondary)',
+              color: metric === m ? 'var(--accent-text)' : 'var(--text-secondary)',
             }}
           >
             {t.metrics[m]}
@@ -461,7 +461,7 @@ function MockInference({ t }: { t: typeof TRANSLATIONS.en }) {
                 fontWeight: 600,
                 fontSize: '0.82rem',
                 cursor: 'pointer',
-                background: 'var(--border-color)',
+                background: 'var(--bg-secondary)',
                 color: 'var(--text-primary)',
               }}
             >
@@ -507,7 +507,7 @@ function MockInference({ t }: { t: typeof TRANSLATIONS.en }) {
         <div
           style={{
             height: 5,
-            background: 'var(--border-color)',
+            background: 'var(--bg-secondary)',
             borderRadius: 3,
             overflow: 'hidden',
             marginTop: '0.5rem',

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -11,7 +11,7 @@ html[data-theme='dracula'] {
 
   --text-primary: #f8f8f2;
   --text-secondary: #bfbfbf;
-  --text-muted: #8e99bd;
+  --text-muted: #98a2c3;
 
   --accent-start: #bd93f9;
   --accent-end: #ff79c6;
@@ -38,12 +38,12 @@ html[data-theme='nord'] {
 
   --text-primary: #eceff4;
   --text-secondary: #d8dee9;
-  --text-muted: #9bb4ce;
+  --text-muted: #aac0d6;
 
   --accent-start: #88c0d0;
   --accent-end: #5e81ac;
   --accent-gradient: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  --accent-text: #88c0d0;
+  --accent-text: #93c6d4;
 
   --glow-color: rgba(136, 192, 208, 0.15);
   --glow-color-strong: rgba(136, 192, 208, 0.35);
@@ -65,7 +65,7 @@ html[data-theme='tokyo-night'] {
 
   --text-primary: #c0caf5;
   --text-secondary: #a9b1d6;
-  --text-muted: #828bb1;
+  --text-muted: #9098ba;
 
   --accent-start: #7aa2f7;
   --accent-end: #bb9af7;
@@ -92,7 +92,7 @@ html[data-theme='catppuccin-mocha'] {
 
   --text-primary: #cdd6f4;
   --text-secondary: #bac2de;
-  --text-muted: #8c90a3;
+  --text-muted: #9094a6;
 
   --accent-start: #cba6f7;
   --accent-end: #f5c2e7;
@@ -119,7 +119,7 @@ html[data-theme='one-dark'] {
 
   --text-primary: #abb2bf;
   --text-secondary: #9da5b4;
-  --text-muted: #969da9;
+  --text-muted: #9ea5b0;
 
   --accent-start: #61afef;
   --accent-end: #c678dd;
@@ -242,7 +242,7 @@ html[data-theme='gruvbox-dark'] {
 
   --text-primary: #ebdbb2;
   --text-secondary: #d5c4a1;
-  --text-muted: #a89984;
+  --text-muted: #b2a491;
 
   --accent-start: #fe8019;
   --accent-end: #fb4934;
@@ -269,12 +269,12 @@ html[data-theme='synthwave'] {
 
   --text-primary: #f9f7ff;
   --text-secondary: #d0bdff;
-  --text-muted: #8f7bcf;
+  --text-muted: #9986d3;
 
   --accent-start: #ff2a6d;
   --accent-end: #0ff0fc;
   --accent-gradient: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  --accent-text: #ff2a6d;
+  --accent-text: #ff5087;
 
   --glow-color: rgba(255, 42, 109, 0.22);
   --glow-color-strong: rgba(255, 42, 109, 0.5);
@@ -296,7 +296,7 @@ html[data-theme='phosphor'] {
 
   --text-primary: #9fffb4;
   --text-secondary: #6bd688;
-  --text-muted: #449a56;
+  --text-muted: #4baa5f;
 
   --accent-start: #33ff66;
   --accent-end: #00cc44;
@@ -323,7 +323,7 @@ html[data-theme='amber-crt'] {
 
   --text-primary: #ffd390;
   --text-secondary: #e5a64b;
-  --text-muted: #ae7b21;
+  --text-muted: #bb8423;
 
   --accent-start: #ffb000;
   --accent-end: #ff8c00;


### PR DESCRIPTION
Pulled the artifacts from the first sharded a11y run and worked through the unique violations.

## Pattern 1: --text-muted vs --bg-card-hover (9 dark themes)

The static contrast test only covered bg-primary, bg-secondary, and bg-card. bg-card-hover (used by hover states + .footer kbd) is slightly lighter on dark themes, dropping muted contrast below 4.5. Bumped:

  default-dark:    #84848d (already passes)
  dracula:         #8e99bd → #98a2c3
  nord:            #9bb4ce → #aac0d6
  tokyo-night:     #828bb1 → #9098ba
  catppuccin-mocha:#8c90a3 → #9094a6
  one-dark:        #969da9 → #9ea5b0
  gruvbox-dark:    #a89984 → #b2a491
  synthwave:       #8f7bcf → #9986d3
  phosphor:        #449a56 → #4baa5f
  amber-crt:       #ae7b21 → #bb8423

Also bumped --accent-text on nord (#88c0d0 → #93c6d4) and synthwave (#ff2a6d → #ff5087) for the same reason.

Extended theme-contrast.test.ts to include bg-card-hover so this class of bug can never silently regress again.

## Pattern 2: --border-color used as a button background

9 demos had a "secondary button" pattern with
`background: var(--border-color); color: var(--text-secondary)`. That combo gives 4.05:1 on catppuccin-latte and 4.06:1 on solarized-light — below WCAG AA. --border-color was never designed to host text. Switched to var(--bg-secondary) across all 9 demos.

## Pattern 3: --accent-start as ternary text color

PR #74's mechanical replace caught `color: 'var(--accent-start)'` as a whole-string match but missed ternary cases like `color: foo ? 'var(--accent-start)' : 'var(--text-muted)'`. Three fixes (DesastresIADemo helicopter labels, PlanificacionDemo extension labels, TfgPolypDemo metric buttons).

## Pattern 4: Footer .kbd background was undefined token

`background: var(--bg-surface, rgba(255, 255, 255, 0.05))` — no --bg-surface is defined anywhere, so it fell through to a 5% white tint that produced #22222a (mid-state) on the dark theme. Replaced with var(--bg-secondary) and an explicit color.