### PR TITLE
feat(seo): wire per-demo OG images via DemoLayout

### DIFF
--- a/.github/workflows/og-capture.yml
+++ b/.github/workflows/og-capture.yml
@@ -1,0 +1,51 @@
+name: OG image capture (manual)
+
+# Manually-triggered job that regenerates per-demo OpenGraph screenshots
+# on a Linux runner. Output is uploaded as an artifact for the operator
+# to download, unzip into `public/og/`, and commit on a feature branch.
+#
+# Run from GitHub UI: Actions → "OG image capture (manual)" → Run workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: |
+          npm run dev > dev.log 2>&1 &
+          # Wait for dev server to be reachable
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:4321/ > /dev/null; then
+              echo "Dev server up after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Capture OG images
+        run: npm run og:capture
+
+      - name: Upload OG images
+        uses: actions/upload-artifact@v4
+        with:
+          name: og-images
+          path: public/og/
+          retention-days: 30

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,3 @@
-2. Google Analytics (GA4)
-   Created an Analytics.astro component and injected it globally into the main Layout and DemoLayout <head> sections.
-   Your Action: Sign in to Google Analytics, create a property, get your Measurement ID (it starts with G-), and replace the 'G-XXXXXXXXXX' string at the top of the src/components/Analytics.astro file.
+## Google Analytics (GA4)
 
-3. OpenGraph Social Images per Demo
-   Updated DemoLayout.astro to accept an ogImage property. By default, it will fall back to your main /og-image.jpg. I've also updated your JSON data files with a placeholder "image": "" to reflect where they could be stored.
-   Your Action: If you want a specific image to appear when linking a demo on Twitter or LinkedIn, capture a screenshot, place it in public/ (e.g. draculin-og.jpg), and then pass it as a prop in the demo's .astro file like so: <DemoLayout title="..." description="..." ogImage="/draculin-og.jpg">.
+`Analytics.astro` reads `PUBLIC_GA_ID` from the environment and only injects the GA4 pixel when it's set to a valid `G-...` ID. To enable in production, set the secret in the GitHub Pages deploy workflow (or in `.env` for local dev).

--- a/scripts/wire-demos-og-image.mjs
+++ b/scripts/wire-demos-og-image.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * One-shot codemod: add `ogImage="/og/<slug>-og.png"` to every
+ * `<DemoLayout slug="...">` in src/pages/demos/*.astro.
+ *
+ * Idempotent: skips files that already include `ogImage=`.
+ *
+ * Use after running the OG-capture workflow and committing the PNGs to
+ * `public/og/`.
+ */
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DEMOS_DIR = join(ROOT, 'src', 'pages', 'demos');
+
+let updated = 0;
+let skipped = 0;
+let errors = 0;
+
+for (const file of readdirSync(DEMOS_DIR)) {
+  if (!file.endsWith('.astro')) continue;
+  const path = join(DEMOS_DIR, file);
+  const original = readFileSync(path, 'utf8');
+
+  if (/\bogImage=/.test(original)) {
+    skipped += 1;
+    continue;
+  }
+
+  // Match the slug="..." attribute on a <DemoLayout> tag (works whether
+  // the tag is single-line or spans multiple lines, since we don't anchor
+  // on the opening "<DemoLayout").
+  const slugMatch = original.match(/<DemoLayout\b[^>]*?\bslug="([a-z0-9-]+)"/s);
+  if (!slugMatch) {
+    console.error(`! ${file}: no <DemoLayout slug="..."> found`);
+    errors += 1;
+    continue;
+  }
+  const slug = slugMatch[1];
+  const ogAttr = ` ogImage="/og/${slug}-og.png"`;
+
+  // Insert the new attribute right after the matched slug="..."
+  const replaced = original.replace(
+    /<DemoLayout\b([^>]*?\bslug="[a-z0-9-]+")/s,
+    (_full, attrs) => `<DemoLayout${attrs}${ogAttr}`
+  );
+
+  writeFileSync(path, replaced);
+  updated += 1;
+  console.log(`✓ ${file} (slug=${slug})`);
+}
+
+console.log(`\nDone — wired ${updated}, skipped ${skipped} already-wired, ${errors} errors.`);
+if (errors > 0) process.exitCode = 1;

--- a/src/pages/demos/algorithms.astro
+++ b/src/pages/demos/algorithms.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('algorithms', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="algorithms">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="algorithms"
+  ogImage="/og/algorithms-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/apa-practica.astro
+++ b/src/pages/demos/apa-practica.astro
@@ -14,6 +14,7 @@ const demo = getDemo('apa-practica', lang);
   title={demo.metaTitle ?? demo.title}
   description={demo.metaDescription}
   slug="apa-practica"
+  ogImage="/og/apa-practica-og.png"
 >
   <div class="container">
     <DemoHeader

--- a/src/pages/demos/bitsx-marato.astro
+++ b/src/pages/demos/bitsx-marato.astro
@@ -14,6 +14,7 @@ const demo = getDemo('bitsx-marato', lang);
   title={demo.metaTitle ?? demo.title}
   description={demo.metaDescription}
   slug="bitsx-marato"
+  ogImage="/og/bitsx-marato-og.png"
 >
   <div class="container">
     <DemoHeader

--- a/src/pages/demos/caim.astro
+++ b/src/pages/demos/caim.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('caim', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="caim">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="caim"
+  ogImage="/og/caim-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/desastres-ia.astro
+++ b/src/pages/demos/desastres-ia.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('desastres-ia', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="desastres-ia">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="desastres-ia"
+  ogImage="/og/desastres-ia-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/draculin.astro
+++ b/src/pages/demos/draculin.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('draculin', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="draculin">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="draculin"
+  ogImage="/og/draculin-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/grafics.astro
+++ b/src/pages/demos/grafics.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('grafics', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="grafics">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="grafics"
+  ogImage="/og/grafics-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/joc-eda.astro
+++ b/src/pages/demos/joc-eda.astro
@@ -12,7 +12,12 @@ const tr = getJocEdaCopy(lang);
 const t = useTranslations(lang);
 ---
 
-<DemoLayout title={demo.metaTitle ?? demo.title} description={demo.metaDescription} slug="joc-eda">
+<DemoLayout
+  title={demo.metaTitle ?? demo.title}
+  description={demo.metaDescription}
+  slug="joc-eda"
+  ogImage="/og/joc-eda-og.png"
+>
   <div class="container joc-eda-page">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/jsbach.astro
+++ b/src/pages/demos/jsbach.astro
@@ -11,7 +11,12 @@ const demo = getDemo('jsbach', lang);
 const hint = demo.hints ?? [];
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="jsbach">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="jsbach"
+  ogImage="/og/jsbach-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/matriculas.astro
+++ b/src/pages/demos/matriculas.astro
@@ -10,7 +10,12 @@ const t = useTranslations(lang);
 const demo = getDemo('matriculas', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="matriculas">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="matriculas"
+  ogImage="/og/matriculas-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/mpids.astro
+++ b/src/pages/demos/mpids.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('mpids', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="mpids">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="mpids"
+  ogImage="/og/mpids-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/par-parallel.astro
+++ b/src/pages/demos/par-parallel.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('par-parallel', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="par-parallel">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="par-parallel"
+  ogImage="/og/par-parallel-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/phase-transitions.astro
+++ b/src/pages/demos/phase-transitions.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('phase-transitions', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="phase-transitions">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="phase-transitions"
+  ogImage="/og/phase-transitions-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/planificacion.astro
+++ b/src/pages/demos/planificacion.astro
@@ -14,6 +14,7 @@ const demo = getDemo('planificacion', lang);
   title={demo.metaTitle ?? demo.title}
   description={demo.metaDescription}
   slug="planificacion"
+  ogImage="/og/planificacion-og.png"
 >
   <div class="container">
     <DemoHeader

--- a/src/pages/demos/pro2.astro
+++ b/src/pages/demos/pro2.astro
@@ -10,7 +10,12 @@ const t = useTranslations(lang);
 const demo = getDemo('pro2', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="pro2">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="pro2"
+  ogImage="/og/pro2-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/prop.astro
+++ b/src/pages/demos/prop.astro
@@ -12,7 +12,12 @@ const tr = getPropCopy(lang);
 const t = useTranslations(lang);
 ---
 
-<DemoLayout title={demo.metaTitle ?? demo.title} description={demo.metaDescription} slug="prop">
+<DemoLayout
+  title={demo.metaTitle ?? demo.title}
+  description={demo.metaDescription}
+  slug="prop"
+  ogImage="/og/prop-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/rob-robotics.astro
+++ b/src/pages/demos/rob-robotics.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('rob-robotics', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="rob-robotics">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="rob-robotics"
+  ogImage="/og/rob-robotics-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/sbc-ia.astro
+++ b/src/pages/demos/sbc-ia.astro
@@ -11,7 +11,12 @@ const t = useTranslations(lang);
 const demo = getDemo('sbc-ia', lang);
 ---
 
-<DemoLayout title={demo.title} description={demo.metaDescription} slug="sbc-ia">
+<DemoLayout
+  title={demo.title}
+  description={demo.metaDescription}
+  slug="sbc-ia"
+  ogImage="/og/sbc-ia-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/tenda.astro
+++ b/src/pages/demos/tenda.astro
@@ -11,7 +11,12 @@ const demo = getDemo('tenda', lang);
 const t = useTranslations(lang);
 ---
 
-<DemoLayout title={demo.metaTitle ?? demo.title} description={demo.metaDescription} slug="tenda">
+<DemoLayout
+  title={demo.metaTitle ?? demo.title}
+  description={demo.metaDescription}
+  slug="tenda"
+  ogImage="/og/tenda-og.png"
+>
   <div class="container">
     <DemoHeader
       badge={demo.badge}

--- a/src/pages/demos/tfg-polyps.astro
+++ b/src/pages/demos/tfg-polyps.astro
@@ -14,6 +14,7 @@ const demo = getDemo('tfg-polyps', lang);
   title={demo.metaTitle ?? demo.title}
   description={demo.metaDescription}
   slug="tfg-polyps"
+  ogImage="/og/tfg-polyps-og.png"
 >
   <div class="container">
     <DemoHeader


### PR DESCRIPTION
## Summary

- All 20 demo pages now pass \`ogImage=\"/og/<slug>-og.png\"\` to \`<DemoLayout>\` (was: each fell back to global \`/og-image.jpg\`)
- One-shot, idempotent codemod (\`scripts/wire-demos-og-image.mjs\`) does the wiring; new demos can call it or add the prop manually
- New \`.github/workflows/og-capture.yml\` (\`workflow_dispatch\`) runs the existing \`scripts/capture-og-images.mjs\` against the dev server on Linux and uploads PNGs as a 30-day artifact
- TODO.md trimmed: the OG section is now obsolete; the remaining GA4 note documents the existing env-var pattern

## Why

Per-demo OG previews give every demo a dedicated social card. Without this, sharing \`/demos/jsbach\` on Twitter/LinkedIn shows the generic site-wide image, which buries the demo's identity.

## How to bring online

1. Merge this PR — wiring lands; \`og:image\` URLs resolve to 404s until PNGs exist
2. Run \`Actions → OG image capture (manual) → Run workflow\` against main
3. Download the \`og-images\` artifact, unzip into \`public/og/\`
4. Commit the 20 PNGs on a feature branch — \`og:image\` URLs now resolve

## Test plan

- [x] \`npm run check\` / \`npm run lint\` / \`npm run format:check\` — clean
- [x] \`npm run build\` — every demo's HTML now contains \`<meta property=\"og:image\" content=\".../og/<slug>-og.png\">\` (verified \`dist/demos/jsbach/index.html\`)
- [ ] After OG PNGs committed: Twitter Card validator and LinkedIn Post Inspector show the per-demo image

🤖 Generated with [Claude Code](https://claude.com/claude-code)