### PR TITLE
fix(sentry): tolerate RuntimeError when resetting session-id contextvar

### DIFF
--- a/planner-api/app/_sentry_obs.py
+++ b/planner-api/app/_sentry_obs.py
@@ -454,8 +454,11 @@ def _bind_session_id(value: str | None) -> Any:
 def _reset_session_id(token: Any) -> None:
     try:
         _SESSION_ID.reset(token)
-    except (LookupError, ValueError):
-        # Token from a different context — safe to ignore.
+    except (LookupError, ValueError, RuntimeError):
+        # Token from a different context, or already reset once — safe to
+        # ignore. Flask's test client can replay teardown for a request
+        # whose token was already reset, which raises RuntimeError
+        # ("<Token> has already been used once").
         pass
 
 

--- a/scripts/sentry-snippets/_sentry_obs.py
+++ b/scripts/sentry-snippets/_sentry_obs.py
@@ -454,8 +454,11 @@ def _bind_session_id(value: str | None) -> Any:
 def _reset_session_id(token: Any) -> None:
     try:
         _SESSION_ID.reset(token)
-    except (LookupError, ValueError):
-        # Token from a different context — safe to ignore.
+    except (LookupError, ValueError, RuntimeError):
+        # Token from a different context, or already reset once — safe to
+        # ignore. Flask's test client can replay teardown for a request
+        # whose token was already reset, which raises RuntimeError
+        # ("<Token> has already been used once").
         pass
 
 


### PR DESCRIPTION
## What

`_reset_session_id` in the canonical `_sentry_obs.py` only caught `(LookupError, ValueError)`. Flask's test client replays `teardown_request` for a request whose session-id `Token` was already reset, so `_SESSION_ID.reset(token)` raises `RuntimeError: <Token> has already been used once` and fails the request/test.

## Fix

Widen the `except` to also catch `RuntimeError` (already-reset / cross-context tokens are safe to ignore).

## Scope

- Canonical source: `scripts/sentry-snippets/_sentry_obs.py`
- In-repo copy: `planner-api/app/_sentry_obs.py`
- Propagated verbatim to the 8 sibling backend copies (projectA already patched; TFG, projectA2, CAIM, SBC_IA, desastresIA, bitsXlaMarato, Draculin-Backend updated in their own repos).

Only Flask backends hit the bug at runtime; FastAPI/ASGI copies reset once in `finally`. This keeps every copy byte-identical to canonical so the fix does not drift back on the next resync.