### PR TITLE
fix(ci): build site before capturing visual baselines

### DIFF
--- a/.github/workflows/visual-baselines.yml
+++ b/.github/workflows/visual-baselines.yml
@@ -46,6 +46,9 @@ jobs:
             npx playwright install --with-deps chromium chromium-headless-shell
           fi
 
+      - name: Build site
+        run: npm run build
+
       - name: Capture baselines (--update-snapshots)
         run: npx playwright test --project=visual --update-snapshots
 


### PR DESCRIPTION
## Problem

The `Refresh visual baselines` workflow failed at **Capture baselines** with:

```nError: Timed out waiting 240000ms from config.webServer.
```n
## Cause

In CI, Playwright's `webServer` runs `npm run preview:static` (serves the prebuilt `dist/`) — it does **not** build. The capture job went straight from installing browsers to `playwright test --update-snapshots` with no `npm run build`, so `dist/` never existed, the preview server served nothing, and Playwright timed out after 240s.

## Fix

Add a `Build site` step (`npm run build`) before the capture step, mirroring the working `playwright` jobs in `test.yml`.

## Validation

- `actionlint` clean.
- Matches the build+preview pattern already proven green by `test.yml`'s playwright jobs.
- Workflow is `workflow_dispatch`-only, so it won't run on this PR — trigger it manually from the Actions tab after merge.