### PR TITLE
a11y: close accent-as-text + tinted-badge violations

### DIFF
--- a/src/components/demos/ApaPracticaDemo.tsx
+++ b/src/components/demos/ApaPracticaDemo.tsx
@@ -534,7 +534,7 @@ export default function ApaPracticaDemo({ lang = 'en' }: { lang?: Lang }) {
               href="https://github.com/martagranero"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: accent2, textDecoration: 'none' }}
+              style={{ color: 'var(--accent-text)', textDecoration: 'none' }}
             >
               Marta Granero
             </a>
@@ -795,7 +795,7 @@ export default function ApaPracticaDemo({ lang = 'en' }: { lang?: Lang }) {
             style={{
               marginLeft: 'auto',
               fontSize: '0.75rem',
-              color: accent2,
+              color: 'var(--accent-text)',
               textDecoration: 'none',
             }}
           >

--- a/src/components/demos/PlanificacionDemo.tsx
+++ b/src/components/demos/PlanificacionDemo.tsx
@@ -299,7 +299,7 @@ export default function PlanificacionDemo({ lang = 'en' }: { lang?: Lang }) {
                 margin: '0 0 0.35rem',
                 fontSize: '0.76rem',
                 fontWeight: 600,
-                color: accent1,
+                color: 'var(--accent-text)',
               }}
             >
               {t.fullAppDesc}
@@ -616,7 +616,7 @@ export default function PlanificacionDemo({ lang = 'en' }: { lang?: Lang }) {
               letterSpacing: '0.05em',
               textTransform: 'uppercase',
               background: 'color-mix(in srgb, var(--accent-start) 15%, transparent)',
-              color: 'var(--accent-text)',
+              color: 'var(--text-primary)',
               border: '1px solid color-mix(in srgb, var(--accent-start) 25%, transparent)',
             }}
           >

--- a/src/components/demos/SbcDemo.tsx
+++ b/src/components/demos/SbcDemo.tsx
@@ -691,7 +691,7 @@ export default function SbcDemo({ lang = 'en' }: { lang?: Lang }) {
                       style={{
                         ...s.tag,
                         background: 'color-mix(in srgb, var(--accent-start) 15%, transparent)',
-                        color: 'var(--accent-text)',
+                        color: 'var(--text-primary)',
                       }}
                     >
                       {t.hotel}

--- a/src/components/demos/TfgPolypDemo.tsx
+++ b/src/components/demos/TfgPolypDemo.tsx
@@ -561,8 +561,11 @@ function CycleGanVisualizer({ t }: { t: typeof TRANSLATIONS.en }) {
               fontWeight: 600,
               cursor: 'pointer',
               border: direction === d ? `1px solid ${accent1}` : '1px solid var(--border-color)',
-              background: direction === d ? `${accent1}18` : 'var(--bg-card-hover)',
-              color: direction === d ? accent1 : 'var(--text-secondary)',
+              background:
+                direction === d
+                  ? 'color-mix(in srgb, var(--accent-start) 10%, transparent)'
+                  : 'var(--bg-card-hover)',
+              color: direction === d ? 'var(--accent-text)' : 'var(--text-secondary)',
             }}
           >
             {d === 'mask2polyp' ? t.m2p : t.p2m}
@@ -621,7 +624,9 @@ function CycleGanVisualizer({ t }: { t: typeof TRANSLATIONS.en }) {
         </div>
 
         {/* Arrow */}
-        <div style={{ color: accent1, fontSize: '1.5rem', fontWeight: 700 }}>{'\u2192'}</div>
+        <div style={{ color: 'var(--accent-text)', fontSize: '1.5rem', fontWeight: 700 }}>
+          {'\u2192'}
+        </div>
 
         {/* Output */}
         <div


### PR DESCRIPTION
## Summary

Pulled the failing main CI run after the previous batch landed (run [25922457956](https://github.com/cuberhaus/PersonalPortfolio/actions/runs/25922457956)), aggregated the 27 unique violation patterns by color pair, and worked through them.

## Three patterns

### 1. Local accent constants used as text color (5 spots)

Earlier passes used a mechanical sed that only matched literal `color: 'var(--accent-...)'` strings. Locations using **local consts** like `accent1`/`accent2` were missed:

| File | Line | What |
|---|---|---|
| [ApaPracticaDemo.tsx](src/components/demos/ApaPracticaDemo.tsx) | 537 | `<a>` link to martagranero |
| [ApaPracticaDemo.tsx](src/components/demos/ApaPracticaDemo.tsx) | 798 | `<a>` link to nbviewer |
| [PlanificacionDemo.tsx](src/components/demos/PlanificacionDemo.tsx) | 302 | fullAppDesc paragraph |
| [TfgPolypDemo.tsx](src/components/demos/TfgPolypDemo.tsx) | 627 | → arrow between cards |
| [TfgPolypDemo.tsx](src/components/demos/TfgPolypDemo.tsx) | 565 | Mask→Polyp toggle button |

All switched to `var(--accent-text)`.

### 2. Tinted accent bg + accent-text color (same-hue conflict)

A few badges had both `color-mix(in srgb, var(--accent-start) 15%, transparent)` background AND `var(--accent-text)` color. Same hue tinting both = bad contrast (dracula failed at 4.2:1 due to `#bd93f9` text on a `#433e59` tinted bg).

Switched badge text in [PlanificacionDemo](src/components/demos/PlanificacionDemo.tsx) and [SbcDemo](src/components/demos/SbcDemo.tsx) to `var(--text-primary)`. Border still uses an accent tint, so visual identity is preserved without the same-hue conflict.

### 3. Malformed CSS template literal (TfgPolypDemo)

Line 564 had `background: \`${accent1}18\`` — a Tailwind-style alpha shorthand attempt that doesn't work with CSS variables (the literal `"18"` gets concatenated as an undefined CSS value, producing some browser-default bg). Replaced with the proper `color-mix(in srgb, var(--accent-start) 10%, transparent)`.

## Verification

- ✅ `npm run check`: 0 errors
- ✅ `npm run lint`: 0 errors
- ✅ `npm run format:check`: clean
- ✅ `npm test`: all passing

The new run will tell us if any failures remain. If so, repeat the artifact-aggregate-fix loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)