### PR TITLE
fix(themes): restore section-label text in inverted-block designs

### DIFF
--- a/src/styles/designs.css
+++ b/src/styles/designs.css
@@ -1295,6 +1295,14 @@ html[data-design='brutalist'] .section-label {
   font-size: 0.85rem;
   background: var(--br-ink);
   color: var(--bg-primary);
+  /* Undo the global .section-label gradient-clipped-to-text trick — the
+     brutalist treatment is a solid block with inverted text, not a
+     transparent-fill gradient. Without these resets the label inherits
+     the global -webkit-text-fill-color: transparent and shows only the
+     dark background pill with invisible text. */
+  -webkit-text-fill-color: currentColor;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
   padding: 0.15rem 0.45rem;
   display: inline-block;
 }
@@ -2485,6 +2493,12 @@ html[data-design='risograph'] .section-label {
   display: inline-block;
   background: var(--text-primary);
   color: var(--bg-primary);
+  /* Undo the global gradient-clipped-to-text trick (see brutalist
+     above). Without these the inverted-block treatment shows the
+     pill but the text is invisible. */
+  -webkit-text-fill-color: currentColor;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
   padding: 0.15rem 0.5rem;
   font-weight: 700;
   letter-spacing: 0.1em;
@@ -3251,6 +3265,12 @@ html[data-design='zine'] .section-label {
   letter-spacing: 0.04em;
   background: var(--zine-ink);
   color: var(--zine-paper);
+  /* Undo the global gradient-clipped-to-text trick (see brutalist
+     above). Without these the inverted-block treatment shows the
+     pill but the text is invisible. */
+  -webkit-text-fill-color: currentColor;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
   padding: 0.2rem 0.5rem;
   text-transform: uppercase;
   display: inline-block;


### PR DESCRIPTION
## What you saw

Brutalist theme, "Where I've worked" section: the dark inverted-block above the title was visible but its **text was invisible** — the screenshot shows just an empty cream-on-dark pill where "EXPERIENCE" should be.

## Root cause

The global \`.section-label\` rule in [global.css:184](src/styles/global.css#L184) sets:

\`\`\`css
.section-label {
  background: var(--accent-gradient);
  -webkit-background-clip: text;
  -webkit-text-fill-color: transparent;
}
\`\`\`

That's a gradient-clipped-to-text trick — works as long as the design keeps the transparent fill in place.

Three designs (**brutalist**, **risograph**, **zine**) flip the label to a solid inverted-block treatment:

\`\`\`css
html[data-design='brutalist'] .section-label {
  background: var(--br-ink);   /* solid dark block */
  color: var(--bg-primary);    /* light text */
}
\`\`\`

But they only override \`background\` and \`color\` — \`-webkit-text-fill-color: transparent\` cascades through unchanged, so the text is rendered with transparent fill on top of the dark block. Net effect: visible pill, invisible label.

## Fix

In each of the three designs that use the inverted-block treatment, also reset:

\`\`\`css
-webkit-text-fill-color: currentColor;
-webkit-background-clip: border-box;
background-clip: border-box;
\`\`\`

Other designs that override \`.section-label\` (editorial, swiss, terminal, cyber, notebook, blueprint, academic, ide, deco, wabisabi, comic) only touch \`color:\` or \`font-*\` — they keep the gradient-clip trick and don't need the reset.

## Test plan

- [x] \`npm run check\` / \`npm run format:check\` — clean
- [ ] Switch to brutalist / risograph / zine in the theme picker, verify "EXPERIENCE", "ABOUT", "PROJECTS" etc. are all visible
- [ ] Visual regression: the next \`Refresh visual baselines\` workflow run on these themes will pick up the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)