### PR TITLE
feat(about): configurable CV download with 4 section checkboxes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,11 +37,27 @@ jobs:
       - name: Fetch latest CV PDFs from cuberhaus/cv
         run: |
           set -e
-          mkdir -p public
+          mkdir -p public public/cv
           BASE="https://github.com/cuberhaus/cv/releases/latest/download"
+
+          # Back-compat aliases consumed by About.astro's server-side fallback
+          # (existsSync(public/cv*.pdf)). The cv repo publishes cv_<lang>.pdf
+          # as an alias for cv_<lang>_0111.pdf (canonical CV, no certifications).
           curl -fL -o public/cv.pdf    "$BASE/cv_english.pdf"
           curl -fL -o public/cv_es.pdf "$BASE/cv_spanish.pdf"
           curl -fL -o public/cv_ca.pdf "$BASE/cv_catalan.pdf"
+
+          # 48 variant PDFs for the CvDownloader checkbox UI. Filename
+          # convention: cv_<lang>_<cepsbits>.pdf where each bit toggles
+          # certifications / extracurricular / projects / skills (left to
+          # right). summary / education / experience are always included.
+          for lang in english spanish catalan; do
+            for c in 0 1; do for e in 0 1; do for p in 0 1; do for s in 0 1; do
+              toggles="${c}${e}${p}${s}"
+              curl -fL -o "public/cv/cv_${lang}_${toggles}.pdf" \
+                "$BASE/cv_${lang}_${toggles}.pdf"
+            done; done; done; done
+          done
 
       - name: Build site
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage/
 public/cv.pdf
 public/cv_es.pdf
 public/cv_ca.pdf
+public/cv/
 
 # OG images regenerated on every deploy by scripts/capture-og-images.mjs
 public/og-image.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,5 +47,7 @@ Installable skills live under `.agents/skills/` (gitignored; restore with `make 
 - **`data-astro-reload`** — required on links that change language, switch demos, or return from a demo to the portfolio; otherwise transitions break layout/lang context.
 - **Live demo specs** — guard with `test.skip(!response.ok(), 'Backend unreachable')` so missing Docker backends don't fail CI.
 - **`.cursorrules` stays** — Cursor reads it. Do not delete or rename; mirror substantive changes here.
+- **CV download has two modes** — `About.astro` uses [`CvDownloader.tsx`](src/components/CvDownloader.tsx) (4 section checkboxes) when `public/cv/cv_english_0111.pdf` exists (i.e. `deploy.yml` has fetched the 48 variants from cuberhaus/cv). Falls back to a single legacy download button when only `public/cv.pdf` / `cv_es.pdf` / `cv_ca.pdf` are present (local dev). To exercise the variant UI locally, create a stub `public/cv/cv_english_0111.pdf` and run `npm run dev`.
+- **CV variant filename contract** — `cv_<lang>_<cepsbits>.pdf` where each bit toggles certifications / extracurricular / projects / skills (left to right). The cuberhaus/cv repo owns this naming; any change to the toggle set must be coordinated in lockstep across both repos (cv's `.tex` files + matrix + this repo's `CvDownloader.tsx` + i18n keys + `deploy.yml` fetch loop).
 
 See [README.md](README.md) for full setup and usage.

--- a/locales/ca/ui.json
+++ b/locales/ca/ui.json
@@ -1,6 +1,13 @@
 {
   "about": {
     "cv": "Descarregar CV",
+    "cvDownload": "Descarregar",
+    "cvSectionsTitle": "Personalitza les seccions",
+    "cvSectionsHint": "Tria quines seccions incloure. Resum, formació i experiència sempre s'inclouen.",
+    "cvSectionSkills": "Habilitats",
+    "cvSectionProjects": "Projectes destacats",
+    "cvSectionExtracurricular": "Activitats extracurriculars",
+    "cvSectionCertifications": "Certificacions",
     "label": "Sobre mi",
     "p1": "Hola! Soc el Pol, Enginyer Informàtic de Barcelona. Em vaig graduar a la Facultat d'Informàtica de Barcelona (FIB) de la UPC i ara treballo com a Consultor d'IA i Dades a Deloitte, on passo la major part dels dies a la intersecció de la IA, les plataformes de dades i la realitat una mica caòtica de fer-les útils.",
     "p2": "El que realment gaudeixo és construir: explorar eines noves, entendre com encaixen entre si i ajudar el meu equip a tirar endavant coses de les quals estiguem orgullosos. M'importa més resoldre el problema que fer servir l'stack més de moda, tot i que m'alegra quan les dues coses coincideixen.",

--- a/locales/en/ui.json
+++ b/locales/en/ui.json
@@ -1,6 +1,13 @@
 {
   "about": {
     "cv": "Download CV",
+    "cvDownload": "Download",
+    "cvSectionsTitle": "Customise sections",
+    "cvSectionsHint": "Pick which sections to include. Summary, education and experience are always included.",
+    "cvSectionSkills": "Skills",
+    "cvSectionProjects": "Selected projects",
+    "cvSectionExtracurricular": "Extracurricular activity",
+    "cvSectionCertifications": "Certifications",
     "label": "About",
     "p1": "Hi! I'm Pol — a Computer Science Engineer from Barcelona. I graduated from UPC's Facultat d'Informàtica de Barcelona (FIB) and now work as an AI & Data Consultant at Deloitte, where most of my days are spent at the intersection of AI, data platforms, and the messy reality of making them useful.",
     "p2": "What I actually enjoy is building stuff — exploring new tools, figuring out how they fit together, and helping my team ship things we're proud of. I care more about solving the problem than about picking the trendiest stack, though I'm happy when both line up.",

--- a/locales/es/ui.json
+++ b/locales/es/ui.json
@@ -1,6 +1,13 @@
 {
   "about": {
     "cv": "Descargar CV",
+    "cvDownload": "Descargar",
+    "cvSectionsTitle": "Personaliza las secciones",
+    "cvSectionsHint": "Elige qué secciones incluir. Resumen, formación y experiencia siempre se incluyen.",
+    "cvSectionSkills": "Habilidades",
+    "cvSectionProjects": "Proyectos seleccionados",
+    "cvSectionExtracurricular": "Actividades extracurriculares",
+    "cvSectionCertifications": "Certificaciones",
     "label": "Sobre mí",
     "p1": "¡Hola! Soy Pol, Ingeniero Informático de Barcelona. Me gradué en la Facultat d'Informàtica de Barcelona (FIB) de la UPC y ahora trabajo como Consultor de IA y Datos en Deloitte, donde paso la mayor parte de los días en la intersección de la IA, las plataformas de datos y la realidad algo caótica de hacerlas útiles.",
     "p2": "Lo que realmente disfruto es construir: explorar herramientas nuevas, entender cómo encajan entre sí y ayudar a mi equipo a sacar adelante cosas de las que estemos orgullosos. Me importa más resolver el problema que usar el stack más de moda, aunque me alegra cuando ambas cosas coinciden.",

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getLangFromUrl, useTranslations } from '../i18n/utils';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../config/locales';
+import CvDownloader from './CvDownloader';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -32,8 +33,23 @@ const cvHash = cvFile
 // We calculate the path dynamically so it evaluates correctly at build time
 const hasProfileImage = existsSync(resolve('./public/profile.jpg'));
 const hasCV = cvFile !== null;
+// True when the 48 toggle variants are present (fetched in deploy.yml's
+// build-time step). Sentinel check on the canonical 0111 English variant
+// keeps the cost to one fs lookup. When false (e.g. local dev without a
+// prefetched public/cv/ folder), fall back to the single legacy button.
+const hasCvVariants = existsSync(resolve(`./public/cv/cv_english_0111.pdf`));
 const base = import.meta.env.BASE_URL === '/' ? '' : import.meta.env.BASE_URL;
 const cvHref = cvFile ? `${base}/${cvFile}?v=${cvHash}` : '#';
+
+const cvLabels = {
+  sectionsTitle: t('about.cvSectionsTitle'),
+  sectionsHint: t('about.cvSectionsHint'),
+  skills: t('about.cvSectionSkills'),
+  projects: t('about.cvSectionProjects'),
+  extracurricular: t('about.cvSectionExtracurricular'),
+  certifications: t('about.cvSectionCertifications'),
+  download: t('about.cvDownload'),
+};
 
 const { num } = Astro.props;
 ---
@@ -60,7 +76,11 @@ const { num } = Astro.props;
         </ul>
 
         {
-          hasCV && (
+          hasCvVariants ? (
+            <div class="about-actions">
+              <CvDownloader lang={lang} labels={cvLabels} client:visible />
+            </div>
+          ) : hasCV ? (
             <div class="about-actions">
               <a href={cvHref} class="about-cv-btn" target="_blank" rel="noopener noreferrer">
                 <svg
@@ -80,7 +100,7 @@ const { num } = Astro.props;
                 {t('about.cv')}
               </a>
             </div>
-          )
+          ) : null
         }
       </div>
 

--- a/src/components/CvDownloader.tsx
+++ b/src/components/CvDownloader.tsx
@@ -1,0 +1,201 @@
+// CV download with section toggles.
+//
+// Renders 4 checkboxes (skills, projects, extracurricular, certifications)
+// and a download button. The button's href is computed live from the toggle
+// state and points at one of the 48 pre-built variants in public/cv/
+// (cv_<lang>_<cepsbits>.pdf, where each bit toggles certifications /
+// extracurricular / projects / skills, left-to-right). summary, education
+// and experience are always-on (not toggleable; baked into every variant).
+//
+// Variants are fetched in .github/workflows/deploy.yml from the
+// cuberhaus/cv release. See cv repo AGENTS.md for the build mechanism.
+//
+// Default toggles ('0111' = skills+projects+extracurricular, no
+// certifications) match the canonical CV behaviour pre-toggle.
+import { useId, useState } from 'react';
+
+type Lang = 'en' | 'es' | 'ca';
+
+interface Props {
+  lang: Lang;
+  labels: {
+    sectionsTitle: string;
+    sectionsHint: string;
+    skills: string;
+    projects: string;
+    extracurricular: string;
+    certifications: string;
+    download: string;
+  };
+}
+
+// Portfolio locale code -> cv repo filename slug. The cv repo uses full
+// language names; the portfolio uses ISO-639-1 short codes. Keep this
+// mapping aligned with .github/workflows/deploy.yml's fetch loop.
+const CV_LANG_BY_LOCALE: Record<Lang, string> = {
+  en: 'english',
+  es: 'spanish',
+  ca: 'catalan',
+};
+
+const basePath =
+  typeof import.meta !== 'undefined' && import.meta.env?.BASE_URL != null
+    ? import.meta.env.BASE_URL
+    : '/';
+
+// Strip trailing slash so we can interpolate without doubling: `${basePath}/x`
+// becomes `/x` when basePath is '/' and `/portfolio/x` when basePath is
+// `/portfolio/`.
+const baseStem = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+
+export default function CvDownloader({ lang, labels }: Props) {
+  const [skills, setSkills] = useState(true);
+  const [projects, setProjects] = useState(true);
+  const [extracurricular, setExtracurricular] = useState(true);
+  const [certifications, setCertifications] = useState(false);
+
+  const cvLang = CV_LANG_BY_LOCALE[lang];
+  // Bit order: c, e, p, s (matches cv repo's filename convention).
+  const toggles =
+    (certifications ? '1' : '0') +
+    (extracurricular ? '1' : '0') +
+    (projects ? '1' : '0') +
+    (skills ? '1' : '0');
+  const href = `${baseStem}/cv/cv_${cvLang}_${toggles}.pdf`;
+
+  const formId = useId();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        padding: '1rem',
+        border: '1px solid var(--border, rgba(127,127,127,0.3))',
+        borderRadius: '0.5rem',
+        background: 'var(--surface, transparent)',
+        maxWidth: '28rem',
+      }}
+    >
+      <div>
+        <strong style={{ display: 'block', marginBottom: '0.25rem' }}>
+          {labels.sectionsTitle}
+        </strong>
+        <small style={{ opacity: 0.75 }}>{labels.sectionsHint}</small>
+      </div>
+
+      <fieldset
+        style={{
+          border: 'none',
+          padding: 0,
+          margin: 0,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+          gap: '0.4rem 1rem',
+        }}
+      >
+        <legend className="sr-only">{labels.sectionsTitle}</legend>
+        <Toggle
+          id={`${formId}-skills`}
+          label={labels.skills}
+          checked={skills}
+          onChange={setSkills}
+        />
+        <Toggle
+          id={`${formId}-projects`}
+          label={labels.projects}
+          checked={projects}
+          onChange={setProjects}
+        />
+        <Toggle
+          id={`${formId}-extracurricular`}
+          label={labels.extracurricular}
+          checked={extracurricular}
+          onChange={setExtracurricular}
+        />
+        <Toggle
+          id={`${formId}-certifications`}
+          label={labels.certifications}
+          checked={certifications}
+          onChange={setCertifications}
+        />
+      </fieldset>
+
+      <a
+        href={href}
+        download={`cv_${cvLang}_${toggles}.pdf`}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.6rem 1rem',
+          background: `linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), linear-gradient(135deg, var(--accent-start), var(--accent-end))`,
+          color: '#fff',
+          border: 'none',
+          borderRadius: '0.375rem',
+          fontWeight: 600,
+          textDecoration: 'none',
+          cursor: 'pointer',
+          alignSelf: 'flex-start',
+        }}
+      >
+        <DownloadIcon />
+        {labels.download}
+      </a>
+    </div>
+  );
+}
+
+interface ToggleProps {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function Toggle({ id, label, checked, onChange }: ToggleProps) {
+  return (
+    <label
+      htmlFor={id}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        cursor: 'pointer',
+        userSelect: 'none',
+      }}
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ cursor: 'pointer' }}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Replaces the single `Download CV` button in [`About.astro`](src/components/About.astro) with a React island that exposes 4 toggleable sections and computes the download URL live against one of 48 pre-built variants.

Depends on [cuberhaus/cv#17](https://github.com/cuberhaus/cv/pull/17) (merged; release `latest` already publishes the 51 PDFs).

## What changes

| Surface | Change |
|---|---|
| [`deploy.yml`](.github/workflows/deploy.yml) | Adds a 48-iteration fetch loop pulling `cv_<lang>_<cepsbits>.pdf` from the `latest` cv release into `public/cv/`. Keeps the legacy `cv.pdf` / `cv_es.pdf` / `cv_ca.pdf` aliases for the server-rendered fallback path. |
| [`CvDownloader.tsx`](src/components/CvDownloader.tsx) (new) | React island. 4 `useState` checkboxes + computed `<a href>`. Defaults: skills + projects + extracurricular ON, certifications OFF (matches the canonical `0111` cv build). |
| [`About.astro`](src/components/About.astro) | Server-side sentinel check (`existsSync(./public/cv/cv_english_0111.pdf)`) picks `CvDownloader` when the variants are present, falls back to the single `<a>` button when not (local dev). |
| `locales/{en,es,ca}/ui.json` | 7 new strings under `about.` (cvDownload + cvSectionsTitle + cvSectionsHint + 4 section labels). |
| [`AGENTS.md`](AGENTS.md) | Documents the two-mode rendering, the filename contract, and the cross-repo lockstep requirement. |
| [`.gitignore`](.gitignore) | Adds `public/cv/` (gitignored like the other CV PDFs). |

## Filename contract

`cv_<lang>_<cepsbits>.pdf` where each bit toggles **c**ertifications / **e**xtracurricular / **p**rojects / **s**kills (left-to-right). `<lang>` is the cv repo's filename slug (`english` / `spanish` / `catalan`), not the portfolio locale code. The CvDownloader maps `en|es|ca` -> `english|spanish|catalan` via `CV_LANG_BY_LOCALE`.

This is the same contract enforced by cuberhaus/cv's build matrix; any change to the toggle set requires a coordinated update across BOTH repos.

## Defaults match canonical behaviour

Initial checkbox state matches the canonical CV (`0111` = skills + projects + extracurricular, no certifications). A user who clicks Download without touching the checkboxes gets the same PDF they would have downloaded before this PR. Adding certifications, or removing any of the three defaulted-on sections, swaps the URL to one of the 47 other variants.

## Backwards compatibility

- Legacy `cv.pdf` / `cv_es.pdf` / `cv_ca.pdf` still fetched, hashed, and used by `About.astro`'s fallback path (when `public/cv/` is missing).
- No URL or route changes. Visible at `/`, `/es/`, `/ca/`.
- Local dev without `public/cv/` shows the original single button.

## Verification

- `npm run build` -> 65 pages built, 14s (verified with a stub variant PDF in `public/cv/`).
- `npm run lint` -> 0 new warnings introduced (149 pre-existing, none in touched files).
- `npm test` -> 1264 tests pass (41 files).
- Lefthook `no-commit-on-main` + prettier + eslint pre-commit hooks all green.