### PR TITLE
fix(ci): use @playwright/test chromium in og:capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "globals": "^15.14.0",
         "lefthook": "^1.10.10",
-        "playwright": "1.58.2",
         "prettier": "^3.4.2",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.7.3",
@@ -14444,31 +14443,13 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0",
     "lefthook": "^1.10.10",
-    "playwright": "1.58.2",
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.7.3",

--- a/scripts/capture-og-images.mjs
+++ b/scripts/capture-og-images.mjs
@@ -16,7 +16,11 @@
  *   OG_OUT_DIR    output dir relative to repo root (default "public")
  */
 
-import { chromium } from 'playwright';
+// Use @playwright/test's chromium (matches the version that
+// `npx playwright install` downloads in CI). Importing from the
+// `playwright` package directly pulls in a different pinned version
+// and points at a browser build that was never installed.
+import { chromium } from '@playwright/test';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';


### PR DESCRIPTION
## Summary

The deploy job's \`Capture OG images\` step crashed with:

\`\`\`
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/...
\`\`\`

Root cause: \`scripts/capture-og-images.mjs\` imports \`chromium\` from the standalone \`playwright\` package (pinned at 1.58.2 → expects browser build 1208), but CI installs browsers via the \`@playwright/test\` 1.59.1 binary which downloads a different build (1217/1223). The two binaries don't share the cache, so the script crashed every deploy.

## Fix

- Import \`chromium\` from \`@playwright/test\` instead — matches the version CI installed
- Drop the standalone \`playwright\` dep entirely; nothing else in the repo imports from it directly (e2e specs already use \`@playwright/test\`), and keeping both around just invites this kind of version drift again

## Test plan

- [x] \`npm run check\` / \`npm run format:check\` — clean
- [ ] Deploy workflow's \`Capture OG images\` step now succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)