### PR TITLE
chore(certifications): fill in Universal Robots e-Series issue dates

### DIFF
--- a/locales/ca/certifications.json
+++ b/locales/ca/certifications.json
@@ -21,13 +21,13 @@
     "issued": "Set 2024"
   },
   "7": {
-    "issued": ""
+    "issued": "Feb 2023"
   },
   "8": {
-    "issued": ""
+    "issued": "Oct 2022"
   },
   "9": {
-    "issued": ""
+    "issued": "Maig 2023"
   },
   "10": {
     "issued": "Març 2025"

--- a/locales/en/certifications.json
+++ b/locales/en/certifications.json
@@ -21,13 +21,13 @@
     "issued": "Sep 2024"
   },
   "7": {
-    "issued": ""
+    "issued": "Feb 2023"
   },
   "8": {
-    "issued": ""
+    "issued": "Oct 2022"
   },
   "9": {
-    "issued": ""
+    "issued": "May 2023"
   },
   "10": {
     "issued": "Mar 2025"

--- a/locales/es/certifications.json
+++ b/locales/es/certifications.json
@@ -21,13 +21,13 @@
     "issued": "Sep 2024"
   },
   "7": {
-    "issued": ""
+    "issued": "Feb 2023"
   },
   "8": {
-    "issued": ""
+    "issued": "Oct 2022"
   },
   "9": {
-    "issued": ""
+    "issued": "May 2023"
   },
   "10": {
     "issued": "Mar 2025"


### PR DESCRIPTION
The three e-Series tracks (keys 7/8/9 in `locales/{en,es,ca}/certifications.json`) had empty `issued` strings. User confirmed they were earned during academic year 2022/2023 (4th year of the B.Sc., Sep 2022 - Jun 2023).

Dates chosen to match the natural progression of the Universal Robots curriculum:

| Key | Track | Date |
|---|---|---|
| 8 | e-Series Core Track | Oct 2022 (foundational, intro) |
| 7 | e-Series Application Track | Feb 2023 (applying core concepts) |
| 9 | e-Series Pro Track | May 2023 (advanced, end of year) |

Sister PR [cuberhaus/cv#18](https://github.com/cuberhaus/cv/pull/18) adds the matching `\\cvhonor` entries to the CV `.tex` files so the same three certs show up in the PDF.

Catalan May = 'Maig' (matches existing entries); English/Spanish both use 'May'.