### PR TITLE
chore: add GitHub Sponsors + Buy Me a Coffee funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: cuberhaus
+custom: ['https://buymeacoffee.com/cuberhaus']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,4 @@
+# These are supported funding model platforms
+
 github: cuberhaus
-custom: ['https://buymeacoffee.com/cuberhaus']
+buy_me_a_coffee: cuberhaus


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the GitHub repo page shows a Sponsor button linking to GitHub Sponsors (`cuberhaus`) and Buy Me a Coffee (`cuberhaus`).