### PR TITLE
fix(a11y): close every accent-text-on-tinted-bg violation from PR #80…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
        rebuild free-ports check-registry \
        obs-install obs-up obs-down obs-restart obs-status obs-logs obs-wipe \
        mlops-up mlops-down \
-       clean test help \
+       clean test test-a11y test-a11y-grep help \
        _db-tfg _db-bitsx _db-tenda _db-draculin _db-pro2 _db-planif \
        _db-desastres _db-mpids _db-phase _db-caim _db-joceda _db-sbcia \
        _db-rob _db-par _db-fib _db-grafics
@@ -257,6 +257,12 @@ rebuild: ## Force rebuild all Docker images (ignore cache) and Astro site
 
 preview: ## Serve the built static site from dist/ to verify production behavior
 	npm run preview
+
+test-a11y: ## Run the a11y axe sweep locally (4 workers, fast)
+	npx playwright test --project=a11y --workers=4
+
+test-a11y-grep: ## Run a11y subset, e.g. `make test-a11y-grep PATTERN=dark.*tfg`
+	npx playwright test --project=a11y --workers=4 --grep "$(PATTERN)"
 
 test: ## Run ALL test suites (portfolio + every demo backend)
 	npm test

--- a/src/components/demos/DesastresIADemo.tsx
+++ b/src/components/demos/DesastresIADemo.tsx
@@ -465,7 +465,7 @@ export default function DesastresIADemo({ lang = 'en' }: { lang?: Lang }) {
                         padding: '0.1rem 0.35rem',
                         borderRadius: '0.25rem',
                         background: 'var(--glow-color)',
-                        color: 'var(--accent-text)',
+                        color: 'var(--text-primary)',
                         fontWeight: 600,
                       }}
                     >

--- a/src/components/demos/JSBachDemo.tsx
+++ b/src/components/demos/JSBachDemo.tsx
@@ -69,9 +69,9 @@ const styles = {
     color: 'var(--text-secondary)',
   },
   error: {
-    color: 'var(--accent-text)',
-    background: 'rgba(239, 68, 68, 0.1)',
-    border: '1px solid rgba(239, 68, 68, 0.2)',
+    color: 'var(--text-primary)',
+    background: 'color-mix(in srgb, var(--status-error) 10%, transparent)',
+    border: '1px solid color-mix(in srgb, var(--status-error) 25%, transparent)',
     borderRadius: '0.5rem',
     padding: '0.75rem 1rem',
     fontSize: '0.85rem',

--- a/src/components/demos/MPIDSDemo.tsx
+++ b/src/components/demos/MPIDSDemo.tsx
@@ -368,7 +368,7 @@ export default function MPIDSDemo({ lang = 'en' }: { lang?: Lang }) {
             borderRadius: 8,
             background: 'color-mix(in srgb, var(--accent-end) 8%, transparent)',
             border: '1px solid color-mix(in srgb, var(--accent-end) 19%, transparent)',
-            color: 'var(--accent-text)',
+            color: 'var(--text-primary)',
             fontSize: '0.85rem',
           }}
         >

--- a/src/components/demos/Pro2Demo.tsx
+++ b/src/components/demos/Pro2Demo.tsx
@@ -71,7 +71,7 @@ const styles = {
   },
   dangerBtn: {
     background: 'color-mix(in srgb, var(--accent-end) 10%, transparent)',
-    color: 'var(--accent-text)',
+    color: 'var(--text-primary)',
   },
   tag: {
     display: 'inline-block',

--- a/src/components/demos/TfgPolypDemo.tsx
+++ b/src/components/demos/TfgPolypDemo.tsx
@@ -173,7 +173,7 @@ function ModelComparison({ t }: { t: typeof TRANSLATIONS.en }) {
                 metric === m
                   ? 'color-mix(in srgb, var(--accent-start) 10%, transparent)'
                   : 'var(--bg-card-hover)',
-              color: metric === m ? 'var(--accent-text)' : 'var(--text-secondary)',
+              color: metric === m ? 'var(--text-primary)' : 'var(--text-secondary)',
             }}
           >
             {t.metrics[m]}
@@ -565,7 +565,7 @@ function CycleGanVisualizer({ t }: { t: typeof TRANSLATIONS.en }) {
                 direction === d
                   ? 'color-mix(in srgb, var(--accent-start) 10%, transparent)'
                   : 'var(--bg-card-hover)',
-              color: direction === d ? 'var(--accent-text)' : 'var(--text-secondary)',
+              color: direction === d ? 'var(--text-primary)' : 'var(--text-secondary)',
             }}
           >
             {d === 'mask2polyp' ? t.m2p : t.p2m}

--- a/src/components/demos/caim/ZipfTab.tsx
+++ b/src/components/demos/caim/ZipfTab.tsx
@@ -423,7 +423,7 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: '0.4rem',
     background: 'color-mix(in srgb, var(--accent-end) 10%, transparent)',
     border: '1px solid color-mix(in srgb, var(--accent-end) 30%, transparent)',
-    color: 'var(--accent-text)',
+    color: 'var(--text-primary)',
     fontSize: '0.78rem',
   },
   chartContainer: {

--- a/src/pages/demos/joc-eda.astro
+++ b/src/pages/demos/joc-eda.astro
@@ -237,7 +237,7 @@ const t = useTranslations(lang);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--accent-text);
+    color: var(--text-primary);
     background: color-mix(in srgb, var(--accent-start) 10%, transparent);
     padding: 0.2rem 0.6rem;
     border-radius: var(--radius-sm);


### PR DESCRIPTION
… run

Pulled artifacts from run #25923357180 (PR #80's CI). 13 unique violation patterns all share the same shape: --accent-text on a tinted accent background (color-mix or glow-color).

Same-hue contrast: a 10% color-mix tints the bg toward the same accent the text uses, which lands at ~3-4:1 instead of 4.5+. The fix is to switch the text to --text-primary in these specific patterns. The accent identity is already conveyed by the tinted bg
+ accent-colored border in each case.

## Locations fixed

- TfgPolypDemo: F1 metric button (line 176)
- TfgPolypDemo: Mask→Polyp button (line 568)
- joc-eda.astro: .game-card-badge
- DesastresIADemo: "used in demo" helicopter chip
- Pro2Demo: dangerBtn ("Clear All")
- caim/ZipfTab: errorMsg style
- MPIDSDemo: loadError div
- JsbachDemo: error style (also switched bg to status-error semantic)

## Bonus: make targets for local a11y runs

  make test-a11y                      # all 368 tests, 4 workers
  make test-a11y-grep PATTERN="dark"  # subset

So you can iterate without going through CI.