### PR TITLE
test(visual): add Playwright snapshot suite for theme/layout drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,56 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # Visual regression. Skipped until baselines exist under
+  # e2e/visual.spec.ts-snapshots/ — generate them via the
+  # "Visual baselines (manual)" workflow, download the artifact, and
+  # commit the PNGs to enable this job.
+  playwright-visual:
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for baselines
+        id: baselines
+        run: |
+          if [ -d e2e/visual.spec.ts-snapshots ] && [ -n "$(ls -A e2e/visual.spec.ts-snapshots 2>/dev/null)" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Visual baselines not committed yet — skipping. See .github/workflows/visual-baselines.yml."
+          fi
+
+      - name: Setup Node
+        if: steps.baselines.outputs.exists == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.baselines.outputs.exists == 'true'
+        run: npm ci
+
+      - name: Install Playwright browsers
+        if: steps.baselines.outputs.exists == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run visual-regression
+        if: steps.baselines.outputs.exists == 'true'
+        run: npx playwright test --project=visual
+
+      - name: Upload Playwright report (with diffs)
+        if: always() && steps.baselines.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-visual
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
   lighthouse:
     runs-on: ubuntu-latest
     needs: quality

--- a/.github/workflows/visual-baselines.yml
+++ b/.github/workflows/visual-baselines.yml
@@ -1,0 +1,41 @@
+name: Visual baselines (manual)
+
+# Manually-triggered job that regenerates the committed visual-regression
+# baselines on a Linux runner (so the snapshots match what `playwright (visual)`
+# will compare against in CI). Output is uploaded as an artifact for the
+# operator to download, unzip into `e2e/visual.spec.ts-snapshots/`, and
+# commit on a feature branch.
+#
+# Run from GitHub UI: Actions → "Visual baselines (manual)" → Run workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Capture baselines (--update-snapshots)
+        run: npx playwright test --project=visual --update-snapshots
+
+      - name: Upload baseline snapshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-baselines
+          path: e2e/visual.spec.ts-snapshots/
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
        rebuild free-ports check-registry \
        obs-install obs-up obs-down obs-restart obs-status obs-logs obs-wipe \
        mlops-up mlops-down \
-       clean test test-a11y test-a11y-grep help \
+       clean test test-a11y test-a11y-grep test-visual test-visual-update help \
        _db-tfg _db-bitsx _db-tenda _db-draculin _db-pro2 _db-planif \
        _db-desastres _db-mpids _db-phase _db-caim _db-joceda _db-sbcia \
        _db-rob _db-par _db-fib _db-grafics
@@ -263,6 +263,12 @@ test-a11y: ## Run the a11y axe sweep locally (4 workers, fast)
 
 test-a11y-grep: ## Run a11y subset, e.g. `make test-a11y-grep PATTERN=dark.*tfg`
 	npx playwright test --project=a11y --workers=4 --grep "$(PATTERN)"
+
+test-visual: ## Run the visual-regression suite against committed baselines
+	npx playwright test --project=visual
+
+test-visual-update: ## Regenerate visual-regression baselines locally (must commit them; CI is Linux-only)
+	npx playwright test --project=visual --update-snapshots
 
 test: ## Run ALL test suites (portfolio + every demo backend)
 	npm test

--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ make test   # runs everything: Vitest + Playwright + backend pytests + Go + Rust
 5. **Rust (cargo test)** — pracpro2 backend
 6. **Vitest (JS)** — Planificación web
 
+### Visual regression
+
+A `visual` Playwright project diffs each route against a committed PNG baseline so theme/layout drift surfaces in CI with a side-by-side diff in the artifact.
+
+Baselines live at `e2e/visual.spec.ts-snapshots/` and **must be generated on Linux** (font hinting is OS-specific). Two ways:
+
+- **Recommended** — trigger the `Visual baselines (manual)` GitHub Action (`Actions → Run workflow`), download the `visual-baselines` artifact, unzip it into `e2e/visual.spec.ts-snapshots/`, and commit on a feature branch.
+- **Locally on Linux/WSL** — `make test-visual-update` regenerates them in place.
+
+Once baselines are committed, the `playwright-visual` CI job auto-enables. Use `make test-visual` for a local diff run against existing baselines.
+
 ## Project layout
 
 ```

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Visual regression suite. Compares each route against a committed PNG
+ * baseline so theme, layout, or component refactors that change pixels
+ * surface as a CI failure with a side-by-side diff in the artifact.
+ *
+ * Baselines live under e2e/visual.spec.ts-snapshots/ and must be regenerated
+ * on Linux (matching CI) — see Makefile target `test-visual-update` and the
+ * README's visual-regression section for the workflow.
+ *
+ * Run: npx playwright test --project=visual
+ * Refresh: npx playwright test --project=visual --update-snapshots
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+// Same source-of-truth slug list as browser-demos.spec.ts. Kept inline
+// (rather than imported) because importing src/data/demos.json from a
+// Playwright spec means crossing the Vite/Node boundary, which prior PRs
+// have hit issues with under Node 22's import-attribute requirement.
+const ALL_SLUGS = [
+  'tfg-polyps',
+  'draculin',
+  'bitsx-marato',
+  'matriculas',
+  'joc-eda',
+  'jsbach',
+  'tenda',
+  'pro2',
+  'mpids',
+  'phase-transitions',
+  'planificacion',
+  'desastres-ia',
+  'apa-practica',
+  'prop',
+  'caim',
+  'sbc-ia',
+  'par-parallel',
+  'rob-robotics',
+  'algorithms',
+  'grafics',
+];
+
+async function settle(page: Page) {
+  // Wait for hydration / async data to land. networkidle is fine for the
+  // browser-only demos; the live-demo iframes are masked below regardless.
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  // Disable animations so transient transition states don't leak into the
+  // baseline. Astro/React inline styles aren't affected, but animated
+  // SVG elements and CSS keyframes are.
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  });
+  // Settle one more frame for layout to absorb the override.
+  await page.waitForTimeout(150);
+}
+
+test.describe('Homepage visual', () => {
+  test('/ matches baseline', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await settle(page);
+    await expect(page).toHaveScreenshot('home.png', {
+      // Mask volatile widgets that would otherwise diff every run.
+      mask: [page.locator('canvas'), page.locator('iframe')],
+      fullPage: true,
+    });
+  });
+});
+
+test.describe('Demo pages visual', () => {
+  for (const slug of ALL_SLUGS) {
+    test(`/demos/${slug} matches baseline`, async ({ page }) => {
+      await page.goto(`/demos/${slug}`, { waitUntil: 'domcontentloaded' });
+      await settle(page);
+      await expect(page).toHaveScreenshot(`${slug}.png`, {
+        mask: [page.locator('canvas'), page.locator('iframe')],
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,24 @@ export default defineConfig({
       // on the same failure. Override the project default of 2 retries.
       retries: 0,
     },
+    {
+      name: 'visual',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+      testMatch: /visual\.spec\.ts/,
+      // Snapshot diffs are deterministic — a flaky run is a real signal,
+      // not a retry candidate.
+      retries: 0,
+      expect: {
+        toHaveScreenshot: {
+          // 1% pixel drift tolerance covers font hinting and gradient
+          // banding while still catching real layout shifts.
+          maxDiffPixelRatio: 0.01,
+        },
+      },
+    },
   ],
   webServer: {
     command: 'npm run dev',


### PR DESCRIPTION
## Summary

- New \`e2e/visual.spec.ts\` snapshots the homepage + each of the 20 demo routes against committed PNG baselines (1280×720, animations disabled, canvas/iframe masked)
- New \`visual\` Playwright project (retries=0, 1% pixel-drift tolerance for font hinting / gradient banding)
- New \`playwright-visual\` CI job that auto-skips with a \`::notice::\` until baselines exist under \`e2e/visual.spec.ts-snapshots/\`
- New \`Visual baselines (manual)\` workflow (\`workflow_dispatch\`) that regenerates snapshots on Linux and uploads them as a 30-day artifact
- \`make test-visual\` / \`make test-visual-update\` for local diff / regen; README documents the OS-specific bootstrap

## Why

After the last round closed the a11y / type / lint gaps, the only remaining "silent regression" surface was visual: a stray \`bg-card\` color change or a margin tweak in a shared component would ship without a test failing. This pins every demo and the homepage so theme/layout drift surfaces in CI with a side-by-side diff.

## How to bring online

1. Merge this PR (the new job auto-skips, no failures)
2. Run \`Actions → Visual baselines (manual) → Run workflow\` against the freshly merged main
3. Download the \`visual-baselines\` artifact, unzip into \`e2e/visual.spec.ts-snapshots/\`
4. Commit the PNGs on a feature branch — \`playwright-visual\` flips on automatically

## Test plan

- [x] \`npm run check\` / \`npm run lint\` / \`npm run format:check\` — clean
- [x] YAML structure of both workflows verified
- [ ] After baselines committed: \`playwright (visual)\` job goes green
- [ ] Deliberate \`bg-card\` color tweak → CI fails with diff in artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)