### PR TITLE
fix(deps): clear high-severity audit (hono, vite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8905,9 +8905,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -14679,7 +14679,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,9 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.61.0",
     "vitest": "4.1.8"
+  },
+  "overrides": {
+    "hono": "^4.12.26",
+    "vite": "^7.3.5"
   }
 }


### PR DESCRIPTION
## What

Resolves the two **high-severity** production advisories that were failing the `Lint, format, type-check, audit` CI job (`npm audit --omit=dev --audit-level=high`):

- **hono** (transitive via `@spotlightjs/astro`) -> `^4.12.26` (path traversal, CORS, body-limit bypass advisories)
- **vite** (transitive via `astro` / `@astrojs/react`) -> `^7.3.5` (`server.fs.deny` bypass)

Applied via a minimal `overrides` block rather than `npm audit fix` to avoid churning 180+ packages.

## Verification (local)

- `npm run audit:ci` -> exit 0
- `npm run check` -> 0 errors
- `npm run lint` -> 0 errors
- `npm test` -> 1264 passed