### PR TITLE
chore(ci): expand Lighthouse budget to 9 routes

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,12 @@
         "http://localhost/index.html",
         "http://localhost/demos/algorithms/index.html",
         "http://localhost/demos/grafics/index.html",
-        "http://localhost/demos/joc-eda/index.html"
+        "http://localhost/demos/joc-eda/index.html",
+        "http://localhost/demos/tfg-polyps/index.html",
+        "http://localhost/demos/caim/index.html",
+        "http://localhost/demos/bitsx-marato/index.html",
+        "http://localhost/demos/phase-transitions/index.html",
+        "http://localhost/demos/mpids/index.html"
       ],
       "numberOfRuns": 1,
       "settings": {


### PR DESCRIPTION
## Summary

Adds 5 routes to \`lighthouserc.json\` so the Lighthouse CI job covers the heaviest demos:

- \`tfg-polyps\` — large model-comparison table
- \`caim\` — d3 PageRank + Zipf charts
- \`bitsx-marato\` — Mask R-CNN canvas overlay
- \`phase-transitions\` — canvas physics simulation
- \`mpids\` — d3-force layout up to 300 nodes

## Why

Was 4 routes (home + algorithms + grafics + joc-eda); 17 demos were unbudgeted. A heavy-d3 or canvas refactor on any of the 5 added routes could regress LCP below 0.85 with no CI signal. Thresholds unchanged.

## Risk

Any of the 5 new routes might trip the 2.5 MB total-byte-weight warning. The threshold is set to \`warn\` not \`error\`, so the job stays green either way and we can triage from the published Lighthouse report.

## Test plan

- [ ] CI \`lighthouse\` job runs against 9 URLs
- [ ] All 5 new routes hit perf ≥ 0.85, a11y ≥ 0.9, best-practices ≥ 0.9, SEO ≥ 0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)