### PR TITLE
fix(visual): inject anti-animation CSS via initScript

### DIFF
--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -39,25 +39,47 @@ const ALL_SLUGS = [
   'grafics',
 ];
 
+// CSS injected during the initial document load (before any page script
+// runs) to disable animations / transitions so transient frames can't leak
+// into the screenshot baseline. Done via an init script rather than
+// page.addStyleTag because Astro's ClientRouter can navigate / replace the
+// document mid-load, which destroys the page context and breaks
+// addStyleTag with "Target page, context or browser has been closed".
+const DISABLE_ANIMATIONS_CSS = `
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+`;
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((css) => {
+    // Inject as early as possible; re-inject on each navigation so
+    // ClientRouter swaps don't drop the override.
+    const inject = () => {
+      if (document.getElementById('__visual-no-anim__')) return;
+      const style = document.createElement('style');
+      style.id = '__visual-no-anim__';
+      style.textContent = css;
+      (document.head || document.documentElement).appendChild(style);
+    };
+    if (document.readyState !== 'loading') inject();
+    else document.addEventListener('DOMContentLoaded', inject, { once: true });
+    document.addEventListener('astro:after-swap', inject);
+  }, DISABLE_ANIMATIONS_CSS);
+});
+
 async function settle(page: Page) {
-  // Wait for hydration / async data to land. networkidle is fine for the
-  // browser-only demos; the live-demo iframes are masked below regardless.
-  await page.waitForLoadState('networkidle').catch(() => undefined);
-  // Disable animations so transient transition states don't leak into the
-  // baseline. Astro/React inline styles aren't affected, but animated
-  // SVG elements and CSS keyframes are.
-  await page.addStyleTag({
-    content: `
-      *, *::before, *::after {
-        animation-duration: 0s !important;
-        animation-delay: 0s !important;
-        transition-duration: 0s !important;
-        transition-delay: 0s !important;
-      }
-    `,
-  });
-  // Settle one more frame for layout to absorb the override.
-  await page.waitForTimeout(150);
+  // Wait for hydration / async data to land. Use 'load' rather than
+  // 'networkidle' — the latter never fires on pages that keep a long-poll
+  // open (e.g. dev-server HMR websocket). 'load' is enough to know the
+  // page's top-level scripts ran, including ClientRouter's view-transition
+  // handlers, so subsequent operations don't race a context destruction.
+  await page.waitForLoadState('load').catch(() => undefined);
+  // Settle one more frame for layout to absorb async hydration.
+  await page.waitForTimeout(300);
 }
 
 test.describe('Homepage visual', () => {


### PR DESCRIPTION
## Summary

The visual baseline workflow failed on all 21 demos last run (#25926505443) with:

\`\`\`
Error: page.addStyleTag: Target page, context or browser has been closed
\`\`\`

Same root cause as the keyboard test flakes: Astro's ClientRouter does a view-transition / hydration step mid-navigation that destroys and recreates the page context, and \`addStyleTag\` was racing that window.

## Fix

- **Inject anti-animation CSS via \`page.addInitScript\`** instead of \`addStyleTag\`. The init script runs before any page script executes, so the style tag is in the DOM before ClientRouter can swap the document. The script also listens for \`astro:after-swap\` so ClientRouter navigations re-inject the override.
- **Switch \`settle()\` wait from \`networkidle\` → \`load\`**. \`networkidle\` never fires on the dev server because HMR keeps a websocket open. \`load\` is enough to know top-level scripts ran.
- **Bump post-load settle from 150ms → 300ms** so React's \`client:visible\` boundaries have a beat to mount.

## Next steps after merge

1. Re-run the \`Visual baselines (manual)\` workflow against the new main
2. Download the \`visual-baselines\` artifact, unzip into \`e2e/visual.spec.ts-snapshots/\`
3. Commit the PNGs on a feature branch — \`playwright-visual\` job auto-enables

## Test plan

- [x] \`npm run check\` / \`npm run format:check\` — clean
- [ ] Workflow run completes without the \`addStyleTag\` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)