### PR TITLE
chore: add pre-push hook blocking direct main/master pushes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Block direct pushes to protected branches (main/master).
+# Bypass with `git push --no-verify` only when you know what you're doing.
+
+set -euo pipefail
+
+protected='^(main|master)$'
+remote="${1:-}"
+zero='0000000000000000000000000000000000000000'
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    branch="${remote_ref##refs/heads/}"
+
+    if [[ "$branch" =~ $protected ]]; then
+        # Allow branch deletion (local_sha = zero) — not a content push.
+        [[ "$local_sha" == "$zero" ]] && continue
+
+        printf '\033[31mBLOCKED:\033[0m direct push to \033[33m%s\033[0m on remote \033[33m%s\033[0m.\n' "$branch" "$remote" >&2
+        printf '\nThis branch is protected. Use a feature branch + pull request.\n\n' >&2
+        printf 'To recover a commit made directly on %s:\n' "$branch" >&2
+        printf '  git branch rescue/<short-name> HEAD\n' >&2
+        printf '  git reset --hard origin/%s\n' "$branch" >&2
+        printf '  git switch rescue/<short-name>\n' >&2
+        printf '  git push -u origin rescue/<short-name>\n' >&2
+        printf '  gh pr create --fill\n\n' >&2
+        printf 'Override (last resort): git push --no-verify\n' >&2
+        exit 1
+    fi
+done
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# PersonalPortfolio
+
+Astro 5 + React 19 portfolio with 20 interactive demos, EN/ES/CA i18n, Sentry observability, and sharded a11y CI. See [README.md](README.md) for stack details and `make` targets.
+
+## Architecture
+
+Static site built by Astro; React islands hydrated per-demo. Identity/metadata in [src/data/](src/data/) (JSON); all translatable copy in [locales/](locales/) under per-locale namespaces. Themes ([src/lib/themes.ts](src/lib/themes.ts)) and designs ([src/lib/designs.ts](src/lib/designs.ts)) are independent axes restored before first paint by `ThemeInit.astro`.
+
+Before non-trivial work, read the matching guide:
+
+- Content/data edits → [docs/guides/everyday-tasks.md](docs/guides/everyday-tasks.md)
+- New demo, React island, or live embed → [docs/guides/adding-a-demo.md](docs/guides/adding-a-demo.md)
+- Translations, Crowdin, locale JSON → [docs/guides/i18n.md](docs/guides/i18n.md)
+- Choosing validation commands → [docs/guides/testing.md](docs/guides/testing.md)
+- Cross-cutting/architectural → [docs/architecture/overview.md](docs/architecture/overview.md)
+
+If a guide conflicts with this file, follow the guide and update the stale rule here.
+
+## Build and Test
+
+`make dev` (Astro only), `make dev-bare` (all demo backends + Astro), `make build`, `make test` (full suite). Focused: `npm run test` (Vitest), `npm run test:e2e:smoke`, `npm run lint`, `npm run check`. Playwright projects (`browser-demos`, `live-demos`, `themes`) are independent — pick one rather than running all.
+
+## Conventions
+
+- **Adding a certification** — touch all four or parity tests fail: append object to [src/data/certifications.json](src/data/certifications.json); if a new `issuerIcon` slug, add to `ISSUER_ICON_PATHS` in [src/lib/issuer-icons.ts](src/lib/issuer-icons.ts); append a positional key (next integer = array length − 1) with `{ "issued": "<Mon YYYY>" }` to `locales/{en,es,ca}/certifications.json` (Catalan months: `Gen Feb Març Abr Maig Jun Jul Ago Set Oct Nov Des`); verify with `npx vitest run content-parity data-integrity`.
+- **i18n** — no inline `TRANSLATIONS` objects, hardcoded English, alt text, ARIA labels, or mock-banner copy in `.astro`/`.tsx`. Place strings in `locales/{locale}/ui.json` (shared), `demos.json` (card/header), `<slug>-demo.json` (island), or `designs.json`. Locale namespaces must keep identical keys/order (enforced by `content-parity.test.ts`, `data-integrity.test.ts`, `designs.test.ts`).
+- **Theming in demos** — never hardcode hex colors. CSS/HTML/JSX styles use `var(--accent-start)`, `var(--bg-card)`, `var(--text-primary)`, etc.; semi-transparent accents use `color-mix(in srgb, var(--accent-start) 15%, transparent)`. For `<canvas>` `fillStyle`/`strokeStyle` and D3 `.attr('fill', …)`, CSS vars don't resolve — import `getThemeColors()` from [src/lib/demo-theme.ts](src/lib/demo-theme.ts). Designs with custom tokens (`--comic-ink`, `--deco-gold`, …) require light-theme override blocks covering `light`, `nord-light`, `solarized-light`, `sepia`, `paper`.
+- **React islands** — receive `lang` as a prop; do not read it from URL or context. Prefer `client:visible`; reserve `client:load` for above-the-fold interactivity. Split heavy subtabs with `React.lazy` + `<Suspense>`.
+- **Asset paths** — always BASE_URL-aware: `const base = import.meta.env.BASE_URL === '/' ? '' : import.meta.env.BASE_URL;` then `base + '/asset.png'`. Use `existsSync()` for optional assets (profile image, CV).
+- **Accessibility & motion** — semantic landmarks, `aria-expanded`/`aria-controls`/`aria-current`, `role="status" aria-live="polite"` for dynamic feedback, `aria-hidden="true"` for decorative SVGs. Wrap animations in `@media (prefers-reduced-motion: reduce)` and use `--transition-fast/base/slow` instead of literal ms.
+
+## Pitfalls
+
+- **Astro ViewTransitions** — `DOMContentLoaded` does not fire on client-side navigation. Bind init logic to **both** `DOMContentLoaded` and `astro:page-load`, or use `<script is:inline>` when you need to bypass the bundler.
+- **`data-astro-reload`** — required on links that change language, switch demos, or return from a demo to the portfolio; otherwise transitions break layout/lang context.
+- **Live demo specs** — guard with `test.skip(!response.ok(), 'Backend unreachable')` so missing Docker backends don't fail CI.
+- **`.cursorrules` stays** — Cursor reads it. Do not delete or rename; mirror substantive changes here.
+
+## Git hooks
+
+`main` is protected on GitHub. A tracked `pre-push` hook in `.githooks/` blocks accidental direct pushes to `main`/`master`. Activate it once per clone:
+
+```powershell
+make hooks
+```
+
+Override in an emergency with `git push --no-verify`.
+
+See [README.md](README.md) for full setup and usage.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(OS),Windows_NT)
   .SHELLFLAGS := -c
 endif
 
-.PHONY: install dev dev-bare all all-stop log-relay build build-images preview stop restart health \
+.PHONY: install hooks dev dev-bare all all-stop log-relay build build-images preview stop restart health \
        rebuild free-ports check-registry \
        obs-install obs-up obs-down obs-restart obs-status obs-logs obs-wipe \
        mlops-up mlops-down \
@@ -32,6 +32,10 @@ else
 	@$(CARGO_ENV) \
 	command -v cargo >/dev/null 2>&1 || { echo "Installing Rust..."; curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; }
 endif
+
+hooks: ## Enable tracked git hooks (pre-push guard against direct main/master pushes)
+	git config core.hooksPath .githooks
+	@echo "Git hooks enabled from .githooks/ (pre-push blocks direct main/master pushes)."
 
 ##@ Dev
 


### PR DESCRIPTION
Adds a tracked Git pre-push hook that blocks direct pushes to `main`/`master` and prints recovery steps. Matches the protection already configured on this repo on GitHub, and complements the existing lefthook `no-commit-on-main` (which blocks at commit time; this blocks at push time, including amended commits and bypassed lefthook runs).

## What
- `.githooks/pre-push` — bash hook; allows branch deletion + feature-branch pushes, blocks `main`/`master`.
- `Makefile` — adds a `hooks` target to `##@ Setup` (and registers it in `.PHONY`).
- `AGENTS.md` — adds a short "Git hooks" section; this PR also creates `AGENTS.md` on `main` for the first time (it was previously only on a feature branch).

## Activate (per clone)
```
make hooks
```

## Override (emergencies only)
```
git push --no-verify
```

## Why
Caught a direct-to-`main` commit in `cv` last week; this prevents the same class of mistake on every repo where `main` is GitHub-protected.