### PR TITLE
chore(lint): cut ESLint warning noise from 174 → 79

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,12 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'warn',
-        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+        },
       ],
       '@typescript-eslint/no-require-imports': 'warn',
       '@typescript-eslint/ban-ts-comment': 'warn',
@@ -59,7 +64,10 @@ export default [
       'prefer-const': 'warn',
       'prefer-rest-params': 'warn',
       'no-constant-condition': 'warn',
-      'no-empty': 'warn',
+      // Empty `catch {}` blocks are an idiom in this codebase for "best
+      // effort, ignore failure" paths (e.g. localStorage feature detection,
+      // optional analytics) — silencing those as a category, not per-site.
+      'no-empty': ['warn', { allowEmptyCatch: true }],
       'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
       // jsx-a11y demotions for the existing demo components — re-enable as we
       // clean each rule up.
@@ -83,12 +91,31 @@ export default [
     },
   },
   {
-    files: ['scripts/**/*.{js,mjs,cjs}', '*.config.{js,mjs,cjs,ts}', 'astro.config.mjs'],
+    // Build / verification / codemod scripts. console.log is the intended
+    // interface here, not a debug residue. Covers the root-level utilities
+    // (verify-site.mjs, check-error.mjs) and everything under scripts/.
+    files: [
+      'scripts/**/*.{js,mjs,cjs}',
+      '*.config.{js,mjs,cjs,ts}',
+      'astro.config.mjs',
+      'verify-site.mjs',
+      'check-error.mjs',
+    ],
     languageOptions: {
       globals: { ...globals.node },
     },
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    // OpenCV.js bindings have no usable TypeScript definitions; the `any`
+    // escape is unavoidable and is the documented pattern in the upstream
+    // OpenCV docs. Silence the no-explicit-any noise for this one file so
+    // the lint signal-to-noise stays useful.
+    files: ['src/lib/plate-detection.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
     },
   },
   {

--- a/src/__tests__/data-integrity.test.ts
+++ b/src/__tests__/data-integrity.test.ts
@@ -7,7 +7,7 @@
  * and the actual Astro page files on disk.
  */
 import { describe, it, expect } from 'vitest';
-import { readdirSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { listDemos } from '../i18n/demo';
 import { LOCALES } from '../config/locales';
@@ -67,8 +67,8 @@ describe('Demo pages match demo data', () => {
 describe('Homepage pages consume the sections SSOT', () => {
   const enHomePath = join(__dirname, '..', 'pages', 'index.astro');
   const langHomePath = join(__dirname, '..', 'pages', '[lang]', 'index.astro');
-  const enHome = require('fs').readFileSync(enHomePath, 'utf-8') as string;
-  const langHome = require('fs').readFileSync(langHomePath, 'utf-8') as string;
+  const enHome = readFileSync(enHomePath, 'utf-8') as string;
+  const langHome = readFileSync(langHomePath, 'utf-8') as string;
 
   // Both pages MUST import { sections } from config/sections so the order
   // is centralised in one place. Detailed structural assertions live in
@@ -116,7 +116,7 @@ describe('i18n translations', () => {
 
 describe('Dynamic demo router ([lang]/demos/[demo].astro)', () => {
   const routerPath = join(__dirname, '..', 'pages', '[lang]', 'demos', '[demo].astro');
-  const routerContent = require('fs').readFileSync(routerPath, 'utf-8') as string;
+  const routerContent = readFileSync(routerPath, 'utf-8') as string;
 
   // The router globs every page in src/pages/demos/ at build time, so slug
   // coverage is enforced by the "every slug has a corresponding .astro page"

--- a/src/__tests__/desastres-search.test.ts
+++ b/src/__tests__/desastres-search.test.ts
@@ -8,7 +8,6 @@ import {
   hillClimbing,
   simulatedAnnealing,
   defaultToyScenario,
-  type Board,
   type Assignment,
 } from '../lib/desastresSearch';
 

--- a/src/__tests__/draculin-demo-state.test.ts
+++ b/src/__tests__/draculin-demo-state.test.ts
@@ -93,7 +93,7 @@ const QUESTIONS: QuizQuestion[] = [
 
 describe('DraculinDemo — quiz step progression', () => {
   it('starts at question index 0', () => {
-    let idx = 0;
+    const idx = 0;
     expect(idx).toBe(0);
     expect(QUESTIONS[idx].text).toBe('Q1');
   });

--- a/src/__tests__/graph-phase.test.ts
+++ b/src/__tests__/graph-phase.test.ts
@@ -4,7 +4,6 @@ import {
   connectedComponents,
   isConnected,
   isComponentComplex,
-  allComponentsComplex,
   analyzeGraph,
   nodePercolation,
   edgePercolation,

--- a/src/__tests__/imgproc.test.ts
+++ b/src/__tests__/imgproc.test.ts
@@ -7,8 +7,6 @@ import {
   bitwiseNot,
   bitwiseOr,
   floodFill,
-  clearBorder,
-  fillHoles,
   labelConnectedComponents,
   extractContours,
   boundingRect,

--- a/src/__tests__/tenda-demo-state.test.ts
+++ b/src/__tests__/tenda-demo-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MOCK_PRODUCTS, MOCK_CATEGORIES } from '../data/tenda-mock';
+import { MOCK_PRODUCTS } from '../data/tenda-mock';
 
 /**
  * Tests for the TendaDemo cart state logic.

--- a/src/components/ThemeInit.astro
+++ b/src/components/ThemeInit.astro
@@ -30,7 +30,7 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
   const VALID_THEMES = THEME_IDS;
   const VALID_DESIGNS = DESIGN_IDS;
 
-  var __themeSource = 'fallback';
+  let __themeSource = 'fallback';
   const __theme = (() => {
     const url = new URL(window.location.href);
     const param = url.searchParams.get('theme');
@@ -58,7 +58,7 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
   document.documentElement.setAttribute('data-theme', __theme);
   if (window.__debug) window.__debug.log('info', 'theme', 'resolved', { theme: __theme, source: __themeSource });
 
-  var __designSource = 'fallback';
+  let __designSource = 'fallback';
   const __design = (() => {
     const url = new URL(window.location.href);
     const param = url.searchParams.get('design');
@@ -83,22 +83,22 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
 
   // Load design-specific fonts on demand instead of all 14 families upfront.
   // Core fonts (Inter, Inter Tight, JetBrains Mono) are in the main <link>.
-  var __designFonts = {
-    editorial:  'family=Playfair+Display:ital,wght@0,700;0,800;1,800;1,900&family=Crimson+Pro:ital,wght@0,400;0,600;1,400',
-    pixel:      'family=Press+Start+2P',
-    cyber:      'family=Orbitron:wght@500;700;900',
-    notebook:   'family=Caveat:wght@500;600;700',
-    academic:   'family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
-    deco:       'family=Poiret+One&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Playfair+Display:ital,wght@0,700;0,800;1,800;1,900',
-    wabisabi:   'family=Shippori+Mincho:wght@400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
-    comic:      'family=Bangers',
-    newspaper:  'family=UnifrakturMaguntia&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
-  };
-  var __loadedFonts = {};
+  const __designFonts = {
+  editorial:  'family=Playfair+Display:ital,wght@0,700;0,800;1,800;1,900&family=Crimson+Pro:ital,wght@0,400;0,600;1,400',
+  pixel:      'family=Press+Start+2P',
+  cyber:      'family=Orbitron:wght@500;700;900',
+  notebook:   'family=Caveat:wght@500;600;700',
+  academic:   'family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
+  deco:       'family=Poiret+One&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Playfair+Display:ital,wght@0,700;0,800;1,800;1,900',
+  wabisabi:   'family=Shippori+Mincho:wght@400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
+  comic:      'family=Bangers',
+  newspaper:  'family=UnifrakturMaguntia&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500',
+};
+  const __loadedFonts = {};
   window.__loadDesignFonts = function(id) {
     if (__loadedFonts[id] || !__designFonts[id]) return;
     __loadedFonts[id] = true;
-    var link = document.createElement('link');
+    const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = 'https://fonts.googleapis.com/css2?' + __designFonts[id] + '&display=swap';
     document.head.appendChild(link);
@@ -110,7 +110,7 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
   // whenever the OS toggles dark/light, so we get a free `theme.info` for
   // free even if no UI is touched.
   try {
-    var __scQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const __scQuery = window.matchMedia('(prefers-color-scheme: dark)');
     if (__scQuery && typeof __scQuery.addEventListener === 'function') {
       __scQuery.addEventListener('change', function(e) {
         if (window.__debug) {
@@ -122,8 +122,8 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
 
   window.setTheme = function(id) {
     if (!VALID_THEMES.includes(id)) {
-      var msg = 'Unknown theme "' + id + '". Available themes:\n' +
-        VALID_THEMES.map(function(t) { return '  \u2022 ' + t; }).join('\n');
+      const msg = 'Unknown theme "' + id + '". Available themes:\n' +
+      VALID_THEMES.map(function(t) { return '  \u2022 ' + t; }).join('\n');
       if (window.__debug) window.__debug.log('error', 'theme', msg);
       else console.error(msg);
       return;
@@ -135,8 +135,8 @@ const recFor = (themeId: string): string => (recommendedBy[themeId] ?? []).join(
 
   window.setDesign = function(id) {
     if (!VALID_DESIGNS.includes(id)) {
-      var msg = 'Unknown design "' + id + '". Available designs:\n' +
-        VALID_DESIGNS.map(function(d) { return '  \u2022 ' + d; }).join('\n');
+      const msg = 'Unknown design "' + id + '". Available designs:\n' +
+      VALID_DESIGNS.map(function(d) { return '  \u2022 ' + d; }).join('\n');
       if (window.__debug) window.__debug.log('error', 'theme', msg);
       else console.error(msg);
       return;

--- a/src/components/demos/ApaPracticaDemo.tsx
+++ b/src/components/demos/ApaPracticaDemo.tsx
@@ -13,7 +13,7 @@ const NB = 'https://nbviewer.org/github/cuberhaus/APA_Practica/blob/main';
 const MAIN_NB = 'PracticaAPA-Hipotiroidismo-PolCasacubertaMartaGranero.ipynb';
 const LINEAR_NB = 'PracticaAPA-Hipotiroidismo-ModelsLineals.ipynb';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/apa-practica-demo';
+import { TRANSLATIONS } from '../../i18n/demos/apa-practica-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 
 type Lang = 'en' | 'es' | 'ca';

--- a/src/components/demos/BitsXMaratoDemo.tsx
+++ b/src/components/demos/BitsXMaratoDemo.tsx
@@ -7,7 +7,7 @@ const FRAME = { w: 472, h: 296, maskPolygon: '2,205 470,185 470,215 2,236' };
 
 const TEAM = ['Pol Casacuberta', 'Tatiana Meyer', 'Pablo Vega', 'Ton Vilà'];
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/bits-xmarato-demo';
+import { TRANSLATIONS } from '../../i18n/demos/bits-xmarato-demo';
 import { useDemoLifecycle } from '../../lib/useDebug';
 
 type Lang = 'en' | 'es' | 'ca';

--- a/src/components/demos/CAIMDemo.tsx
+++ b/src/components/demos/CAIMDemo.tsx
@@ -1,6 +1,6 @@
 import { useState, lazy, Suspense } from 'react';
 
-import { T, type DemoTranslations } from '../../i18n/demos/caim-demo';
+import { T } from '../../i18n/demos/caim-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/DesastresIADemo.tsx
+++ b/src/components/demos/DesastresIADemo.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../lib/desastresSearch';
 import { AssignmentMapFigure, PerHeliBreakdown, QueueStrips } from './DesastresVisual';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/desastres-ia-demo';
+import { TRANSLATIONS } from '../../i18n/demos/desastres-ia-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/DraculinDemo.tsx
+++ b/src/components/demos/DraculinDemo.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/draculin-demo';
+import { TRANSLATIONS } from '../../i18n/demos/draculin-demo';
 import MockBanner from './MockBanner';
 import { debug } from '../../lib/debug';
 import { useDemoLifecycle } from '../../lib/useDebug';

--- a/src/components/demos/GraficsDemo.tsx
+++ b/src/components/demos/GraficsDemo.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from 'react';
 import { drawWave, drawPhong, drawCheckerboard, drawExplode } from '../../lib/grafics-kernels';
 
-import { T, type DemoTranslations } from '../../i18n/demos/grafics-demo';
+import { T } from '../../i18n/demos/grafics-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/JSBachDemo.tsx
+++ b/src/components/demos/JSBachDemo.tsx
@@ -6,7 +6,7 @@ import {
   type JSBachResult,
 } from '../../lib/jsbach/interpreter';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/jsbach-demo';
+import { TRANSLATIONS } from '../../i18n/demos/jsbach-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/MPIDSDemo.tsx
+++ b/src/components/demos/MPIDSDemo.tsx
@@ -12,7 +12,7 @@ import {
   type MPIDSResult,
 } from '../../lib/mpids';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/mpids-demo';
+import { TRANSLATIONS } from '../../i18n/demos/mpids-demo';
 import { debug } from '../../lib/debug';
 import { useDemoLifecycle } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';

--- a/src/components/demos/ParDemo.tsx
+++ b/src/components/demos/ParDemo.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { computeMandelbrot, jacobiStep, initHeatGrid, computePi } from '../../lib/par-kernels';
 import { getThemeColors } from '../../lib/demo-theme';
 
-import { T, type DemoTranslations } from '../../i18n/demos/par-demo';
+import { T } from '../../i18n/demos/par-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/PhaseTransitionsDemo.tsx
+++ b/src/components/demos/PhaseTransitionsDemo.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../lib/graph-phase';
 import { forceLayout } from '../../lib/mpids';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/phase-transitions-demo';
+import { TRANSLATIONS } from '../../i18n/demos/phase-transitions-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/PlanificacionDemo.tsx
+++ b/src/components/demos/PlanificacionDemo.tsx
@@ -1,7 +1,7 @@
 import { useId, useState } from 'react';
 import LiveAppEmbed from './LiveAppEmbed';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/planificacion-demo';
+import { TRANSLATIONS } from '../../i18n/demos/planificacion-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/Pro2Demo.tsx
+++ b/src/components/demos/Pro2Demo.tsx
@@ -13,7 +13,7 @@ import {
   DEFAULT_K,
 } from '../../lib/wpgma';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/pro2-demo';
+import { TRANSLATIONS } from '../../i18n/demos/pro2-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/RobDemo.tsx
+++ b/src/components/demos/RobDemo.tsx
@@ -5,7 +5,7 @@ import {
   forwardKinematicsPositions,
 } from '../../lib/rob-kernels';
 
-import { T, type DemoTranslations } from '../../i18n/demos/rob-demo';
+import { T } from '../../i18n/demos/rob-demo';
 import { getThemeColors, lighten, withAlpha } from '../../lib/demo-theme';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';

--- a/src/components/demos/SPMatriculasDemo.tsx
+++ b/src/components/demos/SPMatriculasDemo.tsx
@@ -6,7 +6,7 @@ import {
   type WorkerPipelineResult,
 } from '../../lib/opencv-loader';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/spmatriculas-demo';
+import { TRANSLATIONS } from '../../i18n/demos/spmatriculas-demo';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 

--- a/src/components/demos/SbcDemo.tsx
+++ b/src/components/demos/SbcDemo.tsx
@@ -12,7 +12,7 @@ import {
   type Transport,
 } from '../../data/sbc-mock';
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/sbc-demo';
+import { TRANSLATIONS } from '../../i18n/demos/sbc-demo';
 import MockBanner from './MockBanner';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';

--- a/src/components/demos/TendaDemo.tsx
+++ b/src/components/demos/TendaDemo.tsx
@@ -3,7 +3,7 @@ import { MOCK_CATEGORIES, MOCK_PRODUCTS, type Category, type Product } from '../
 import { withDemoErrorBoundary } from '../DemoErrorBoundary';
 
 type View = 'home' | 'category' | 'product' | 'cart' | 'checkout';
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/tenda-demo';
+import { TRANSLATIONS } from '../../i18n/demos/tenda-demo';
 import MockBanner from './MockBanner';
 import { useDemoLifecycle, useDebug } from '../../lib/useDebug';
 

--- a/src/components/demos/TfgPolypDemo.tsx
+++ b/src/components/demos/TfgPolypDemo.tsx
@@ -15,7 +15,7 @@ const card = {
   padding: '1.5rem',
 } as const;
 
-import { TRANSLATIONS, type DemoTranslations } from '../../i18n/demos/tfg-polyp-demo';
+import { TRANSLATIONS } from '../../i18n/demos/tfg-polyp-demo';
 
 type Lang = 'en' | 'es' | 'ca';
 


### PR DESCRIPTION
## Summary

CI was printing 174 ESLint warnings on every run, deep enough that real regressions could hide. Two-thirds were noise. Cuts to **79** by:

**Config (\`eslint.config.mjs\`):**
- \`verify-site.mjs\` + \`check-error.mjs\` now part of the existing \`scripts/**\` \`no-console\` exemption (build/verification utilities — \`console.log\` is the intended interface)
- \`caughtErrorsIgnorePattern: '^_'\` so \`catch (_e) {}\` stops tripping no-unused-vars
- \`no-empty: { allowEmptyCatch: true }\` — empty catches are the codebase's "best-effort, ignore failure" idiom
- Per-file \`no-explicit-any: 'off'\` for \`src/lib/plate-detection.ts\` (OpenCV.js bindings — no usable TS defs)

**Code:**
- Drop unused \`type DemoTranslations\` imports from 17 demo components (autoimported pattern never used)
- \`require('fs')\` → top-level \`readFileSync\` import in \`data-integrity.test.ts\`
- Drop unused test-scaffolding imports across 4 test files

## Remaining 79

All real items needing case-by-case review (real \`any\`s in d3 wrappers, real jsx-a11y in \`TendaDemo\`'s hover cards, etc.). Lowering further is a separate refactor.

## Test plan

- [x] \`npm run check\` — 0 errors
- [x] \`npm test\` — 1270 passing
- [x] \`npm run lint\` — 0 errors, 79 warnings (was 174)
- [x] \`npm run format:check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)