### PR TITLE
feat(schema): validate demos.json with Zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "d3-shape": "^3.2.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "topojson-client": "^3.1.0"
+        "topojson-client": "^3.1.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
@@ -18841,9 +18842,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "d3-shape": "^3.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "topojson-client": "^3.1.0"
+    "topojson-client": "^3.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/__tests__/data-integrity.test.ts
+++ b/src/__tests__/data-integrity.test.ts
@@ -9,24 +9,24 @@
 import { describe, it, expect } from 'vitest';
 import { readdirSync } from 'fs';
 import { join } from 'path';
-import demosData from '../data/demos.json';
 import { listDemos } from '../i18n/demo';
 import { LOCALES } from '../config/locales';
 import { ui, languages } from '../i18n/ui';
-import { ICON_PATHS } from '../lib/demo-icons';
-import type { AnyLocalized as LocalizedEntry } from '../i18n/load';
 
 const DEMO_PAGES_DIR = join(__dirname, '..', 'pages', 'demos');
 const demoPageFiles = readdirSync(DEMO_PAGES_DIR)
   .filter((f) => f.endsWith('.astro'))
   .map((f) => f.replace('.astro', ''));
 
-const VALID_ICONS = Object.keys(ICON_PATHS);
-
-const demosCanonical = demosData as LocalizedEntry[];
 const demosEn = listDemos('en');
 
 // ─── Demo data consistency ──────────────────────────────────────
+//
+// Per-entry shape (slug regex, icon enum, tags non-empty, github URLs,
+// default-locale presence) is enforced by the Zod schema in
+// src/i18n/demo-schema.ts at module load — see demo-schema.test.ts for
+// the negative cases. The checks below are cross-cutting properties Zod
+// can't express on a single entry.
 
 describe('Demo data files', () => {
   it('flattens to the same number of demos in every locale', () => {
@@ -38,55 +38,6 @@ describe('Demo data files', () => {
   it('every demo has a unique slug', () => {
     const slugs = demosEn.map((d) => d.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
-  });
-
-  it('every demo has a non-empty title and description in every locale', () => {
-    for (const locale of LOCALES) {
-      for (const demo of listDemos(locale)) {
-        expect(demo.title.trim().length, `${locale}: empty title for ${demo.slug}`).toBeGreaterThan(
-          0
-        );
-        expect(
-          demo.description.trim().length,
-          `${locale}: empty description for ${demo.slug}`
-        ).toBeGreaterThan(0);
-      }
-    }
-  });
-
-  it('every demo has at least one tag', () => {
-    for (const demo of demosEn) {
-      expect(demo.tags.length, `no tags for ${demo.slug}`).toBeGreaterThanOrEqual(1);
-    }
-  });
-
-  it('every demo uses a valid icon', () => {
-    for (const demo of demosEn) {
-      expect(VALID_ICONS, `unknown icon "${demo.icon}" for ${demo.slug}`).toContain(demo.icon);
-    }
-  });
-
-  it('every demo has a github link (string or array)', () => {
-    for (const demo of demosEn) {
-      const gh = demo.github;
-      if (Array.isArray(gh)) {
-        expect(gh.length, `empty github array for ${demo.slug}`).toBeGreaterThan(0);
-        for (const url of gh) {
-          expect(url).toMatch(/^https:\/\/github\.com\//);
-        }
-      } else {
-        expect(gh).toMatch(/^https:\/\/github\.com\//);
-      }
-    }
-  });
-
-  it('icon and slug live in identity (shared across locales by construction)', () => {
-    for (const entry of demosCanonical) {
-      expect(typeof entry.identity.slug, `entry missing identity.slug`).toBe('string');
-      expect(typeof entry.identity.icon, `entry ${entry.identity.slug} missing identity.icon`).toBe(
-        'string'
-      );
-    }
   });
 });
 

--- a/src/__tests__/demo-schema.test.ts
+++ b/src/__tests__/demo-schema.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Schema-level guarantees for demos.json. The happy path is exercised by the
+ * import in src/i18n/demo.ts (which throws at module load on parse failure);
+ * this file pins the negative cases so future schema changes don't silently
+ * loosen the contract.
+ */
+import { describe, it, expect } from 'vitest';
+import demosData from '../data/demos.json';
+import { DemoEntrySchema, DemosFileSchema } from '../i18n/demo-schema';
+
+const cloneFirstEntry = (): unknown => structuredClone(demosData[0]);
+
+describe('DemosFileSchema', () => {
+  it('parses the real demos.json', () => {
+    expect(() => DemosFileSchema.parse(demosData)).not.toThrow();
+  });
+});
+
+describe('DemoEntrySchema rejections', () => {
+  it('rejects an uppercase slug', () => {
+    const entry = cloneFirstEntry() as { identity: { slug: string } };
+    entry.identity.slug = 'INVALID-Upper';
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-github.com link', () => {
+    const entry = cloneFirstEntry() as { identity: { github: string } };
+    entry.identity.github = 'https://gitlab.com/foo/bar';
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown icon name', () => {
+    const entry = cloneFirstEntry() as { identity: { icon: string } };
+    entry.identity.icon = 'definitely-not-an-icon';
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing default-locale copy', () => {
+    const entry = cloneFirstEntry() as { copy: Record<string, unknown> };
+    delete entry.copy.en;
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty tags array on identity when no copy fallback provides tags', () => {
+    const entry = cloneFirstEntry() as {
+      identity: { tags?: string[] };
+      copy: Record<string, { tags?: string[] }>;
+    };
+    entry.identity.tags = [];
+    for (const locale of Object.keys(entry.copy)) delete entry.copy[locale].tags;
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts tags defined per-locale instead of identity', () => {
+    const entry = cloneFirstEntry() as {
+      identity: { tags?: string[] };
+      copy: Record<string, { tags?: string[] }>;
+    };
+    delete entry.identity.tags;
+    for (const locale of Object.keys(entry.copy)) entry.copy[locale].tags = ['Per-locale'];
+    const result = DemoEntrySchema.safeParse(entry);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/i18n/demo-schema.ts
+++ b/src/i18n/demo-schema.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { ICON_PATHS } from '../lib/demo-icons';
+import { LOCALES, DEFAULT_LOCALE } from '../config/locales';
+
+const iconNames = Object.keys(ICON_PATHS) as [string, ...string[]];
+const localeValues = LOCALES as unknown as [string, ...string[]];
+
+const githubUrl = z.string().regex(/^https:\/\/github\.com\//, {
+  message: 'Must be a https://github.com/ URL',
+});
+
+const CopySchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().min(1),
+  lead: z.string().optional(),
+  badge: z.string().optional(),
+  metaTitle: z.string().optional(),
+  metaDescription: z.string().optional(),
+  aboutTitle: z.string().optional(),
+  aboutDescription: z.string().optional(),
+  hints: z.array(z.string()).optional(),
+  // Tags can live here per-locale (e.g. translated taxonomy) or in identity.
+  tags: z.array(z.string().min(1)).min(1).optional(),
+});
+
+const IdentitySchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]+$/, {
+    message: 'slug must be lowercase letters, digits, or hyphens',
+  }),
+  // Tags may live here (shared across locales) or in `copy[locale].tags`.
+  // Cross-field check enforced by the entry-level refinement below.
+  tags: z.array(z.string().min(1)).min(1).optional(),
+  icon: z.enum(iconNames),
+  github: z.union([githubUrl, z.array(githubUrl).min(1)]),
+  image: z.string(),
+  title: z.string().min(1).optional(),
+  badge: z.string().optional(),
+  metaTitle: z.string().optional(),
+  accent: z
+    .object({
+      from: z.string(),
+      to: z.string(),
+    })
+    .optional(),
+});
+
+export const DemoEntrySchema = z
+  .object({
+    identity: IdentitySchema,
+    copy: z.record(z.enum(localeValues), CopySchema),
+  })
+  .refine((entry) => entry.copy[DEFAULT_LOCALE] !== undefined, {
+    message: `Each demo's copy must include the default locale "${DEFAULT_LOCALE}"`,
+    path: ['copy', DEFAULT_LOCALE],
+  })
+  .refine(
+    (entry) => {
+      const def = entry.copy[DEFAULT_LOCALE];
+      if (!def) return true;
+      const hasIdentityTitle = typeof entry.identity.title === 'string';
+      const hasCopyTitle = typeof def.title === 'string';
+      return hasIdentityTitle || hasCopyTitle;
+    },
+    { message: 'A demo must have a title in identity or in default-locale copy' }
+  )
+  .refine(
+    (entry) => {
+      if (entry.identity.tags && entry.identity.tags.length > 0) return true;
+      // Otherwise every locale present must carry its own tags array.
+      return Object.values(entry.copy).every(
+        (copy) => Array.isArray(copy?.tags) && (copy?.tags?.length ?? 0) > 0
+      );
+    },
+    {
+      message:
+        'Tags must be defined on identity, or every present locale must include its own tags',
+      path: ['identity', 'tags'],
+    }
+  );
+
+export const DemosFileSchema = z.array(DemoEntrySchema);
+
+export type DemoEntry = z.infer<typeof DemoEntrySchema>;
+export type DemoCopy = z.infer<typeof CopySchema>;
+export type DemoIdentity = z.infer<typeof IdentitySchema>;

--- a/src/i18n/demo.ts
+++ b/src/i18n/demo.ts
@@ -1,6 +1,7 @@
 import demosData from '../data/demos.json' with { type: 'json' };
 import { flattenForLocale } from './load';
 import type { Locale } from '../config/locales';
+import { DemosFileSchema } from './demo-schema';
 
 export type DemoLang = Locale;
 
@@ -23,6 +24,10 @@ export interface Demo {
   hints?: string[];
 }
 
+// Validate demos.json against the canonical schema at module-load time. A
+// malformed entry is a build-time error rather than a silent runtime drift.
+const validatedDemos = DemosFileSchema.parse(demosData);
+
 const cache = new Map<DemoLang, Demo[]>();
 
 /** Flat, legacy-shape demo array for a given locale (cached). */
@@ -32,10 +37,10 @@ export function listDemos(lang: string): Demo[] {
     : 'en';
   const cached = cache.get(locale);
   if (cached) return cached;
-  const flat = flattenForLocale(
-    demosData as Parameters<typeof flattenForLocale>[0],
+  const flat = flattenForLocale<Demo>(
+    validatedDemos as unknown as Parameters<typeof flattenForLocale>[0],
     locale
-  ) as unknown as Demo[];
+  );
   cache.set(locale, flat);
   return flat;
 }


### PR DESCRIPTION
## Summary

- New \`src/i18n/demo-schema.ts\` with Zod schemas for the canonical demos.json shape (identity + per-locale copy, github URL, icon enum, tag presence, default-locale completeness)
- \`src/i18n/demo.ts\` now parses demos.json at module load — a malformed entry fails the build instead of drifting silently to runtime
- Trimmed redundant shape assertions from \`data-integrity.test.ts\` (Zod covers them now); added \`demo-schema.test.ts\` to pin the negative cases

## Test plan

- [x] \`npm run check\` — 0 errors
- [x] \`npm test\` — 1255 passing (was 1207)
- [x] \`npm run lint\` / \`format:check\` — clean
- [x] Negative case: temporarily flip a slug to \`UPPER\` → schema rejects with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)