### PR TITLE
feat(quizzes): host hidden NVIDIA cert practice quizzes

### DIFF
--- a/public/nca-genm/index.html
+++ b/public/nca-genm/index.html
@@ -142,7 +142,25 @@
     border-bottom: 1px solid var(--border);
     font-weight: bold;
     z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    flex-wrap: wrap;
   }
+  #scoreText .ok { color: var(--reveal); }
+  #scoreText .ko { color: var(--wrong-border); }
+  #reviewWrong {
+    font-size: .85rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  #reviewWrong.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  #reviewWrong:disabled { opacity: .5; cursor: default; }
   .multi-tag {
     font-size: .75rem;
     background: var(--multi-bg);
@@ -192,6 +210,26 @@
     align-items: center;
     gap: .35rem;
   }
+  .explanation {
+    margin-top: .85rem;
+    padding: .7rem .95rem;
+    border-left: 3px solid var(--accent);
+    background: var(--hover);
+    border-radius: 6px;
+    font-size: .9rem;
+    color: var(--fg);
+    white-space: pre-wrap;
+  }
+  .explanation[hidden] { display: none; }
+  .explanation .exp-label {
+    display: block;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: .3rem;
+    text-transform: uppercase;
+    font-size: .7rem;
+    letter-spacing: .05em;
+  }
 </style>
 </head>
 <body>
@@ -216,7 +254,10 @@
 <button class="tab" data-set="Set 6">Set 6</button>
 <button class="tab" data-set="Set 7">Set 7</button>
 </div>
-<div id="score">Score: 0 / 0 answered</div>
+<div id="score">
+  <span id="scoreText">Score: 0 / 0 answered</span>
+  <button id="reviewWrong" type="button" disabled>Review wrong (0)</button>
+</div>
 <div id="quiz"></div>
 <div class="actions" style="margin: 2rem 0;">
   <button id="checkAll" class="primary">Check all</button>
@@ -5810,8 +5851,9 @@ const QUESTIONS = [
 const SETS = ["Set 1", "Set 2", "Set 3", "Set 4", "Set 5", "Set 6", "Set 7"];
 
 const quiz = document.getElementById('quiz');
-const scoreEl = document.getElementById('score');
+const scoreEl = document.getElementById('scoreText');
 let activeSet = 'all';  // 'all' or a set name like 'set1'
+let reviewWrong = false;  // when true, show only answered-incorrectly questions
 
 function letter(i) { return String.fromCharCode(65 + i); }
 
@@ -5828,6 +5870,10 @@ function renderQuestion(q, qi) {
   const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
   const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
   const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  const expHtml = q.e
+    ? `<div class="explanation" id="exp${qi}" hidden><span class="exp-label">Explanation</span>${escapeHtml(q.e)}</div>`
+    : '';
+  const expBtn = q.e ? `<button data-explain="${qi}">Explanation</button>` : '';
   return `
     <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
       <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
@@ -5835,7 +5881,9 @@ function renderQuestion(q, qi) {
       <div class="actions">
         <button data-check="${qi}">Check</button>
         <button data-reset="${qi}">Reset</button>
+        ${expBtn}
       </div>
+      ${expHtml}
     </div>`;
 }
 
@@ -5859,6 +5907,8 @@ function checkQuestion(qi) {
       label.classList.add('reveal-correct');
     }
   });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = false;
   updateScore();
 }
 
@@ -5867,6 +5917,8 @@ function resetQuestion(qi) {
     label.classList.remove('correct', 'wrong', 'reveal-correct');
     label.querySelector('input').checked = false;
   });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = true;
   updateScore();
 }
 
@@ -5874,30 +5926,52 @@ function inActiveSet(q) {
   return activeSet === 'all' || q.set === activeSet;
 }
 
+function pickedFor(qi) {
+  return [...document.querySelectorAll(`#q${qi} input`)]
+    .filter(i => i.checked).map(i => +i.value);
+}
+
+function isExact(qi, picked) {
+  const expected = new Set(QUESTIONS[qi].c);
+  return picked.length === expected.size && picked.every(p => expected.has(p));
+}
+
+// A question counts as "wrong" once it has a selection that is not an exact match.
+function isWrongAnswered(qi) {
+  const picked = pickedFor(qi);
+  return picked.length > 0 && !isExact(qi, picked);
+}
+
 function updateScore() {
   let answered = 0, correct = 0, total = 0;
   QUESTIONS.forEach((q, qi) => {
     if (!inActiveSet(q)) return;
     total++;
-    const inputs = document.querySelectorAll(`#q${qi} input`);
-    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    const picked = pickedFor(qi);
     if (picked.length === 0) return;
     answered++;
-    const expected = new Set(q.c);
-    const isExactMatch =
-      picked.length === expected.size &&
-      picked.every(p => expected.has(p));
-    if (isExactMatch) correct++;
+    if (isExact(qi, picked)) correct++;
   });
+  const wrong = answered - correct;
   const label = activeSet === 'all' ? 'overall' : activeSet;
-  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+  scoreEl.innerHTML =
+    `<span class="ok">${correct} correct</span> · ` +
+    `<span class="ko">${wrong} wrong</span> · ` +
+    `${answered}/${total} answered (${label})`;
+  const reviewBtn = document.getElementById('reviewWrong');
+  if (reviewBtn) {
+    reviewBtn.textContent = reviewWrong ? `Show all (${wrong} wrong)` : `Review wrong (${wrong})`;
+    reviewBtn.classList.toggle('active', reviewWrong);
+    reviewBtn.disabled = wrong === 0 && !reviewWrong;
+  }
 }
 
 function applyFilter() {
   QUESTIONS.forEach((q, qi) => {
     const el = document.getElementById(`q${qi}`);
     if (!el) return;
-    el.classList.toggle('hidden', !inActiveSet(q));
+    const visible = inActiveSet(q) && (!reviewWrong || isWrongAnswered(qi));
+    el.classList.toggle('hidden', !visible);
   });
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.set === activeSet);
@@ -5947,6 +6021,10 @@ quiz.addEventListener('click', e => {
   const t = e.target;
   if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
   else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+  else if (t.matches('[data-explain]')) {
+    const ex = document.getElementById(`exp${t.dataset.explain}`);
+    if (ex) ex.hidden = !ex.hidden;
+  }
 });
 quiz.addEventListener('change', () => { updateScore(); saveCache(); });
 
@@ -5956,7 +6034,20 @@ document.getElementById('checkAll').addEventListener('click', () => {
 });
 document.getElementById('resetAll').addEventListener('click', () => {
   QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  reviewWrong = false;
+  applyFilter();
   saveCache();
+});
+
+document.getElementById('reviewWrong').addEventListener('click', () => {
+  reviewWrong = !reviewWrong;
+  if (reviewWrong) {
+    // Reveal correct answers on the wrong questions so they can be reviewed.
+    QUESTIONS.forEach((q, qi) => { if (inActiveSet(q) && isWrongAnswered(qi)) checkQuestion(qi); });
+    saveCache();
+  }
+  applyFilter();
+  window.scrollTo({ top: 0, behavior: 'instant' });
 });
 
 document.querySelectorAll('.tab').forEach(tab => {

--- a/public/nca-genm/index.html
+++ b/public/nca-genm/index.html
@@ -1,0 +1,5999 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NCA Generative AI Multimodal Practice Quiz</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --border: #ddd;
+    --hover: rgba(0, 0, 0, 0.04);
+    --card: #fafafa;
+    --accent: #2563eb;
+    --correct-bg: #16a34a;
+    --correct-fg: #ffffff;
+    --correct-border: #15803d;
+    --wrong-bg: #dc2626;
+    --wrong-fg: #ffffff;
+    --wrong-border: #b91c1c;
+    --reveal: #16a34a;
+    --multi-bg: #2563eb;
+  }
+  html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --fg: #e7e9ee;
+    --muted: #9aa3b2;
+    --border: #2a2f3a;
+    --hover: rgba(255, 255, 255, 0.05);
+    --card: #161a21;
+    --accent: #60a5fa;
+    --correct-bg: #166534;
+    --correct-fg: #ecfdf5;
+    --correct-border: #22c55e;
+    --wrong-bg: #7f1d1d;
+    --wrong-fg: #fee2e2;
+    --wrong-border: #ef4444;
+    --reveal: #22c55e;
+    --multi-bg: #3b82f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme]) {
+      color-scheme: dark;
+      --bg: #0f1115;
+      --fg: #e7e9ee;
+      --muted: #9aa3b2;
+      --border: #2a2f3a;
+      --hover: rgba(255, 255, 255, 0.05);
+      --card: #161a21;
+      --accent: #60a5fa;
+      --correct-bg: #166534;
+      --correct-fg: #ecfdf5;
+      --correct-border: #22c55e;
+      --wrong-bg: #7f1d1d;
+      --wrong-fg: #fee2e2;
+      --wrong-border: #ef4444;
+      --reveal: #22c55e;
+      --multi-bg: #3b82f6;
+    }
+  }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    max-width: 880px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .subtitle { color: var(--muted); margin: 0 0 1rem; }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .q {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    background: var(--card);
+  }
+  .q h2 { font-size: 1rem; margin: 0 0 .75rem; }
+  .opts { list-style: none; padding: 0; margin: 0; }
+  .opts li { margin: .35rem 0; }
+  .opts label {
+    display: block;
+    padding: .5rem .75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    color: var(--fg);
+  }
+  .opts label:hover { background: var(--hover); }
+  .opts input { margin-right: .5rem; }
+  .opts label.correct {
+    background: var(--correct-bg);
+    color: var(--correct-fg);
+    border-color: var(--correct-border);
+  }
+  .opts label.wrong {
+    background: var(--wrong-bg);
+    color: var(--wrong-fg);
+    border-color: var(--wrong-border);
+  }
+  .opts label.reveal-correct { outline: 2px dashed var(--reveal); }
+  .actions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+    margin-top: .75rem;
+  }
+  button {
+    padding: .4rem .8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--fg);
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover { background: var(--hover); }
+  button.primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  button.primary:hover { filter: brightness(1.1); }
+  .note { font-size: .85rem; color: var(--muted); }
+  #score {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: .5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-weight: bold;
+    z-index: 10;
+  }
+  .multi-tag {
+    font-size: .75rem;
+    background: var(--multi-bg);
+    color: white;
+    padding: .1rem .4rem;
+    border-radius: 3px;
+    margin-left: .5rem;
+    vertical-align: middle;
+  }
+  .set-tag {
+    font-size: .7rem;
+    color: var(--muted);
+    margin-left: .5rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+  }
+  .tabs {
+    display: flex;
+    gap: .25rem;
+    flex-wrap: wrap;
+    margin: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: .5rem;
+  }
+  .tab {
+    padding: .35rem .7rem;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: .9rem;
+  }
+  .tab:hover { background: var(--hover); color: var(--fg); }
+  .tab.active {
+    background: var(--card);
+    border-color: var(--border);
+    border-bottom-color: var(--card);
+    color: var(--fg);
+    font-weight: 600;
+  }
+  .q.hidden { display: none; }
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <div>
+    <h1>NCA Generative AI Multimodal Practice Quiz</h1>
+    <p class="subtitle">All 7 practice sets (420 questions). Use the tabs to focus on one set.</p>
+  </div>
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">
+    <span id="themeIcon">🌙</span>
+    <span id="themeLabel">Dark</span>
+  </button>
+</div>
+<p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
+<div class="tabs">
+<button class="tab active" data-set="all">All</button>
+<button class="tab" data-set="Set 1">Set 1</button>
+<button class="tab" data-set="Set 2">Set 2</button>
+<button class="tab" data-set="Set 3">Set 3</button>
+<button class="tab" data-set="Set 4">Set 4</button>
+<button class="tab" data-set="Set 5">Set 5</button>
+<button class="tab" data-set="Set 6">Set 6</button>
+<button class="tab" data-set="Set 7">Set 7</button>
+</div>
+<div id="score">Score: 0 / 0 answered</div>
+<div id="quiz"></div>
+<div class="actions" style="margin: 2rem 0;">
+  <button id="checkAll" class="primary">Check all</button>
+  <button id="resetAll">Reset</button>
+</div>
+
+<script>
+const QUESTIONS = [
+  {
+    "q": "You are tasked with developing a generative AI model to generate realistic images based on textual descriptions. Your dataset contains pairs of text descriptions and corresponding images. However, the dataset is unbalanced, with some classes having significantly fewer samples than others. Which approach would most effectively address the class imbalance while maintaining the quality of generated images?",
+    "a": [
+      "Use GANs (Generative Adversarial Networks) with class conditioning to generate additional images for the minority classes",
+      "Use data augmentation techniques like rotation and flipping equally on all classes",
+      "Use oversampling on the minority classes and apply random noise augmentation to the images",
+      "Apply under-sampling on the majority classes to balance the dataset"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working on a generative AI project that requires integrating a client's legacy data systems with a new AI model for image generation. The client insists on frequent updates and involvement throughout the development process. What is the most critical initial step in ensuring smooth collaboration and alignment with the client's expectations?",
+    "a": [
+      "Starting with data gathering",
+      "Deploying a minimum viable product (MVP)",
+      "Focusing on integration strategies first",
+      "Conducting a detailed requirements acquisition session"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with creating a retrieval-augmented generation (RAG) model for an AI-powered customer support chatbot that must handle inquiries across multiple languages and product categories. The chatbot needs to quickly access relevant documentation, regardless of the language or specific product. Which approach would best optimize the system's ability to provide accurate and relevant answers across this diverse range of inputs?",
+    "a": [
+      "Fine-tune a multilingual LLM on a dataset covering all product categories and languages",
+      "Use a vector database to store multilingual embeddings of the documentation and query it with semantic search",
+      "Use separate LLMs for each language and product category, switching models based on detected language and topic",
+      "Implement a keyword-based search system with language detection for initial query processing"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are optimizing a multimodal AI model that assists in early detection of forest fires by analyzing satellite images, weather data, and social media posts. The current model is highly accurate but consumes excessive computational resources, which limits its deployment in remote monitoring stations. Which optimization strategy would best enhance energy efficiency while maintaining the model's trustworthiness and accuracy?",
+    "a": [
+      "Increase the frequency of model retraining to ensure the latest data is always included.",
+      "Apply quantization techniques to reduce the precision of calculations in the model.",
+      "Reduce the size of the dataset by focusing only on the most recent data.",
+      "Increase the complexity of the neural network to capture more detailed patterns in the data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An entertainment company wants to create a generative AI system that can produce movie trailers by analyzing multimodal data, including movie scripts (text), existing movie scenes (video), and audio tracks. The system must generate coherent and engaging trailers that effectively combine these elements. Which approach would most likely yield the best results in generating high-quality trailers?",
+    "a": [
+      "Use a clustering algorithm to group similar movie scenes and generate a trailer based on the most common cluster",
+      "Train a Recurrent Neural Network (RNN) solely on the movie scripts",
+      "Employ a multimodal Transformer that can process and integrate text, video, and audio data",
+      "Use a CNN trained on video data to generate the trailer"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "In a scenario where an AI system is designed to generate a personalized multimedia experience (text, images, and audio) from a short user input, which combination of AI techniques would most likely be required to maintain contextual coherence across different modalities?",
+    "a": [
+      "Transformer-based model for text, VAE for image generation, and a basic RNN for audio.",
+      "RNN for text analysis, CNN for image generation, and a simple linear model for audio synthesis.",
+      "Transformer-based model for text analysis, a GAN for image generation, and a WaveNet for audio synthesis.",
+      "LSTM for text processing, VAE for image generation, and a rule-based system for audio synthesis."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a multimodal AI model that needs to classify videos based on both audio and visual content. You plan to use transfer learning by fine-tuning a pre-trained model for each modality. However, the visual modality is underperforming compared to the audio modality after transfer learning. What is the best approach to address this issue?",
+    "a": [
+      "Use a different pre-trained model for the visual modality that is more suitable for video data.",
+      "Combine the visual and audio features earlier in the network architecture.",
+      "Increase the learning rate for the visual modality during fine-tuning.",
+      "Freeze the layers of the visual model and only train the audio model."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a chatbot using a multimodal Large Language Model (LLM) that integrates text and image inputs. The chatbot is designed to assist users with product troubleshooting by analyzing images of the product and understanding user queries. However, during user testing, the chatbot sometimes provides irrelevant solutions or fails to recognize the product correctly. What could be causing these issues? (Select two)",
+    "a": [
+      "The text input queries are not preprocessed consistently before being fed into the model.",
+      "The model's image classification component is not fine-tuned on the specific product dataset.",
+      "The model's text-to-image ratio during training was not balanced.",
+      "The model was trained using a smaller batch size for image data than for text data.",
+      "The chatbot's inference pipeline lacks real-time processing capabilities."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "As a junior developer on a team working on a generative AI project, you are tasked with writing part of the documentation for a module that processes and integrates multimodal data inputs. Your documentation must be clear and concise, adhering to the standards set by the senior staff. What is the most important focus area when writing the documentation for this multimodal data processing module?",
+    "a": [
+      "Describing the theoretical background of multimodal processing",
+      "Listing all possible errors and exceptions",
+      "Providing clear, step-by-step instructions for module integration",
+      "Explaining how to optimize the module for performance"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working with a multimodal generative AI model that processes both text and images to generate detailed descriptions of objects. The model consistently produces inaccurate descriptions when processing high-resolution images with complex backgrounds. Which two actions should you consider to improve the model's performance in handling high-resolution images with complex backgrounds? (Select two)",
+    "a": [
+      "Use grayscale images instead of colored images.",
+      "Increase the model's learning rate to improve accuracy during training.",
+      "Fine-tune the model using a pre-trained model specialized in object detection.",
+      "Implement data augmentation techniques to diversify the training set with various background complexities.",
+      "Reduce the image resolution before feeding it into the model."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "A healthcare organization wants to customize a pre-trained large language model (LLM) to generate patient summaries from clinical notes. The model should perform well without requiring extensive computational resources for customization. Which strategy should be employed to achieve efficient customization?",
+    "a": [
+      "Fine-tune the LLM on a large dataset of general medical literature.",
+      "Apply zero-shot learning by directly using the LLM without any further customization.",
+      "Use domain-specific prompt engineering to guide the LLM in generating summaries.",
+      "Implement transfer learning by training on a small dataset of patient summaries."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are part of a team developing a multimodal generative AI system that can generate personalized marketing content using text, images, and videos. The system must generate content in real-time based on user interactions on a website. However, the system is experiencing significant delays, impacting user experience. What is the most critical step you should take to address the performance issues in this multimodal generative AI system?",
+    "a": [
+      "Enhance the quality of input data",
+      "Optimize the model inference time",
+      "Increase the amount of training data",
+      "Switch to a more complex model architecture"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "When customizing a Large Language Model (LLM) for a specific task, which approach is most efficient in terms of computational resources and time while still ensuring high performance?",
+    "a": [
+      "Customizing the model by manually editing its parameters based on trial and error.",
+      "Using transfer learning by fine-tuning the top layers of the model on your domain-specific dataset.",
+      "Fine-tuning the model with only a few additional layers on a small dataset of examples.",
+      "Retraining the entire model from scratch using your domain-specific dataset."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working with a multimodal dataset that includes audio, video, and textual data for a sentiment analysis project. During data preprocessing, you notice that the timestamps in the video files do not align with the corresponding audio files, leading to inconsistencies. What is the most effective way to resolve this issue before training your model?",
+    "a": [
+      "Discard the audio data to simplify the model and avoid inconsistency issues.",
+      "Manually adjust the timestamps of each modality to ensure they align perfectly.",
+      "Normalize the data independently for each modality without adjusting the timestamps.",
+      "Use a multimodal synchronization algorithm to automatically align the audio and video data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working on a generative AI project where the client is uncertain about the specific outcomes they want but insists on having a system that integrates with their existing CRM and ERP systems. Which approach should you take during the requirements acquisition phase to best support the client?",
+    "a": [
+      "Proceed with a generic AI model and customize later",
+      "Rely on past similar projects to define the requirements",
+      "Conduct iterative workshops with the client to refine requirements",
+      "Focus on defining the deployment strategy first"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working on a project that involves integrating generative AI models into a customer service chatbot. The chatbot needs to handle multiple types of queries including technical support, billing issues, and general inquiries. You want to ensure the chatbot can generate accurate and contextually appropriate responses for these diverse scenarios. Which of the following strategies would be most effective in using prompt engineering to improve the performance of your generative AI model in this complex scenario? (Select two)",
+    "a": [
+      "Regularly update the prompt based on recent customer interactions.",
+      "Employ a single generic prompt for all types of queries.",
+      "Integrate a rule-based system to handle technical support queries.",
+      "Train the model with a broad dataset that includes diverse scenarios.",
+      "Use highly specific prompts for each type of query."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are building a multimodal model that uses both text and audio data to classify spoken commands. The text data consists of transcriptions of the audio, and you observe that the model is heavily influenced by noise in the audio recordings, resulting in poor transcription quality. Which feature engineering technique should you apply to mitigate this issue and improve model performance?",
+    "a": [
+      "Perform stemming and lemmatization on the text data",
+      "Use one-hot encoding for the text data",
+      "Apply noise reduction techniques to the audio data before feature extraction",
+      "Normalize the audio data by scaling the amplitude"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are assisting in the deployment of a multimodal AI model that integrates text, image, and sensor data for a smart city monitoring system. During the initial deployment phase, the model performs well under controlled conditions, but in a real-world environment with high data volume and varied network conditions, the model's performance deteriorates. Which strategy should be implemented to enhance the model's reliability and scalability in this real-world scenario?",
+    "a": [
+      "Implement edge computing to process data locally before sending it to the central server.",
+      "Reduce the data sampling rate to decrease the amount of data processed by the model.",
+      "Switch to a cloud-only deployment to leverage more scalable resources.",
+      "Deploy the model on a local server with increased CPU capacity."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing a multimodal AI system that integrates visual data from medical images (e.g., X-rays) with corresponding patient notes to assist in diagnosing conditions. The system often overlooks critical details in the images, resulting in inaccurate diagnoses. How can you modify the system to improve its accuracy by ensuring it pays closer attention to relevant parts of the medical images?",
+    "a": [
+      "Apply data augmentation techniques to increase the diversity of the training data",
+      "Increase the resolution of input images before processing",
+      "Use a pre-trained image classification model without fine-tuning it on medical images",
+      "Implement a spatial attention mechanism that highlights critical regions in the medical images"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You have deployed a conversational AI application using NVIDIA Riva on a Kubernetes cluster. The application experiences intermittent performance issues under load. What is the most effective strategy to ensure smooth scaling of the application using Helm charts?",
+    "a": [
+      "Manually allocate more CPU resources to the NLP service in the Helm chart.",
+      "Deploy a single replica of each service on the most powerful node in the Kubernetes cluster.",
+      "Increase the number of replicas for the ASR, NLP, and TTS services in the Helm chart.",
+      "Reduce the resource requests for each service in the Helm chart to allow more pods to run on each node."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A research team is building a multimodal AI system to analyze medical records and X-ray images to diagnose lung diseases. The text data includes patient histories and doctors' notes, while the images are processed using a convolutional neural network (CNN). After deploying the system, it consistently underperforms on cases where the patient history is missing or incomplete, leading to incorrect diagnoses. What is the most likely reason for the system's underperformance in this scenario?",
+    "a": [
+      "The AI system is not utilizing cross-modal learning techniques to compensate for missing data.",
+      "The multimodal fusion strategy heavily relies on text data, causing failures when it's incomplete.",
+      "The CNN is not properly trained on diverse X-ray images.",
+      "The text data preprocessing pipeline is failing to handle missing data properly."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "How do transformer-based LLMs facilitate the manipulation, analysis, and generation of text-based data, and what is a key benefit of using them?",
+    "a": [
+      "They utilize reinforcement learning for text analysis; Benefit: Balancing exploration and exploitation",
+      "They use self-attention mechanisms to understand context; Benefit: Handling long-range dependencies effectively",
+      "They rely on recurrent connections to process sequential data; Benefit: Reducing training time",
+      "They implement convolutional layers for text manipulation; Benefit: Improving the accuracy of text classification"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A tech company is deploying a multimodal AI system that combines video surveillance, audio analysis, and motion sensors to enhance security in a large industrial facility. The system works well during the day but struggles at night when there is limited lighting and more background noise. Additionally, the system consumes a significant amount of energy, leading to higher operational costs. What is the most likely cause of the system's poor performance and high energy consumption at night?",
+    "a": [
+      "The AI models are running continuously at full capacity without energy optimization.",
+      "The video model is not optimized for low-light conditions.",
+      "The system's audio model is overfitting to daytime noise patterns.",
+      "The multimodal fusion strategy is not adapting to different environmental conditions effectively."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are collaborating with an AI development team to create a multimodal generative AI system that produces both code snippets and corresponding documentation. During the testing phase, the team notices that the generated documentation often lacks detail or contains inaccuracies, especially when the code is complex. How should the team approach solving this issue?",
+    "a": [
+      "Increase the training data size by adding more complex code examples",
+      "Reduce the length of code snippets used in training",
+      "Manually adjust the documentation output after generation",
+      "Use a different pre-trained language model specialized in documentation generation"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with improving the performance of a multimodal Generative AI model that integrates text, image, and audio inputs for a customer service chatbot. The chatbot is designed to handle customer queries and provide visual and auditory feedback. After a few months of deployment, the model shows signs of bias and fails to generalize well across different accents and image contexts. Which of the following approaches would be the most effective first step in resolving these issues?",
+    "a": [
+      "Switch from a multimodal approach to a unimodal approach to simplify the model.",
+      "Implement adversarial training to make the model more robust against different types of input.",
+      "Increase the model's complexity by adding more layers to the neural network.",
+      "Fine-tune the model using a more diverse dataset that includes various accents and image contexts."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your company is building a document retrieval system that needs to categorize documents into topics and also provide relevant documents based on user queries. The system will use a pre-trained encoder model for both zero-shot classification and embedding generation for semantic search. Which method would be most efficient for using a pre-trained encoder model for both zero-shot classification and generating embeddings?",
+    "a": [
+      "Use AutoModelForSequenceClassification for zero-shot classification and AutoModelForCausalLM for embedding generation.",
+      "Leverage transformers.Pipeline with the zero-shot-classification task and feature-extraction task to handle both classification and embedding generation.",
+      "Apply AutoModelForQuestionAnswering to handle both zero-shot classification and embedding generation.",
+      "Load an encoder model using AutoModelForTokenClassification for embedding generation and classification."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "The AI development team has deployed a multimodal AI application that generates automated reports from various data sources. After several weeks in production, users report that the application occasionally generates incomplete reports, especially during times of high server usage. What is the most effective strategy to identify and resolve this issue?",
+    "a": [
+      "Add more redundancy to the server infrastructure to handle the load",
+      "Reduce the complexity of the generated reports to decrease processing time",
+      "Limit the application's usage during peak hours to prevent overloading",
+      "Conduct a thorough performance profiling and stress testing to identify bottlenecks"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with developing a multimodal AI model that processes both text and image inputs. During the experimentation phase, you notice that the model performs well on text inputs but struggles with image inputs. Which of the following strategies would help you improve the model's performance on image data? (Select two)",
+    "a": [
+      "Use transfer learning with a pre-trained image model",
+      "Increase the size of the image dataset",
+      "Use only grayscale images to simplify the problem",
+      "Add more noise to the image data",
+      "Increase the complexity of the text model"
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are evaluating a multimodal pipeline that combines text, image, and audio data to predict customer sentiment. After training, you observe that the model's performance varies significantly across different data subsets. Which statistical test would be most appropriate to determine if the differences in model performance across these subsets are statistically significant?",
+    "a": [
+      "Chi-square test",
+      "Analysis of Variance (ANOVA)",
+      "Mann-Whitney U test",
+      "Paired t-test"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "In the context of transformer-based NLP models, what is the primary function of the self-attention mechanism?",
+    "a": [
+      "It reduces the dimensionality of input data to speed up processing.",
+      "It filters out unimportant words from the input sequence.",
+      "It assigns a fixed importance score to each word in a sentence.",
+      "It allows the model to consider the relationships between all words in a sentence, regardless of their position."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "What is one of the main opportunities generative AI provides in the field of personalized content creation, and what is a key challenge associated with it?",
+    "a": [
+      "Opportunity: Reducing content creation time; Challenge: Ensuring content originality",
+      "Opportunity: Enhancing user engagement through personalization; Challenge: Managing bias in generated content",
+      "Opportunity: Expanding content distribution channels; Challenge: Data storage requirements",
+      "Opportunity: Automating routine tasks; Challenge: High computational cost"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "How can a pretrained modern LLM be leveraged to handle multiple NLP tasks, such as token classification, text classification, summarization, and question-answering?",
+    "a": [
+      "Pretrained LLMs are inefficient for text classification and require specialized models for each task.",
+      "A pretrained LLM is only effective for text generation and cannot be adapted to tasks like token classification or summarization.",
+      "A pretrained LLM can be fine-tuned on different datasets for each specific task, providing state-of-the-art performance across token classification, text classification, summarization, and question-answering.",
+      "A pretrained LLM can perform token classification but requires additional rule-based systems for summarization and question-answering."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You have developed a multimodal AI model that uses voice recordings, facial expressions, and text data to assess customer satisfaction. During testing, you find that the model tends to incorrectly predict dissatisfaction for certain accents and facial expressions from specific ethnic groups. What is the best course of action to improve the accuracy and fairness of your model?",
+    "a": [
+      "Adjust the model to give more weight to text data, which is less likely to introduce bias.",
+      "Increase the diversity of the training dataset by including more samples from underrepresented groups.",
+      "Remove the voice and facial expression data and rely solely on text data for predictions.",
+      "Retrain the model on the same dataset with different hyperparameters."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A content creation company is using a multimodal AI system to generate blog posts that include both text and images. The AI system is supposed to generate relevant images that align closely with the text content. However, the images generated often do not match the theme or context of the text, leading to a disjointed user experience. Which prompt engineering strategy is most likely to improve the alignment between the generated images and the text content?",
+    "a": [
+      "Asking the model to generate images based on its interpretation of the text, without further guidance.",
+      "Using a prompt that describes the desired image in very general terms.",
+      "Using a very short prompt to allow the AI system more creative freedom in generating images.",
+      "Including specific details from the text content in the prompt for image generation."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are building a U-Net model designed to generate high-resolution images from pure noise, aiming to produce photorealistic landscapes. Despite extensive training, the images generated by the model are not diverse and tend to look very similar to each other. What could be the most effective strategy to increase the diversity of the generated images while maintaining quality?",
+    "a": [
+      "Reduce the size of the training dataset to focus the model on specific types of landscapes.",
+      "Introduce more variability in the noise input by increasing its dimensionality.",
+      "Increase the number of filters in the convolutional layers.",
+      "Use a fixed noise vector for all images during training to ensure consistency."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are training a generative AI model for multimodal tasks, and you notice that the model's loss oscillates during training, preventing convergence. Which hyperparameter adjustment is most likely to stabilize training and improve convergence?",
+    "a": [
+      "Decrease the learning rate",
+      "Use a higher dropout rate",
+      "Increase the number of layers in the model",
+      "Increase the batch size"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are working on a team developing a technical manual for a new generative AI software that uses multimodal inputs. Your role is to ensure that the manual accurately describes how to train the model with the correct input formats and parameters. Which aspect is most important to emphasize when documenting the training process for the generative AI model?",
+    "a": [
+      "Model evaluation metrics",
+      "Software installation instructions",
+      "Input data preprocessing steps",
+      "Hardware requirements"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are assisting in the development of a multimodal AI system that processes video data and related textual captions to generate video summaries. Under the guidance of a senior team member, you wrote a script that processes the video frames and aligns them with the corresponding captions. After deploying your script, the senior member notices that the video summaries are not accurately representing the content, and the alignment between video and text is inconsistent. What is the most likely mistake in your script?",
+    "a": [
+      "The script uses a standard tokenizer for text processing instead of a custom one.",
+      "The script processes the text captions before extracting video frames, leading to a mismatch in data sequence.",
+      "The video frames were extracted at a fixed interval without considering scene changes.",
+      "The script does not account for variations in the frame rate of the videos."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with developing a multimodal AI system that assists in medical diagnosis by analyzing images, text reports, and patient history. To validate the effectiveness of your system, you conduct an experiment where different prompt formulations are used to guide the model's diagnostic recommendations. What is the most important aspect to consider when evaluating the effectiveness of different prompts during experimentation?",
+    "a": [
+      "The length of the prompts",
+      "The variety of medical cases tested",
+      "The complexity of the prompts",
+      "Accuracy of the model's diagnostic outputs"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "While testing different multimodal AI models, you experiment with early, late, and hybrid fusion techniques to combine text and image data. You observe that the hybrid fusion method consistently outperforms the others. What could be the most likely reason for this superior performance?",
+    "a": [
+      "Hybrid fusion allows the model to handle missing data from one modality more effectively.",
+      "Hybrid fusion optimally balances between leveraging individual modality strengths and their interactions.",
+      "Hybrid fusion reduces the computational complexity compared to early and late fusion.",
+      "Hybrid fusion increases the model's capacity by combining more parameters from both modalities."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are analyzing the effectiveness of a multimodal model that combines visual and textual inputs to answer questions about images. The model uses attention maps to align relevant text with specific regions of the image. How would you interpret the attention map to ensure the model is correctly associating text with image content?",
+    "a": [
+      "Ensure that the attention map is concentrated on the center of the image, regardless of the text input",
+      "Assess if the attention map has high values in regions of the image with less visual information",
+      "Check if the attention map is uniformly distributed across the entire image",
+      "Verify that the attention map highlights regions of the image corresponding to the key words in the text"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Which of the following is an example of a real-world application of generative AI in the creative industry?",
+    "a": [
+      "Generating realistic deepfake videos for entertainment and media purposes.",
+      "Predicting customer behavior based on past purchase history.",
+      "Optimizing supply chain logistics using past data and AI models.",
+      "Filtering spam emails from legitimate ones in an email inbox."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with building a customer support chatbot that can handle a wide range of queries by generating unbounded, contextually appropriate responses. The chatbot must understand the context of the conversation and provide coherent answers that are relevant to the user's questions. Which LLM architecture should you choose?",
+    "a": [
+      "Use a sequence-to-sequence (seq2seq) model with attention for generating unbounded conversational responses.",
+      "Use a decoder-only model like GPT for generating unbounded conversational responses.",
+      "Use an encoder-only model like BERT to generate responses for unbounded conversations.",
+      "Use a generative adversarial network (GAN) for generating unbounded conversational responses."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are building a generative AI model that needs to create personalized marketing content based on user data, including demographics, past purchases, and browsing history. Which data preprocessing steps would most likely improve the quality and relevance of the generated content?",
+    "a": [
+      "Dropping all categorical variables and focusing only on numerical data.",
+      "Normalizing all numerical data and one-hot encoding categorical variables.",
+      "Applying PCA (Principal Component Analysis) to reduce the dimensionality of categorical variables.",
+      "Scaling all numerical data to a range of 0-255 to mimic image preprocessing."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A manufacturing plant is using time-series autoencoders to predict equipment failures based on sensor data (e.g., pressure, temperature, and flow rates). Due to the scarcity of failure examples, the model is trained primarily on normal operating data. To improve the reliability of failure predictions, which of the following actions would be most effective?",
+    "a": [
+      "Modify the autoencoder to prioritize reconstruction errors for data points close to known failure thresholds.",
+      "Reduce the amount of normal data used in training to focus the model on rare failure events.",
+      "Integrate synthetic anomalies into the training data to help the autoencoder recognize potential failures.",
+      "Use a generative adversarial network (GAN) to generate additional normal data for training."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a multimodal AI system that combines text analysis, facial recognition, and speech processing to assist in job applicant evaluations. To ensure fairness and avoid bias in the hiring process, what should be your primary focus during the development and deployment of this AI system?",
+    "a": [
+      "Ensuring that the training data is diverse and representative of all demographic groups.",
+      "Prioritizing the AI system's speed in processing applications over fairness concerns.",
+      "Using only the most qualified applicants' data for training the AI model.",
+      "Focusing on optimizing the AI's accuracy in matching applicants to job descriptions."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "In a factory producing automotive parts, you are developing a computer vision system to identify defects in real-time. The dataset contains a mix of labeled defective parts and a large amount of unlabeled images from various production stages. Which approach would most efficiently use this dataset to improve defect detection accuracy?",
+    "a": [
+      "Use a transfer learning approach with a pre-trained model on similar industrial datasets.",
+      "Employ an unsupervised anomaly detection model on the unlabeled data only.",
+      "Implement a fully supervised learning model on the labeled data to ensure high accuracy.",
+      "Train a semi-supervised learning model that combines labeled and unlabeled data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a multimodal AI system that assists in medical image diagnosis and text-based report generation. How can you ensure that the AI system remains both accurate and unbiased, particularly when deployed in diverse healthcare environments?",
+    "a": [
+      "Relying solely on post-processing techniques to correct biases in the generated reports.",
+      "Training the AI on a diverse, representative dataset that includes data from various demographics and regions.",
+      "Limiting the AI's application to only a specific demographic group to reduce variability.",
+      "Focusing on increasing the size of the dataset without considering its diversity."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with developing a multimodal Generative AI system that uses both text and sensor data to monitor the health of industrial machines. Due to limited labeled failure data, you decide to implement an anomaly detection system using time-series autoencoders. The model must identify potential failures before they occur. During testing, the system correctly identifies some anomalies but also produces a high number of false positives. What should you do first to reduce the number of false positives?",
+    "a": [
+      "Adjust the threshold for anomaly detection to be less sensitive.",
+      "Add more layers to the autoencoder to increase its complexity.",
+      "Use a different machine learning model that is not based on autoencoders.",
+      "Introduce more noise to the training data to improve the model's robustness."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with customizing a large language model (LLM) to process and generate outputs based on both textual and numerical data inputs. Given the constraints of computational efficiency and the need for accurate interpretation of both data types, which approach should you use?",
+    "a": [
+      "Ignore the numerical data and focus on fine-tuning the LLM for text only.",
+      "Use a multimodal LLM that can directly interpret and process both textual and numerical inputs.",
+      "Fine-tune the LLM only on textual data and then manually input numerical data during inference.",
+      "Pre-process numerical data into textual form and fine-tune the LLM on the combined dataset."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A financial services company is deploying a multimodal AI system that processes both text (customer inquiries) and numerical data (transaction records) to detect fraudulent activities in real-time. To ensure the system's effectiveness, the team needs to monitor data collection processes, experiments, and the overall software pipeline regularly. Which two monitoring tools or methods are most critical for ensuring the continuous and accurate functioning of the data collection and processing pipeline in this multimodal AI system? (Select two)",
+    "a": [
+      "Automated Experiment Tracking (e.g., MLflow)",
+      "Real-time Data Stream Monitoring (e.g., Apache Kafka)",
+      "Network Traffic Analysis Tools",
+      "CPU and GPU Utilization Monitors",
+      "Batch Processing Systems (e.g., Hadoop)"
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are preprocessing a multimodal dataset containing time-series sensor data, textual logs, and images for a predictive maintenance application. Upon examining the data, you find that the time-series data is recorded at different sampling rates, the textual logs contain various formats and languages, and the images have different resolutions. What is the best approach to handle these inconsistencies before training your model?",
+    "a": [
+      "Ignore the differences in data formats and train the model directly to learn from diverse inputs.",
+      "Use only the data type that is most consistent across all samples to avoid complications.",
+      "Discard any data that does not conform to a single standardized format.",
+      "Resample the time-series data to a uniform rate, use a common language translation tool for the text, and resize all images to the same resolution."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing a multimodal model that processes both text and image data to classify social media posts. The model struggles to balance the contributions of both modalities during training, often leading to dominance by one modality in the final predictions. Which type of loss function would best address this issue?",
+    "a": [
+      "Apply a cross-entropy loss only to the text modality",
+      "Implement a weighted sum of losses with dynamic weighting",
+      "Implement a hinge loss function that penalizes incorrect predictions more heavily",
+      "Use a simple sum of individual losses from each modality"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are overseeing an AI system that processes multimodal data, including images, text, and structured tabular data, to generate detailed product reviews on an e-commerce platform. Recently, customers have reported that the reviews generated by the system are often irrelevant or poorly aligned with the product images. What is the most likely reason for the irrelevance in generated reviews?",
+    "a": [
+      "The text data is being preprocessed with a new natural language processing (NLP) model.",
+      "The system's training data has not been updated with the latest product reviews.",
+      "The tabular data contains incorrect or outdated product specifications.",
+      "The image processing pipeline is not correctly tagging the products."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with developing a custom natural language processing application with a rapid development cycle. To achieve this, you decide to utilize the HuggingFace model repository and the Transformers API to experiment with various LLMs. When rapidly prototyping a solution using HuggingFace's pre-trained models, which approach allows you to experiment with different model architectures without changing much of your code?",
+    "a": [
+      "Use the transformers.Pipeline with different tasks for each model architecture.",
+      "Clone the entire HuggingFace model repository and manually integrate each model into your application.",
+      "Use the AutoModel class to load different model architectures by specifying the model name.",
+      "Directly modify the underlying model architecture code each time you want to experiment with a new model."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with deploying a multimodal generative AI model that can generate detailed textual descriptions of images for an e-commerce website. The model needs to handle a variety of products ranging from electronics to clothing. The goal is to ensure that the generated descriptions are both accurate and relevant to the specific product in the image. Which of the following approaches would be most effective in fine-tuning a multimodal model to achieve the desired accuracy and relevance in textual descriptions?",
+    "a": [
+      "Fine-tune the model on a dataset containing only electronic products, then manually adjust the descriptions for other categories.",
+      "Fine-tune the model exclusively on the clothing category to maximize performance for clothing descriptions.",
+      "Fine-tune the model on a dataset with a balanced mix of product categories using contrastive learning.",
+      "Use a general pre-trained language model without fine-tuning, as it will adapt to any product category automatically."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a voice-activated assistant for a healthcare application, where it is crucial that the ASR model correctly interprets medical terminology and patient names. You plan to customize and deploy the ASR model using NVIDIA Riva. Which of the following strategies would best ensure accurate recognition of domain-specific vocabulary?",
+    "a": [
+      "Fine-tune the Riva ASR model on a healthcare-specific dataset that includes medical terminology and patient names.",
+      "Fine-tune the Riva ASR model on a dataset of general speech data.",
+      "Rely on post-processing techniques to correct errors in the ASR output instead of fine-tuning.",
+      "Use the default Riva ASR model without customization."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are developing a generative AI model that creates synthetic images for a medical imaging application. The images are intended to be used for training purposes in hospitals. After deployment, you receive feedback that the model occasionally produces images with unrealistic features that could potentially mislead healthcare professionals during training. What action should you take to ensure the trustworthiness of your AI model?",
+    "a": [
+      "Add a disclaimer to the images indicating that they are synthetically generated and may not represent real medical conditions.",
+      "Reduce the resolution of the generated images to make the unrealistic features less noticeable.",
+      "Retrain the model using a larger dataset to improve the realism of the synthetic images.",
+      "Limit the use of synthetic images to non-critical training sessions only."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing a multimodal AI system that assists in analyzing social media content to detect early signs of mental health issues. The system needs to process sensitive personal data, including text, images, and videos. What is the best approach to balance data privacy with the system's need to access relevant data?",
+    "a": [
+      "Storing all data indefinitely to allow future analysis and model improvements.",
+      "Disabling any data privacy measures to streamline data processing and system performance.",
+      "Implementing differential privacy techniques to anonymize personal data while still allowing the system to detect patterns.",
+      "Collecting all available data without anonymization to ensure the highest accuracy."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing a recommendation system that uses collaborative filtering to suggest products to users based on their previous interactions. After deployment, you notice that the system consistently recommends very similar items across different users, leading to a lack of diversity in recommendations. What technique would most likely address this issue?",
+    "a": [
+      "Decrease the learning rate of the model during training",
+      "Apply dimensionality reduction on the user-item interaction matrix",
+      "Introduce content-based filtering in conjunction with collaborative filtering",
+      "Increase the number of latent factors in the matrix factorization model"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your team is developing a multimodal AI model for a client, involving text, image, and audio data. The client requests real-time updates on the project's status, but they are not technical experts. How should you structure your progress reporting to ensure the client stays informed and engaged without overwhelming them?",
+    "a": [
+      "Deliver progress updates only at the end of each development phase",
+      "Share detailed technical reports and data logs",
+      "Schedule daily technical meetings with the client",
+      "Provide high-level summaries focused on project milestones"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are analyzing a large dataset containing customer transaction data. The dataset includes missing values, duplicated records, and categorical variables with high cardinality. Your goal is to prepare the data for a machine learning model that predicts customer churn. What is the best approach to handle these data quality issues?",
+    "a": [
+      "Drop all missing values, remove duplicates, and one-hot encode all categorical variables",
+      "Replace missing values with zeros, keep all duplicates, and label encode categorical variables",
+      "Fill missing values with the mean, retain duplicates for more data, and use frequency encoding for categorical variables",
+      "Impute missing values with the most frequent value, remove duplicates, and use target encoding for high-cardinality categorical variables"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "How can large transformer-based language models (LLMs) be utilized to analyze and generate contextually accurate and coherent text-based data?",
+    "a": [
+      "LLMs primarily rely on recurrent connections to ensure coherence in text generation.",
+      "LLMs cannot be used for analyzing text; they are only suitable for text generation tasks.",
+      "LLMs generate text by using fixed-size embeddings that limit their ability to understand context.",
+      "LLMs can generate text by predicting the next word in a sequence, ensuring contextual accuracy through self-attention mechanisms."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a software application that incorporates generative AI to assist developers by suggesting code snippets based on their written descriptions. The goal is to improve the accuracy of code suggestions based on varying levels of detail provided in the descriptions. Which approach best utilizes prompt engineering to enhance the generative AI model's ability to provide accurate code suggestions? (Select two)",
+    "a": [
+      "Limit prompt complexity to only the most basic descriptions of the code needed.",
+      "Provide feedback on generated code snippets to refine the prompt over time.",
+      "Allow the model to infer requirements from vague and broad descriptions.",
+      "Use detailed and structured prompts that specify the exact requirements for the code snippet.",
+      "Train the model exclusively on code snippets without including context or descriptions."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are evaluating the performance of a multimodal AI model that generates descriptive captions for complex scenes based on image inputs. The model uses attention maps to decide which parts of the image to focus on while generating each word in the caption. What should you check in the attention maps to ensure the model is effectively aligning the visual content with the generated text?",
+    "a": [
+      "Confirm that the attention maps always focus on the most colorful parts of the image",
+      "Check if the attention maps are concentrated on a single object throughout the caption generation",
+      "Verify that the attention maps shift focus to different regions of the image as each word in the caption is generated",
+      "Ensure that attention is evenly distributed across all regions of the image"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are designing a U-Net model to function as an autoencoder for compressing and reconstructing medical images. After training, you notice that the reconstructed images exhibit loss of fine details, particularly in areas of interest like tumors or lesions. Which architectural adjustment would likely improve the model's ability to preserve these important details?",
+    "a": [
+      "Apply dropout in both the encoder and decoder to prevent overfitting.",
+      "Reduce the number of skip connections between the encoder and decoder.",
+      "Use dilated convolutions in the encoder to capture a broader context without losing resolution.",
+      "Increase the stride in the convolutional layers of the encoder."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Which approach is most effective in designing an energy-efficient multimodal AI system without compromising performance?",
+    "a": [
+      "Using more powerful hardware to accelerate processing and reduce time.",
+      "Deploying the multimodal models on edge devices to minimize data transmission.",
+      "Reducing the number of parameters in all models to decrease computational load.",
+      "Implementing model quantization and pruning to optimize model performance and energy consumption."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a generative AI application for a medical imaging company that requires analyzing radiology images and corresponding patient notes. The system must generate diagnostic reports based on these multimodal inputs. Which approach would be most effective for integrating and interpreting these diverse data types within a single model framework?",
+    "a": [
+      "Use a pre-trained image model for radiology images and a separate text model for patient notes, then combine their outputs.",
+      "Use a rule-based system to combine insights from separate image and text models.",
+      "Train a single transformer-based model on both image and text data simultaneously.",
+      "Convert images to textual descriptions and process them using a language model."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with evaluating the effectiveness of different multimodal pipelines for an image captioning task. You have several models that integrate visual and textual data, and you want to compare their performance across multiple metrics (e.g., accuracy, BLEU score, inference time). Which statistical analysis method should you use to assess if there are significant differences in the performance of these models across all metrics?",
+    "a": [
+      "Independent t-tests for each metric",
+      "Cross-validation without statistical testing",
+      "Principal Component Analysis (PCA)",
+      "Multivariate Analysis of Variance (MANOVA)"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are working on a project that requires the integration of geospatial data, text data from social media posts, and images from satellite data to monitor environmental changes over time. Some of the geospatial data is incomplete due to satellite malfunctions, and the text data includes several irrelevant posts. What is the most appropriate strategy to ensure high-quality multimodal data integration for this project?",
+    "a": [
+      "Use text-based NLP models to generate missing geospatial data based on social media posts.",
+      "Ignore the incomplete geospatial data and focus on the available text and image data.",
+      "Fill missing geospatial data with the mean value and discard irrelevant text data.",
+      "Use filtering techniques to remove irrelevant text data and apply interpolation for the geospatial data gaps."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with developing a generative AI system that creates personalized learning materials for students. To ensure that the AI system is fair and trustworthy, it must be designed to avoid any biases in the generated content that could disadvantage certain groups of students. Which approach would most effectively ensure the trustworthiness of the AI system?",
+    "a": [
+      "Implement manual review of all generated content to identify and remove biases.",
+      "Use a diverse dataset during training to minimize the chances of bias in the generated content.",
+      "Randomize the selection of learning materials to ensure fairness across all student groups.",
+      "Allow the AI system to learn from student feedback without any initial bias control."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You want to deploy a custom TTS model using NVIDIA Riva that can generate speech in multiple accents. Which strategy would be most effective for achieving this?",
+    "a": [
+      "Use a pre-trained model and fine-tune it separately for each accent.",
+      "Train a single TTS model on a multilingual dataset.",
+      "Deploy separate TTS models for each accent and switch between them based on user preference.",
+      "Increase the dataset size by mixing audio samples from different accents in a single training process."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are working with a team that is developing a multimodal AI system designed to assist in system analysis by generating both system diagrams and detailed specifications based on user input. During testing, the team finds that the generated system diagrams are accurate, but the accompanying specifications often miss critical requirements. What should the team do to resolve this issue?",
+    "a": [
+      "Increase the model's focus on diagram accuracy during training",
+      "Reduce the complexity of the system diagrams generated",
+      "Limit the model to generating only specifications, excluding diagrams",
+      "Increase the diversity of the training dataset to include more varied system specifications"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI model that integrates speech recognition, text processing, and image analysis to assist visually impaired users by describing their surroundings in real time. The model works well in controlled environments but fails to perform in noisy, real-world conditions. Which of the following adjustments is most likely to improve the model's performance in noisy environments?",
+    "a": [
+      "Increase the training data size by adding more images.",
+      "Implement noise-canceling algorithms in the speech recognition module.",
+      "Deploy the model on more powerful hardware.",
+      "Use a more complex image processing algorithm."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Which strategy is most effective in minimizing bias when developing an AI system that processes multimodal data (e.g., text, images, and audio)?",
+    "a": [
+      "Regularly auditing the AI system's outputs for bias and making adjustments as necessary.",
+      "Using AI-generated data to supplement the training dataset.",
+      "Limiting the dataset to a single modality to reduce complexity.",
+      "Training the AI system on a dataset that includes only the most common scenarios."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are part of a team developing a multimodal AI system that generates captions for images based on visual content and associated metadata. Under the guidance of a senior team member, you have written a Python script to preprocess the images and metadata. However, after deploying the system, the generated captions are often irrelevant to the content of the images. What is the most likely issue with your script?",
+    "a": [
+      "The script uses a standard image resizing function, which changes the aspect ratio of the images.",
+      "The script fails to properly align the metadata with the corresponding images, leading to incorrect caption generation.",
+      "The script does not apply data augmentation techniques to the image data, leading to overfitting during training.",
+      "The script compresses the images to reduce file size, which leads to a loss of visual information."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are conducting an experiment to evaluate a multimodal AI model that integrates text, audio, and visual data. During testing, you observe that the model's performance varies significantly across different test batches. What might be causing this inconsistency? (Select two)",
+    "a": [
+      "Inconsistent preprocessing across different modalities.",
+      "The model is under-optimized.",
+      "The model is being tested on a single modality instead of multimodal data.",
+      "The test environment is not identical to the training environment.",
+      "Different test batches contain different amounts of data."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are assisting with the fine-tuning of a multimodal AI model that processes images and corresponding descriptive text to perform sentiment analysis. After several epochs, the model starts to show signs of overfitting, with the training accuracy increasing while validation accuracy plateaus. The senior team member asks for your input on how to address this issue. What optimization technique should you recommend?",
+    "a": [
+      "Increase the number of epochs to ensure the model learns from the training data.",
+      "Implement dropout in the fully connected layers of the model.",
+      "Add more layers to the model to capture more complex patterns.",
+      "Decrease the learning rate to avoid overfitting."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are building a multilingual customer service chatbot that must provide natural-sounding responses in different languages. You will use NVIDIA Riva to customize and deploy TTS models for this application. What is the most effective approach to ensure the TTS outputs are natural and contextually appropriate in multiple languages?",
+    "a": [
+      "Deploy a single, general-purpose TTS model for all languages without customization.",
+      "Use an ASR model trained on multiple languages to improve the TTS model's output.",
+      "Optimize the TTS model for speed rather than naturalness to ensure real-time responses.",
+      "Fine-tune the TTS model on a multilingual dataset that includes varied speech samples for each target language."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "In the context of developing a generative AI model that utilizes user data for personalized content creation, how can you ensure that the balance between data privacy and user consent is maintained?",
+    "a": [
+      "Allowing users to consent only to non-personalized data collection to maintain privacy.",
+      "Prioritizing the collection of as much user data as possible to enhance the AI model's performance.",
+      "Automatically opting users into data sharing and allowing them to opt out later if they wish.",
+      "Obtaining explicit user consent for data collection and usage, with clear communication about how their data will be used and stored."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with developing a generative AI model that integrates multiple types of data, including text, images, and time-series data, to predict user behavior on an e-commerce platform. You notice that some of the data modalities, particularly the time-series data, have missing values at irregular intervals. Which of the following approaches is most effective in handling missing data across multiple modalities in this scenario?",
+    "a": [
+      "Apply modality-specific imputation techniques and integrate them during data preprocessing.",
+      "Drop any data points that have missing values.",
+      "Use mean imputation for missing time-series data.",
+      "Ignore missing data and train the model with existing data."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are deploying a multimodal generative AI model for a customer support chatbot that processes both text and image inputs. The model must accurately identify product issues from customer-uploaded photos and accompanying descriptions. However, the model struggles when the textual description is ambiguous or contradicts the visual input. What is the best approach to improve the model's performance in this scenario?",
+    "a": [
+      "Fine-tune the model on a dataset containing examples of ambiguous and contradictory inputs.",
+      "Simplify the customer input process by limiting inputs to text or image only.",
+      "Increase the size of the text dataset while keeping the image dataset constant.",
+      "Focus solely on enhancing the image recognition capabilities of the model."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "In a scenario where an AI system is used to generate high-quality images for an e-commerce platform, the system needs to ensure that the images are free from artifacts and accurately represent the product details. How can the denoising diffusion process be applied to improve the quality of these generated images?",
+    "a": [
+      "Use a GAN model for generating images and apply denoising only at the end of the process.",
+      "Use the denoising diffusion process to iteratively refine the generated images, reducing noise and improving details at each step.",
+      "Skip the denoising diffusion process and rely solely on upscaling techniques to enhance image quality.",
+      "Apply a simple Gaussian filter to the final image to reduce noise after generation."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "While testing a multimodal AI model designed to generate captions for images, you observe that the generated captions are often too literal, failing to capture the nuances or context of the images. Which strategies should you consider to improve the quality of the generated captions? (Select two)",
+    "a": [
+      "Train the model with a higher learning rate",
+      "Increase the diversity of the training dataset",
+      "Reduce the size of the training dataset",
+      "Use an image feature extraction model trained on a similar domain",
+      "Incorporate a reinforcement learning approach with human feedback"
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI tool designed to summarize long, complex medical lectures, which include spoken content, slides with diagrams, and text annotations. The tool needs to produce concise summaries that accurately reflect both the visual and verbal content. Which approach would best achieve this?",
+    "a": [
+      "Leverage a multimodal LLM that can simultaneously process spoken words, text, and images for summarization",
+      "Summarize the text and images separately, then combine the summaries manually",
+      "Apply a text-based summarization model and include screenshots of the slides in the output",
+      "Use a speech-to-text model to transcribe the lectures and then summarize the text using an LLM"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are building a generative AI model to create realistic synthetic images for a fashion brand's online store. The model must generate high-quality images that reflect the latest fashion trends while maintaining diversity in style and appearance. Which data augmentation strategy would best support the model's ability to generate diverse and realistic images?",
+    "a": [
+      "Adding duplicate images to the dataset to increase its size.",
+      "Applying transformations such as rotation, scaling, and color adjustments to existing fashion images in the dataset.",
+      "Augmenting the dataset with random noise and distortions to make the model more robust.",
+      "Using only textual data augmentation to improve the descriptions of the fashion items."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are deploying a stateful conversational AI application using Helm charts in a Kubernetes cluster. The application requires persistent data storage for user sessions. What is the best approach to manage stateful services in this scenario?",
+    "a": [
+      "Configure persistent volumes manually outside of the Helm chart and link them to the pods.",
+      "Use a Deployment in the Helm chart and rely on Kubernetes' built-in session affinity.",
+      "Use a StatefulSet in the Helm chart to manage the conversational AI pods.",
+      "Deploy the conversational AI services as DaemonSets in the Helm chart."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "When developing a multimodal AI model, which method is most effective for transferring knowledge from a pre-trained unimodal model to improve the model's ability to process multiple data types?",
+    "a": [
+      "Using the unimodal model as a feature extractor and concatenating its output with features from other modalities.",
+      "Training a new multimodal model from scratch while initializing it with the unimodal model's weights.",
+      "Transfer learning by fine-tuning the entire unimodal model on the multimodal data.",
+      "Freezing the unimodal model's weights and only training the new layers specific to multimodal integration."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal generative AI system for an autonomous vehicle that needs to interpret and respond to various real-world scenarios in real-time, including visual and textual inputs. Which approach is most critical to ensure the system can accurately interpret these scenarios?",
+    "a": [
+      "Training the model only on textual data while ignoring visual inputs.",
+      "Using a pre-trained text-only model to interpret the visual data.",
+      "Fine-tuning the model on a dataset containing both text and images relevant to real-world driving scenarios.",
+      "Implementing separate models for text and image interpretation without any integration."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "In a scenario where a company wants to quickly develop a customer service chatbot capable of handling diverse customer inquiries, how can Large Language Models (LLMs) be effectively leveraged to accelerate the development process?",
+    "a": [
+      "Deploy an off-the-shelf LLM without any customization, assuming it will automatically handle all types of customer inquiries.",
+      "Build a custom language model from scratch, training it on a massive dataset to ensure it understands all possible customer inquiries.",
+      "Use a simple rule-based system in conjunction with the LLM to handle customer inquiries more effectively.",
+      "Fine-tune a pretrained LLM on a dataset of customer interactions, enabling the chatbot to handle various inquiries with minimal additional coding."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are building a generative AI model for creating realistic images based on text descriptions. After training, you notice that the model generates images that are visually appealing but do not accurately reflect the input text prompts. What is the most likely cause of this issue, and how can it be resolved?",
+    "a": [
+      "The model is using an inappropriate loss function.",
+      "The model is overfitting to the training data.",
+      "The training data may not have been accurately labeled or diverse enough.",
+      "The model's architecture is too simple for the task."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "The AI development team is working on a multimodal AI application that generates both voice commands and corresponding code snippets for a smart home system. During integration, the team finds that when the voice commands are long or contain multiple instructions, the generated code snippets are incomplete or incorrect. What would be the best approach to address this issue?",
+    "a": [
+      "Increase the model's training epochs to improve general performance",
+      "Break down voice commands into shorter, simpler instructions",
+      "Fine-tune the model on a dataset that includes complex, multi-part voice commands",
+      "Reduce the complexity of the smart home system to match the model's current capabilities"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Which of the following best describes how context embeddings can be used within a diffusion model to control the characteristics of the generated image?",
+    "a": [
+      "Context embeddings are integrated into the diffusion model to condition the image generation process, allowing specific attributes (such as color or style) to be controlled based on input data.",
+      "Context embeddings allow the diffusion model to ignore user input and generate images based solely on random noise.",
+      "Context embeddings are only relevant in text-based models and have no impact on image generation in diffusion models.",
+      "Context embeddings are applied after the diffusion model has generated the image to adjust attributes like color and texture."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You're tasked with generating photorealistic images from English text prompts using a diffusion model guided by Contrastive Language-Image Pretraining (CLIP). If the generated images frequently lack detail and sharpness, which modification would most effectively enhance image quality?",
+    "a": [
+      "Switch to a different language model for text processing",
+      "Use a lower-dimensional latent space",
+      "Increase the number of diffusion steps",
+      "Reduce the learning rate during training"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI application that generates marketing slogans based on product descriptions. The initial results from the generative AI model are too generic and do not capture the unique selling points of the products. How can you use prompt engineering to better influence the model to generate more specific and compelling slogans?",
+    "a": [
+      "Use a prompt that asks the model to generate slogans based on its understanding of similar products.",
+      "Use a prompt like \"Generate a marketing slogan for this product.\"",
+      "Incorporate specific product details and desired tone into the prompt, such as \"Create a catchy and memorable slogan that emphasizes the eco-friendly materials and innovative design of this product.\"",
+      "Provide a prompt that asks for multiple slogans without specifying any product details."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with selecting a generative AI model for a new application that creates personalized marketing content, including text, images, and video, based on user data. The content must be highly tailored to individual user preferences, requiring the model to understand and process diverse input types. Which type of model architecture would be most suitable for this application to ensure the content is well-tailored to user preferences?",
+    "a": [
+      "Recurrent Neural Network (RNN)",
+      "Multimodal Transformer",
+      "Convolutional Neural Network (CNN)",
+      "Autoencoder"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with designing a generative AI system for a healthcare provider that needs to analyze medical images (e.g., X-rays) and patient records (text) to assist in diagnostics. The system must process high-resolution images quickly while also analyzing large volumes of unstructured text data. What combination of hardware and software components would best meet the requirements for this system?",
+    "a": [
+      "Implement a CPU with integrated graphics for both image and text processing, with a traditional HDD for storage",
+      "Use an FPGA for image processing, a CPU for text analysis, and an HDD for storage",
+      "Use a GPU with high VRAM for image processing, a CPU with many cores for text analysis, and an SSD for data storage",
+      "Use a high-end CPU for all tasks, with a large HDD for storage, and rely on cloud-based GPUs when needed"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are building a multimodal AI model that combines image and text data to generate captions for images in real-time. The model performs well during testing, but in a live environment, it produces captions that are less accurate and sometimes irrelevant. What could be the potential issues? (Select two)",
+    "a": [
+      "The model was not pretrained on a large dataset.",
+      "The model architecture is too simple.",
+      "The model was overfitted on the training data.",
+      "The model's learning rate was too high during training.",
+      "The live data distribution differs from the training data."
+    ],
+    "c": [
+      2,
+      4
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are assisting in the training of a multimodal AI model that integrates both textual and visual data to classify products in an e-commerce application. The senior team member notices that the model's training loss is decreasing very slowly, leading to longer training times. They ask for your suggestion on how to accelerate the training process without compromising model accuracy. What would be the most effective strategy to suggest?",
+    "a": [
+      "Increase the learning rate significantly to speed up the training process.",
+      "Add more data augmentation techniques to the training pipeline.",
+      "Reduce the number of layers in the model to make it more lightweight.",
+      "Switch from a Stochastic Gradient Descent (SGD) optimizer to an Adam optimizer."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI model that combines text, image, and sensor data. During training, you realize that the sensor data is significantly less frequent than the text and image data, causing the model to underperform when relying on sensor inputs. What is the most effective strategy to improve model performance in this scenario?",
+    "a": [
+      "Use data fusion techniques to combine the modalities more effectively.",
+      "Reduce the frequency of text and image data to match the sensor data.",
+      "Increase the number of sensor data samples by generating synthetic data.",
+      "Train separate models for each modality and ensemble them later."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with developing a generative AI model for creating synthetic customer profiles based on real customer data. During testing, you find that the synthetic profiles are too similar to the original data, posing a risk to privacy. Which method would most effectively reduce this risk while maintaining the utility of the synthetic data?",
+    "a": [
+      "Implement Differential Privacy in the model training process",
+      "Use a simpler model with fewer parameters to generate the profiles",
+      "Add Gaussian noise to the generated profiles",
+      "Apply data augmentation techniques to the original dataset"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are collaborating on a multimodal AI project that combines audio and text data for speech-to-text transcription. Under the supervision of a senior team member, you have written a Python script to preprocess audio files and synchronize them with their corresponding text data. After deploying the script, the accuracy of the transcription model drops significantly, and the transcriptions are often incomplete. What is the most likely error in your script?",
+    "a": [
+      "The script processes the text data using a different language model than the one used for training the transcription model.",
+      "The script converts the audio files to a lower sample rate, reducing the quality of the audio data.",
+      "The script fails to segment the audio into appropriate chunks, leading to misalignment with the text data.",
+      "The script normalizes the audio files to a standard volume level before processing."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are optimizing the training of a large-scale generative AI model under the supervision of a senior team member. The model training is taking longer than expected, and the memory usage is extremely high, leading to frequent out-of-memory errors. Which two strategies should you employ to optimize the model training process? (Select two)",
+    "a": [
+      "Increase the batch size to reduce training iterations.",
+      "Use gradient checkpointing to save memory during backpropagation.",
+      "Disable data augmentation to reduce computational load.",
+      "Implement mixed precision training.",
+      "Switch to a less complex model architecture."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are analyzing a multimodal AI research dataset that includes text, video, and physiological sensor data to determine factors influencing user engagement. What is the most effective method to identify relationships between the different modalities and their impact on engagement?",
+    "a": [
+      "Use regression analysis to determine the contribution of each modality to engagement.",
+      "Use a scatter plot matrix to visualize the relationships between all pairs of variables.",
+      "Create a pie chart to show the proportion of engagement attributed to each modality.",
+      "Generate a line chart to track engagement metrics over time for each modality."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are designing a multimodal AI system for an autonomous vehicle that must process real-time video feeds (image data) and sensor readings (numerical data) while making split-second decisions. The system needs to balance processing speed and power efficiency. Which hardware and software components would best meet these requirements?",
+    "a": [
+      "Use an integrated graphics CPU for video processing, with an FPGA for sensor data, and an HDD for data storage",
+      "Use a high-end GPU for video processing, a single-core CPU for sensor data, and network-attached storage (NAS)",
+      "Implement a high-performance CPU for both video and sensor data processing, with an HDD for data storage",
+      "Use a GPU with Tensor Cores for video processing, a multi-core CPU for sensor data analysis, and an SSD for high-speed data access"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "After fine-tuning a large language model (LLM) for generating legal documents, what is the most effective way to assess whether the fine-tuning has improved the model's performance for this specific task?",
+    "a": [
+      "Comparing the fine-tuned model's output with that of a non-fine-tuned model on random text generation tasks.",
+      "Testing the fine-tuned model on a set of common, non-legal text generation tasks to measure general improvement.",
+      "Evaluating the model's output against a benchmark dataset of legal documents that it has never seen before.",
+      "Measuring the speed at which the fine-tuned model generates text, regardless of content accuracy."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Which of the following best describes the role of \"backpropagation\" in training a deep neural network?",
+    "a": [
+      "It forwards the input data through the network to generate predictions.",
+      "It initializes the weights of the neural network.",
+      "It normalizes the inputs to each layer to ensure consistent data distribution.",
+      "It updates the model's weights by calculating the gradients of the loss function with respect to each weight."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are deploying a multimodal generative AI model that integrates text, images, and audio to create personalized virtual experiences. However, during testing, you notice that the model generates inconsistent results when switching between different modalities, leading to a fragmented user experience. What is the most critical approach to address the inconsistency issues when switching between different modalities in the generative AI model?",
+    "a": [
+      "Optimize the model for inference speed",
+      "Implement modality-specific fine-tuning",
+      "Expand the dataset with more diverse examples",
+      "Increase the number of training epochs"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI model that processes text and image data to classify product reviews as positive, neutral, or negative. During testing, you find that the model consistently predicts \"positive\" regardless of the actual sentiment. Upon reviewing the dataset, you notice that 80% of the reviews are positive. What is the most effective way to address this issue?",
+    "a": [
+      "Increase the number of layers in the model to make it more complex.",
+      "Use a weighted loss function to penalize incorrect predictions on the underrepresented classes.",
+      "Train the model only on the neutral and negative reviews to balance the classes.",
+      "Apply data augmentation techniques to generate synthetic positive reviews."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a system that requires analyzing large volumes of legal documents to identify key clauses and generate summaries. The system should also be able to manipulate the text by extracting relevant information based on user queries. Which feature of transformer-based LLMs makes them ideal for this task?",
+    "a": [
+      "The self-attention mechanism that allows the model to focus on specific parts of the text relevant to the query.",
+      "The ability to process text sequentially from beginning to end.",
+      "The capability to parallelize text processing across multiple GPUs.",
+      "The use of pre-trained embeddings to represent words in a fixed context."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal translation system that uses both text and images to translate instructional documents. During training, you observe that the text translation quality is high, but the visual information is not being adequately incorporated. Which loss function modification is most appropriate to enhance the model's ability to integrate visual data?",
+    "a": [
+      "Add a regularization term that minimizes the difference between text and image losses",
+      "Increase the penalty for text translation errors",
+      "Apply a multimodal consistency loss that ensures both text and image representations align",
+      "Use a lower learning rate for the text processing layers"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are working on a multimodal AI model that integrates computer vision and natural language processing for real-time traffic monitoring. The model needs to accurately identify and describe traffic incidents while minimizing energy consumption on edge devices. Which of the following actions would most effectively balance accuracy and energy efficiency in this scenario?",
+    "a": [
+      "Disable real-time monitoring and process data in batches.",
+      "Apply transfer learning using a pre-trained model specifically designed for edge computing.",
+      "Increase the model's complexity by adding additional layers to the neural network.",
+      "Reduce the model's accuracy requirements by lowering the resolution of input images."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are building an application that requires processing and generating content from multiple data types, such as text, images, and audio. Your goal is to use a single, pretrained LLM to perform different tasks like text generation, image captioning, and speech-to-text transcription. What approach would be most effective for customizing the model for these diverse tasks?",
+    "a": [
+      "Use a multimodal pretrained model that can be fine-tuned on specific tasks involving text, images, and audio.",
+      "Use an encoder-only model like BERT and fine-tune it for image captioning and speech-to-text.",
+      "Use a convolutional neural network (CNN) pretrained on images and adapt it for text and audio tasks.",
+      "Use a text-only LLM like GPT-3 and fine-tune it for tasks involving images and audio."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are responsible for deploying a generative AI model that processes images, text, and audio to generate detailed multimedia reports for medical diagnostics. The model needs to be integrated into an existing hospital IT system that has strict compliance and data security requirements. What is the most critical step in ensuring that the generative AI model can be successfully integrated into the hospital's IT system while adhering to compliance and data security requirements?",
+    "a": [
+      "Integrating with cloud-based storage",
+      "Optimizing model inference speed",
+      "Scaling the model to handle large datasets",
+      "Ensuring data encryption and secure transmission"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A manufacturing company wants to implement predictive maintenance to reduce equipment downtime. They have collected time-series data from various sensors monitoring temperature, pressure, and vibration levels of their machines. Which of the following steps would be most critical in building an XGBoost-based machine learning classification model to predict equipment failures?",
+    "a": [
+      "Randomly shuffle the time-series data to eliminate any temporal dependencies before training.",
+      "Train the XGBoost model without any feature engineering to avoid bias.",
+      "Ensure the time-series data is properly segmented into regular time intervals before feeding it into the model.",
+      "Apply image recognition techniques to the sensor data to enhance the model's prediction accuracy."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "How do transformers serve as the basic building blocks for modern large language models (LLMs) in natural language processing (NLP), and what is a primary advantage they provide?",
+    "a": [
+      "Transformers use recurrent connections; Advantage: Reducing memory consumption",
+      "Transformers utilize fixed-length context windows; Advantage: Easier parallelization",
+      "Transformers rely on convolutional layers; Advantage: Fast processing of sequential data",
+      "Transformers use self-attention mechanisms; Advantage: Capturing long-range dependencies"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You have deployed a generative AI model, but the output quality is lower than expected. Which hyperparameter tuning strategy is most likely to improve the model's accuracy without significantly increasing training time?",
+    "a": [
+      "Switch to a higher regularization term",
+      "Optimize the learning rate using a learning rate scheduler",
+      "Increase the number of training epochs",
+      "Decrease the batch size"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are developing a multimodal AI application that requires processing both image and text data to generate captions for images. You need to ensure that the captions are semantically accurate and contextually relevant. Which two Python libraries would be most suitable for handling the text analysis and semantic similarity tasks in this scenario? (Select two)",
+    "a": [
+      "OpenCV",
+      "NumPy",
+      "Gensim",
+      "spaCy",
+      "PyTorch"
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are working on a multimodal AI system that integrates text and numerical data for sentiment analysis on customer reviews. The text is processed using spaCy for NLP tasks, while the numerical data is handled using NumPy. After implementing the new model, you notice that the sentiment predictions are consistently skewed toward neutral sentiments, even when the text clearly indicates positive or negative emotions. What is the most likely cause of this issue?",
+    "a": [
+      "The NumPy arrays containing the numerical data are incorrectly scaled.",
+      "The Keras model is not appropriately compiling the loss function.",
+      "The spaCy NLP model is not correctly tokenizing the text data.",
+      "The numerical features are not being correctly concatenated with the text features."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with building a multimodal model that uses text and image data to generate captions for images. To improve the model's performance, you decide to apply transfer learning. However, the model struggles with generalizing to new, unseen image-text pairs during evaluation. What transfer learning strategy should you consider to improve generalization?",
+    "a": [
+      "Only fine-tune the text encoder and keep the image encoder frozen.",
+      "Fine-tune both the text and image encoders on a small, specific dataset.",
+      "Reduce the number of layers in the image encoder to simplify the model.",
+      "Use domain-specific pre-trained models for text and image encoders."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are using CLIP (Contrastive Language-Image Pretraining) to generate images from English text prompts. However, you notice that the generated images are often not accurately reflecting the details specified in the text prompts. For example, when prompting \"a red apple on a green table,\" the apple sometimes appears green or the table is not visible. What technique would most likely improve the alignment between the text prompt and the generated image?",
+    "a": [
+      "Increase the number of training epochs for CLIP to enhance its understanding of text-image relationships.",
+      "Fine-tune the CLIP model specifically on a dataset that pairs similar text descriptions with images.",
+      "Simplify the text prompts by removing adjectives like \"red\" or \"green.\"",
+      "Generate images at a lower resolution to minimize the impact of errors in detail representation."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are building a generative AI model to create personalized email responses based on customer queries. However, the generated emails are either too formal or too informal and occasionally miss addressing the customer's key concern. To improve the output, you decide to use prompt engineering. Which approach should you take to better guide the model in generating responses that are appropriately toned and directly address the customer's issue?",
+    "a": [
+      "Use a prompt that asks the model to generate multiple responses to increase variety.",
+      "Include the desired tone and key points to address in the prompt, such as \"Write a professional but friendly email that answers the customer's specific question about shipping times.\"",
+      "Avoid including any specific customer information in the prompt to maintain privacy.",
+      "Use a simple prompt like \"Generate an email response.\""
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with building and deploying an end-to-end conversational AI application for a banking system. The application must accurately transcribe customer requests (ASR), understand and process their intent (NLP), and generate appropriate spoken responses (TTS). You plan to deploy this pipeline using NVIDIA Riva. What is the most critical consideration to ensure the system correctly understands and responds to customer inquiries?",
+    "a": [
+      "Use a general-purpose TTS model to generate responses to customer inquiries.",
+      "Ensure that the ASR model is fine-tuned on a general dataset with various accents and dialects.",
+      "Deploy the NLP model without customization to handle a broad range of customer inquiries.",
+      "Customize the NLP model to recognize and process domain-specific terminology used in banking."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A company is developing a real-time multimodal AI system for autonomous vehicles that integrates data from LIDAR sensors, cameras, and GPS. The system performs well in most environments but consistently fails to accurately detect and respond to obstacles in heavy rain, especially when GPS signals are weak. What is the most likely cause of the system's failure in these specific conditions?",
+    "a": [
+      "The LIDAR sensor data is being incorrectly fused with camera data.",
+      "The LIDAR sensor is not designed to work in rainy conditions.",
+      "The GPS data is given too much weight in the multimodal fusion process.",
+      "The camera's image quality degrades in low light conditions."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are testing a multimodal AI model that combines sensor data and video footage to detect anomalies in industrial machinery. Despite achieving good individual accuracy with each modality, the model's performance decreases when both modalities are used together. What is the most likely cause of this problem?",
+    "a": [
+      "The video data might be of higher quality than the sensor data, causing the model to ignore the latter.",
+      "The model requires a deeper neural network to process the combined data.",
+      "The model's loss function is too simple to capture the complexity of both modalities.",
+      "The sensor data and video features are not properly aligned or synchronized in the model."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are training a multimodal model that combines text and image data to generate detailed captions for images. During training, you notice that the model's performance on the text modality degrades significantly while the image modality performs well. What is the most effective strategy to maintain balanced performance across both modalities?",
+    "a": [
+      "Increase the batch size for text data only",
+      "Use separate learning rates for each modality during training",
+      "Add more layers to the text processing part of the model",
+      "Apply dropout only to the image processing layers"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A company is using a multimodal AI system to analyze both text and image data for content moderation on a social media platform. The text data is analyzed using a transformer-based model, and the image data is analyzed using a convolutional neural network (CNN). The AI system frequently misclassifies text with embedded images as safe when they contain inappropriate content. What is the most likely reason for the misclassification in this multimodal AI system?",
+    "a": [
+      "The transformer model is underfitting the text data.",
+      "The multimodal fusion strategy is not effectively integrating the outputs of the text and image models.",
+      "The image preprocessing pipeline is misaligned with the text preprocessing pipeline.",
+      "The CNN model is overfitting the image data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal AI system that combines image recognition, text analysis, and natural language processing to assist in evaluating loan applications. The system must make fair decisions across applicants from different socioeconomic backgrounds. What is the most effective strategy to minimize bias in this AI system?",
+    "a": [
+      "Prioritizing the accuracy of predictions based solely on applicants with high credit scores.",
+      "Using historical data on loan approvals without modification to maintain consistency.",
+      "Training the model on data from a single region with a homogenous population to simplify the system.",
+      "Incorporating fairness constraints during the model training process to ensure balanced outcomes for different demographic groups."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An AI-powered application you are working on generates real-time analytics for a financial services company. After several months of operation, the application starts experiencing frequent timeouts and delays, particularly during high market activity. This is affecting the reliability of the analytics provided. What is the best course of action to address this issue?",
+    "a": [
+      "Implement a manual override system to control data flow during high activity",
+      "Profile the application to identify specific performance bottlenecks during high load",
+      "Upgrade the server hardware to handle higher loads more effectively",
+      "Reduce the frequency of real-time updates to minimize processing load"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are analyzing a large dataset of customer purchasing behaviors to identify patterns that could inform marketing strategies. The dataset includes numerous features, such as customer demographics, purchase history, and browsing behavior. Which data mining or visualization technique would be most effective for identifying clusters of customers with similar purchasing patterns?",
+    "a": [
+      "K-Means Clustering",
+      "Regression Analysis",
+      "Decision Trees",
+      "Principal Component Analysis (PCA)"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "When customizing an LLM for a specific industry task where quick deployment and computational efficiency are priorities, which of the following methods would be most appropriate?",
+    "a": [
+      "Fine-tuning an existing large model on a small, targeted dataset specific to the industry.",
+      "Applying data augmentation techniques on the industry-specific dataset without fine-tuning the model.",
+      "Using the original LLM without any modifications to handle industry-specific tasks.",
+      "Training a new model from scratch using industry-specific data."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal AI model that combines image data and text descriptions to classify product images on an e-commerce website. You are using Keras for model development, with NumPy to handle the image data and spaCy for text preprocessing. After training, the model's accuracy on the validation set is significantly lower than expected, particularly in cases where the text descriptions are longer. What is the most likely reason for the low accuracy in these specific cases?",
+    "a": [
+      "The Keras model's dropout rate is set too high, leading to underfitting.",
+      "The spaCy text processing pipeline is truncating longer descriptions, leading to loss of important context.",
+      "The Keras model is overfitting to the training data due to a small batch size.",
+      "The NumPy arrays representing the image data are not normalized."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with developing a generative AI model to produce realistic financial reports based on various structured and unstructured data sources, including spreadsheets, PDFs, and email correspondence. What data preparation steps would most likely ensure the accuracy and reliability of the generated reports?",
+    "a": [
+      "Randomly sample a subset of the data to reduce the processing load and feed only that into the model.",
+      "Normalize numerical data, apply Optical Character Recognition (OCR) to extract text from PDFs, and categorize email data by topics.",
+      "Combine all unstructured data into a single text document and treat structured data as separate features.",
+      "Convert all data into a single text format before feeding it into the model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with designing a generative AI model that creates artwork based on input text prompts. To ensure the model remains fair and doesn't inadvertently reinforce harmful stereotypes, what is the most important step in your workflow?",
+    "a": [
+      "Use an energy-efficient GPU for training.",
+      "Focus solely on improving the model's accuracy.",
+      "Increase the model's capacity by adding more layers.",
+      "Ensure the training dataset is diverse and representative."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying a generative AI model for image-to-text translation on an edge device with limited computational resources. Which strategy would best optimize the model's performance while maintaining high output quality?",
+    "a": [
+      "Quantization of the model weights",
+      "Enabling mixed precision training",
+      "Using a smaller, pre-trained model",
+      "Applying dropout during inference"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A research team is developing a large language model (LLM) to analyze and generate legal documents. The model must understand complex legal language, maintain coherence over long documents, and accurately capture relationships between different sections of a contract. What is the most significant advantage of using transformers in this scenario?",
+    "a": [
+      "Incorporating prior knowledge without fine-tuning",
+      "Reducing the need for large labeled datasets",
+      "Ability to capture long-range dependencies across the document",
+      "Simplifying the tokenization process for legal language"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a computer vision model for industrial inspection using XGBoost, autoencoders, and GANs to identify defective products. The dataset consists of thousands of images of both defective and non-defective items, but the defective items are heavily underrepresented. Which of the following strategies would best address the class imbalance during model training?",
+    "a": [
+      "Apply oversampling to the non-defective items to match the number of defective items.",
+      "Use random noise as input to the autoencoder to simulate defective items.",
+      "Use the GAN to generate additional images of defective items to balance the dataset.",
+      "Train the XGBoost model only on defective items to focus the model on the minority class."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal AI model that combines video data with sensor readings to monitor and predict equipment failures in an industrial setting. The model outputs a probability score indicating the likelihood of failure. However, your stakeholders are struggling to interpret these scores. Which visualization approach would be most effective in conveying the likelihood of equipment failure and the contributing factors?",
+    "a": [
+      "Use a line chart to display the probability scores over time",
+      "Implement a heatmap that shows the correlation between different sensor readings and the probability of failure",
+      "Develop a gauge chart to display the real-time probability of failure, combined with a tooltip feature to explain the contributing factors",
+      "Use a scatter plot to show the relationship between sensor readings and the probability of failure"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with developing a multimodal AI system that integrates video, audio, and text to provide real-time translations and cultural context for international business meetings. What is the most effective approach to ensure that the AI system remains culturally sensitive and trustworthy across diverse global audiences?",
+    "a": [
+      "Prioritizing translation speed over cultural accuracy to ensure real-time performance.",
+      "Training the model on a diverse dataset that includes various languages, dialects, and cultural contexts.",
+      "Focusing on text translation accuracy and ignoring audio and video modalities.",
+      "Using a single high-quality dataset from a leading global business hub."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You have developed a multimodal AI model that processes medical images and patient history text data to predict disease risk. To improve the explainability of the model's predictions, you want to understand which modality contributes most to the prediction. What is the best approach to achieve this?",
+    "a": [
+      "Use SHAP (SHapley Additive exPlanations) values to measure the contribution of each modality to the final prediction.",
+      "Use a black-box testing approach to evaluate the model's predictions without focusing on explainability.",
+      "Visualize the learned weights of the model directly to see which modality is more important.",
+      "Train separate models for each modality and compare their accuracy to determine the more significant modality."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal generative AI model that combines text and image inputs. After initial testing, you observe that the model performs exceptionally well on the training set but poorly on the validation set. What is the most effective approach to mitigate this issue?",
+    "a": [
+      "Switch to a simpler model architecture.",
+      "Add dropout layers during training.",
+      "Increase the number of epochs for training.",
+      "Increase the size of the training set by collecting more data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are working on a multimodal AI system for a client that combines text, image, and audio data to generate multimedia content. The client reports that the system is not generating accurate outputs because it is not understanding the context of the input data correctly, particularly when dealing with diverse accents in the audio input. Which two actions should you consider to improve the system's performance in handling diverse accents in the audio data? (Select two)",
+    "a": [
+      "Increase the sampling rate of the audio data to capture more detail.",
+      "Implement a speech normalization preprocessing step to standardize the accents before processing.",
+      "Use a simpler text-to-speech engine for generating audio outputs.",
+      "Collect more audio data representing a wider variety of accents and retrain the model.",
+      "Reduce the amount of data used for training to make the model more focused."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying a multimodal AI system that combines text, images, and audio to assist in emergency response decision-making. The system will be used by various agencies across different countries. Which approach will most effectively ensure that the AI system provides reliable and unbiased recommendations in diverse scenarios?",
+    "a": [
+      "Implementing strict usage guidelines to limit the system's decision-making to only certain types of emergencies.",
+      "Incorporating real-time feedback from users in different regions to continuously adapt the model.",
+      "Training the model exclusively on data from regions where it will be deployed.",
+      "Using a single, high-quality dataset from a leading country with advanced emergency response systems."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You have deployed a production-level conversational AI application using NVIDIA Riva in a Kubernetes cluster with Helm. The cluster is experiencing resource contention, leading to degraded performance during peak usage. What is the most effective way to optimize resource utilization using Helm charts?",
+    "a": [
+      "Use NodeSelectors in the Helm chart to bind specific services to specific nodes.",
+      "Increase the resource limits for each service in the Helm chart to prevent them from being throttled.",
+      "Configure resource requests and limits for each service in the Helm chart based on actual usage patterns.",
+      "Deploy all services with the default resource settings in the Helm chart."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A company wants to deploy a generative AI model that can analyze and generate text, images, and audio content simultaneously. The company has access to a large multimodal dataset and powerful hardware but needs to optimize the system architecture to meet the needs of both real-time processing and high-quality generation. Which two components are most critical for optimizing the performance of a generative AI system that handles multimodal data (text, images, and audio) to ensure real-time processing and high-quality generation? (Select two)",
+    "a": [
+      "Traditional CPUs with Multiple Cores",
+      "High-performance GPUs with Tensor Cores",
+      "Solid State Drives (SSDs) for Data Storage",
+      "Custom AI Accelerators (e.g., TPUs)",
+      "High-Bandwidth Memory (HBM)"
+    ],
+    "c": [
+      1,
+      3,
+      4
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with developing an application that leverages a single pretrained model to analyze and generate content from text, images, and audio. Your goal is to customize the model to perform text summarization, image captioning, and speech-to-text conversion. What is the most effective strategy to achieve this?",
+    "a": [
+      "Use a multimodal transformer model like GPT-4 Vision that can be fine-tuned for tasks across text, images, and audio.",
+      "Fine-tune a multimodal transformer model like CLIP, which is designed to handle both text and images.",
+      "Use separate models for text, images, and audio, and integrate their outputs.",
+      "Use a text-based model like GPT-3 and add layers for image and audio processing."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a generative AI model to create high-quality, realistic images from text descriptions. The model needs to handle a wide range of descriptions, including those with complex details and various styles. What strategies should you employ to optimize the performance of your generative AI model in handling complex and diverse text-to-image generation scenarios? (Select two)",
+    "a": [
+      "Use a large and diverse dataset of text-image pairs.",
+      "Apply text embeddings to capture the nuances of the text descriptions.",
+      "Limit the training dataset to only high-resolution images.",
+      "Train the model with generic and simplistic text descriptions.",
+      "Use a model architecture that supports multi-modal input, such as a transformer-based model."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are designing a deep multimodal network that integrates text, image, and tabular data for a medical diagnosis application. The network is very deep and suffers from vanishing gradients, making training difficult. Which of the following techniques is most effective in addressing this issue?",
+    "a": [
+      "Reduce the number of layers in the network",
+      "Use dropout with a higher rate to prevent overfitting",
+      "Increase the learning rate to accelerate gradient updates",
+      "Implement residual connections between layers"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "In a scenario where your multimodal AI model is underperforming due to latency issues during inference, which optimization technique would be most effective in improving performance while maintaining model accuracy?",
+    "a": [
+      "Increase the batch size during inference.",
+      "Train the model on a more powerful GPU.",
+      "Use model pruning to remove less important neurons from the network.",
+      "Reduce the learning rate during inference."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You need to customize a single, pretrained model to perform different tasks, including text classification, image generation, and audio transcription. Which of the following methods will enable you to most efficiently customize the model for these tasks without having to train separate models for each task?",
+    "a": [
+      "Use separate models for each task, such as GPT for text, CNN for images, and RNN for audio.",
+      "Use a text-based LLM and add additional layers for processing images and audio.",
+      "Use a GAN for all tasks, as it can be trained to generate images, text, and audio.",
+      "Use a transformer-based multimodal model that can be fine-tuned for specific tasks involving text, images, and audio."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A news organization is using a transformer-based large language model (LLM) to automatically generate news summaries from long articles. The model needs to ensure that the summaries are accurate, concise, and maintain the original article's context. However, the organization also requires the model to detect and avoid any potential bias in the summaries. What is the primary challenge in this scenario?",
+    "a": [
+      "Choosing the right dataset for training the model",
+      "Ensuring the model generates summaries that are free from bias",
+      "Scaling the model to handle millions of articles simultaneously",
+      "Reducing the length of the summaries to a predefined word count"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are working on a project to develop a multimodal AI system that can analyze and generate content based on videos, including transcribing speech, recognizing objects, and identifying emotions from facial expressions. The system's performance heavily depends on the quality of the labeled data used for training. What is the most critical consideration when curating and annotating a dataset for this multimodal AI system?",
+    "a": [
+      "Maximizing the size of the dataset",
+      "Using automated tools for quick labeling",
+      "Ensuring accurate and consistent labeling across all modalities",
+      "Including only high-resolution video content"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Which of the following is a core ethical principle of trustworthy AI that ensures AI systems are developed and used responsibly?",
+    "a": [
+      "Transparency, to ensure that AI decision-making processes are understandable and traceable.",
+      "Complexity, to ensure that AI systems can handle a wide range of scenarios.",
+      "Speed, to prioritize quick decision-making processes over accuracy.",
+      "Proprietary control, to maintain confidentiality of the AI algorithms."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are evaluating different multimodal models that integrate text and image data for a content recommendation system. One model shows consistently high accuracy on the training set but fluctuates in performance across different validation sets. Which cross-validation strategy would help you obtain a more reliable estimate of this model's performance?",
+    "a": [
+      "Nested Cross-Validation",
+      "Leave-One-Out Cross-Validation",
+      "Time-Series Cross-Validation",
+      "Stratified K-Fold Cross-Validation"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "While analyzing a dataset for a generative AI model, you discover missing values in several key features. Which method is most appropriate for handling these missing values to ensure the model's performance is not compromised?",
+    "a": [
+      "Impute missing values using the mean or median of the respective feature.",
+      "Replace missing values with randomly generated numbers within the range of the feature.",
+      "Remove all rows with missing values from the dataset.",
+      "Replace all missing values with zero."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are leading a team developing a chatbot application for customer support. The project is under tight deadlines, and you need to rapidly prototype using a pre-trained language model from the HuggingFace model repository. The chatbot must understand customer queries and provide appropriate responses. Your team needs to experiment with different models and fine-tune them as required. Which strategy should your team use to efficiently pull in, fine-tune, and experiment with different HuggingFace models for the chatbot?",
+    "a": [
+      "Manually download each model's weights from HuggingFace, integrate them into your application, and fine-tune them using custom code.",
+      "Use the AutoModelForCausalLM class to load different pre-trained models suitable for generating conversational responses.",
+      "Use the AutoModelForSequenceClassification class to load different pre-trained models and fine-tune them for generating responses.",
+      "Load the models directly using the transformers.ModelLoader class and modify the underlying architecture to meet your needs."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "During the preprocessing of a multimodal dataset that includes environmental sensor readings, user input logs, and satellite imagery for an environmental monitoring system, you identify significant outliers in the sensor data. What is the most appropriate strategy to manage these outliers without compromising the integrity of the model?",
+    "a": [
+      "Use robust statistical techniques to detect and adjust the outliers without removal.",
+      "Remove the outliers from the dataset to prevent skewing the model's predictions.",
+      "Replace the outliers with the mean of the data to maintain consistency.",
+      "Normalize the outlier data to bring it within the expected range."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are building a generative AI application for a fashion retailer that generates custom clothing designs based on customer text descriptions. The retailer wants the system to ensure that subtle design features, like intricate patterns and fabric textures, are accurately represented. Which approach would most effectively improve the model's ability to capture these details?",
+    "a": [
+      "Increase the size of the diffusion model to add more parameters",
+      "Apply post-processing filters to sharpen the generated images",
+      "Train the model on a larger and more diverse dataset of fashion images",
+      "Fine-tune the CLIP model on a curated dataset of fashion descriptions and images"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A healthcare organization is using a multimodal AI system to analyze patient data from various sources, including text-based medical records, medical images, and sensor data from wearable devices. The organization needs to ensure that the data collection, preprocessing, and model experiments are functioning correctly and delivering reliable results. Which two monitoring strategies are most effective for ensuring the proper functioning of data collection and model experimentation in this multimodal AI system? (Select two)",
+    "a": [
+      "Periodic Manual Audits",
+      "Automated Data Quality Monitoring Tools",
+      "Heatmap Visualization of Model Predictions",
+      "Data Consistency Checks",
+      "Regular Software Patching"
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal generative AI system that integrates both image and text data to generate product descriptions based on product images. However, you observe that the model is generating generic and less informative descriptions for certain product categories. To improve the specificity of the generated descriptions, which strategy would be the most effective?",
+    "a": [
+      "Add more layers to the model to increase its capacity",
+      "Fine-tune the model exclusively on the underperforming product categories",
+      "Implement a hierarchical attention mechanism that focuses on specific features in the images",
+      "Increase the number of training epochs and reduce the learning rate"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are building a retrieval-augmented generation (RAG) system using a multimodal LLM to generate text summaries based on text, images, and documents retrieved from a large database. During deployment, the summaries generated are sometimes inaccurate or miss key details from the retrieved documents. What could be contributing to these inaccuracies? (Select two)",
+    "a": [
+      "The model's attention mechanism is not optimized for multimodal inputs.",
+      "The summarization model is using an outdated natural language processing algorithm.",
+      "The LLM is overfitting on the training data used for summarization.",
+      "The LLM was not pre-trained on a dataset that includes multimodal data.",
+      "The retrieval model is not retrieving the most relevant documents."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are testing the quality of a multimodal dataset that includes sensor data, images, and text descriptions for an autonomous vehicle project. You discover that the sensor data has missing values, the images vary significantly in quality, and the text descriptions are inconsistently formatted. Which step should be prioritized to ensure high data quality before training your model?",
+    "a": [
+      "Focus solely on normalizing the text data since inconsistent formatting can confuse the model.",
+      "Apply data imputation techniques to fill in missing sensor data and use image preprocessing to standardize quality.",
+      "Remove all data samples with any quality issues to ensure the remaining data is clean.",
+      "Use a more complex model architecture to handle the inconsistencies in the dataset."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are collaborating with a team to deploy a multimodal AI application that analyzes large datasets and generates predictive models and visualizations. After the initial deployment, users report that the application's performance degrades significantly when processing data from multiple sources simultaneously. The system becomes slow, and the quality of the visualizations decreases. What is the most effective approach to resolve this performance issue?",
+    "a": [
+      "Reduce the number of data sources to prevent system overload",
+      "Decrease the resolution of the visualizations to reduce processing demands",
+      "Manually balance the data load across the system components",
+      "Implement data caching mechanisms to reduce the load on the system"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with developing a computer vision system for industrial inspection to detect surface defects on manufacturing parts. The system uses a combination of XGBoost, autoencoders, and generative adversarial networks (GANs). After training, you notice that the system is very effective at detecting common defects but struggles with rare, subtle defects. Which approach would best improve the model's ability to detect these rare defects?",
+    "a": [
+      "Fine-tune the autoencoder by exclusively training it on images of rare defects.",
+      "Increase the depth of the XGBoost model to improve its sensitivity to all types of defects.",
+      "Use the GAN to generate synthetic images of rare defects and retrain the model.",
+      "Augment the dataset by duplicating images of common defects to balance the training data."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a multimodal generative AI system designed to assist in medical imaging analysis by generating both detailed text reports and corresponding annotated images. After deployment, you notice that while the text reports are accurate, the annotated images often miss critical regions that should be highlighted. What could be the most likely reason for this issue?",
+    "a": [
+      "The text report generation model is interfering with the image annotation process.",
+      "The image resolution used during training was too high, causing the model to overlook smaller details.",
+      "The model's loss function was optimized for text accuracy rather than image accuracy.",
+      "The model was trained on a limited set of annotated images, leading to insufficient learning of critical features."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A healthcare company is developing a generative AI model to assist doctors in diagnosing medical conditions from patient data, including images, text, and lab results. The model needs to provide accurate, reliable, and explainable outputs. What is the most significant challenge in this scenario?",
+    "a": [
+      "Choosing the right deep learning framework for development",
+      "Optimizing the model for real-time inference",
+      "Scaling the model to handle millions of patient records simultaneously",
+      "Ensuring the model is interpretable by medical professionals"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are testing the effectiveness of a multimodal AI model designed to predict stock market trends using financial news articles, social media sentiment, and historical stock prices. The model performs well during periods of market stability but shows significant accuracy drops during market volatility. What approach should you take to improve the model's performance during volatile periods?",
+    "a": [
+      "Reduce the complexity of the model to avoid overfitting to stable market conditions.",
+      "Focus training exclusively on periods of market stability to ensure consistent accuracy.",
+      "Incorporate additional data sources such as real-time trading volumes and macroeconomic indicators to provide more context during volatile periods.",
+      "Apply data augmentation techniques to artificially increase the size of the dataset during stable periods."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with creating a rapid application that requires generating detailed, context-aware code snippets in response to user queries. You decide to use a Large Language Model (LLM) optimized for generating sequences such as code. Which approach will best suit this requirement?",
+    "a": [
+      "Use an encoder-only model like BERT for code generation.",
+      "Use a sequence-to-sequence model like T5 for generating code.",
+      "Use a decoder-only model like GPT for sequence generation.",
+      "Use a reinforcement learning-based model to generate sequences."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with deploying a multimodal AI system that integrates computer vision and natural language processing (NLP) for an e-commerce platform. The system must efficiently process high volumes of product images and customer reviews while maintaining high accuracy. What is the most effective approach to balance energy efficiency, trustworthiness, and accuracy?",
+    "a": [
+      "Implement model quantization techniques and mixed precision training.",
+      "Optimize the model architecture by reducing the number of layers in the neural network.",
+      "Use a larger dataset to train the model to improve accuracy.",
+      "Disable regularization techniques to speed up processing times."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "In designing a prompt for a multimodal AI system to generate a product advertisement that combines persuasive text with a compelling visual, which of the following strategies is most effective?",
+    "a": [
+      "Creating separate prompts for the text and image without any connection between them.",
+      "Instructing the model to generate the text first and then create an image based on the text.",
+      "Using a highly detailed prompt for the text but a very brief one for the image.",
+      "Using a prompt that solely describes the desired visual style."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A company wants to deploy a generative AI model that can generate realistic images from textual descriptions. The model must consider multiple sources of multimodal data, such as text, audio, and existing images, to produce the most accurate outputs. What is the most suitable technique to integrate and process these different types of multimodal data?",
+    "a": [
+      "Use separate models for each data type and combine the outputs",
+      "Implement a multimodal encoder-decoder architecture that processes all data types simultaneously",
+      "Use a GAN trained only on image data and condition it on textual input",
+      "Apply transfer learning using a pre-trained text model"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with customizing a pre-trained large language model (LLM) to generate legal summaries for a law firm. The firm wants the model to accurately reflect their proprietary legal standards without requiring excessive computational resources. Which fine-tuning technique should you use to achieve this?",
+    "a": [
+      "Implement prompt engineering with no fine-tuning to guide the LLM's responses.",
+      "Fine-tune only the final output layer of the LLM on a small subset of legal cases.",
+      "Use a lightweight adapter layer added to the pre-trained LLM and fine-tune only the adapter.",
+      "Fine-tune the entire LLM on the law firm's complete legal dataset."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are experimenting with different AI model architectures for a multimodal project that integrates text, image, and audio data. One model architecture shows high accuracy on the training set but fails to generalize well to the validation set. What is the most appropriate next step to evaluate and improve this model?",
+    "a": [
+      "Switch to a more complex model architecture with additional layers.",
+      "Reduce the size of the training set to decrease overfitting.",
+      "Use cross-validation to better evaluate the model's generalization.",
+      "Increase the number of epochs to further train the model."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "The AI development team is tasked with integrating a multimodal AI system into a software development lifecycle (SDLC) tool. The system is designed to perform system analysis by generating both textual and visual representations of system requirements. However, during testing, the team finds that while the visual representations are accurate, the textual descriptions often contain redundant information or are overly verbose, making them difficult to use. What is the best approach to improve the quality of the textual descriptions?",
+    "a": [
+      "Simplify the visual representations to reduce the verbosity of the text",
+      "Fine-tune the model on a dataset with concise, well-structured textual descriptions",
+      "Manually edit the generated text for each project",
+      "Reduce the model's training time to prevent overfitting"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "When training a deep learning model for image classification, which data augmentation technique is most likely to improve the model's accuracy on unseen data?",
+    "a": [
+      "Repeating the original training images multiple times without any modifications.",
+      "Reducing the resolution of the input images to decrease computational load.",
+      "Adding Gaussian noise to the input images to simulate sensor errors.",
+      "Randomly flipping, rotating, and cropping the input images during training."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "As an AI developer, it's essential to stay informed about the latest advancements in language learning models. Which of the following strategies would be most effective in ensuring you are up-to-date with both academic research and industry trends?",
+    "a": [
+      "Attend webinars and online courses provided by AI companies.",
+      "Subscribe to and regularly read AI-focused academic journals and publications.",
+      "Follow influencers and AI experts on social media.",
+      "Participate in online AI communities and forums daily."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Which of the following best explains how transformer-based large language models (LLMs) can be used to manipulate, analyze, and generate text-based data?",
+    "a": [
+      "LLMs require manual feature extraction to analyze text, making them less efficient than traditional NLP models.",
+      "LLMs rely solely on word frequency to analyze and generate text, which limits their ability to handle complex language tasks.",
+      "LLMs use self-attention to understand and manipulate text context, enabling them to analyze and generate coherent and contextually relevant text.",
+      "LLMs are primarily designed for generating text, with limited capabilities for analyzing or manipulating existing text data."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying an ASR system using NVIDIA Riva in a region with significant dialect variability. What is the most effective approach to ensure the ASR model accurately recognizes speech across different dialects?",
+    "a": [
+      "Use a pre-trained ASR model without any further customization.",
+      "Fine-tune the ASR model separately for each dialect.",
+      "Deploy separate ASR systems for each dialect and select the appropriate one based on user input.",
+      "Train a single ASR model on a combined dataset of all dialects."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "In a scenario where an AI-driven customer support system generates personalized responses by analyzing text, identifying the sentiment, and generating a corresponding audio reply with appropriate tone, which combination of AI models would most likely be required to achieve this functionality?",
+    "a": [
+      "RNN for text analysis, sentiment analysis using a rule-based system, and a simple convolutional model for audio synthesis.",
+      "LSTM for text processing, BERT for sentiment analysis, and a VAE for audio generation.",
+      "Transformer-based model for text, sentiment analysis using LSTM, and a GAN for audio generation.",
+      "Transformer-based model for text analysis, sentiment analysis using BERT, and a WaveNet model for generating the audio reply."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are developing a customer service chatbot using Rapid Application Development with a focus on generating unbounded conversational responses. Which type of LLM model should you employ to ensure the chatbot can produce coherent and contextually appropriate responses?",
+    "a": [
+      "Use an encoder-only model like BERT to handle unbounded conversations.",
+      "Use a GAN (Generative Adversarial Network) to generate conversational responses.",
+      "Use a decoder-only model like GPT to generate conversational responses.",
+      "Use a sequence-to-sequence model like T5 for generating conversations."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are using a multimodal AI model to perform sentiment analysis on customer feedback, which includes both text and video data. To make the model's predictions more interpretable, you want to provide explanations about which specific aspects of the text or video contributed to the sentiment classification. Which technique would be most effective in achieving this?",
+    "a": [
+      "Apply dimensionality reduction techniques like PCA to the multimodal data to make the model simpler and more interpretable.",
+      "Visualize the confusion matrix to understand where the model is making errors and why.",
+      "Train the model only on the text data, as video data is harder to interpret.",
+      "Use attention mechanisms in the model to highlight important words in the text and key frames in the video."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with developing a generative AI chatbot that can understand and generate human-like responses in multiple languages, while also interpreting context from previous interactions. Which aspect of transformer-based models makes them particularly well-suited for this task?",
+    "a": [
+      "The ability to process sequential data one word at a time.",
+      "The requirement of large labeled datasets for effective learning.",
+      "The use of convolutional layers for handling large amounts of data.",
+      "The self-attention mechanism that allows the model to focus on different parts of the input data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are part of a team developing a customer service chatbot that uses a multimodal generative AI model to handle text, images, and voice inputs. During the testing phase, the chatbot often generates irrelevant or misleading responses when dealing with complex, multimodal queries that involve both text and images. What is the most critical step to improve the chatbot's response accuracy when handling complex, multimodal queries?",
+    "a": [
+      "Implementing a context-aware mechanism",
+      "Simplifying the model architecture",
+      "Enhancing the visual data quality",
+      "Increasing the number of training examples"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "When designing a generative AI system, which of the following practices is most aligned with creating an energy-conscious and trustworthy AI system?",
+    "a": [
+      "Training the model on as much data as possible to maximize accuracy.",
+      "Adding more layers to the model to improve its generative capabilities.",
+      "Regularly updating the model with the latest data.",
+      "Using a lightweight model architecture that balances performance and energy efficiency."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are monitoring the functioning of data collection processes for a multimodal AI system that integrates both visual and textual data from social media platforms. Recently, you observed that the system's performance in recognizing sentiment in text and matching it with corresponding images has degraded. What is the most likely cause of this degradation in performance?",
+    "a": [
+      "The visual dataset contains images with a significant increase in noise.",
+      "The text data contains an increasing number of misspellings and abbreviations.",
+      "The images in the dataset are now primarily monochrome.",
+      "The system's hardware experienced a temporary failure, causing a loss of recent data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with building a multimodal AI system that generates descriptive text for images. You decide to use transfer learning, leveraging a pre-trained image model and a pre-trained language model. After initial training, you find that the model is generating high-quality descriptions for common objects but struggles with rare or less frequent items. How should you adjust your transfer learning strategy to improve the model's performance on these rare items?",
+    "a": [
+      "Switch to a different pre-trained image model that was trained on a more diverse dataset.",
+      "Reduce the learning rate for both the image and text models during fine-tuning.",
+      "Increase the number of epochs during fine-tuning on the entire dataset.",
+      "Use data augmentation techniques to artificially increase the frequency of rare items in the training data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are part of a team developing a multimodal AI application that integrates text, image, and speech data. To ensure the quality and reliability of the software, you decide to implement a code review process before merging new features into the main branch. During a review, a team member notices that the code for handling image data does not include error handling for invalid or corrupt images. What is the best practice you should follow in this scenario?",
+    "a": [
+      "Ignore the error and assume the data pipeline will only handle valid images.",
+      "Implement a try-catch block to handle the error, log it, and skip processing the invalid image.",
+      "Log the error but proceed with processing the invalid image data.",
+      "Request that the input data is cleaned manually before being fed into the system."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a document classification system that needs to categorize large volumes of text into predefined categories. The system must handle unseen categories using a zero-shot classification approach. Your team decides to use a pre-trained encoder model from HuggingFace for this purpose. Which approach should your team take to implement zero-shot classification efficiently using an encoder model?",
+    "a": [
+      "Utilize the AutoModel class with a tokenizer and implement custom code for zero-shot classification.",
+      "Use the AutoModelForSequenceClassification class to directly load an encoder model and fine-tune it for zero-shot classification.",
+      "Use the transformers.Pipeline class with the zero-shot-classification task to load and apply an encoder model from HuggingFace.",
+      "Load an encoder model using AutoModelForSeq2SeqLM and adapt it for zero-shot classification."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "In a scenario where an AI system is used to generate photorealistic images of outdoor landscapes for use in virtual reality (VR) environments, how can the denoising diffusion process be applied to ensure that the generated images are both high quality and free from unwanted noise?",
+    "a": [
+      "Use a pre-trained GAN model for image generation and then apply a standard denoising algorithm to the result.",
+      "Use the denoising diffusion process only at the start of the image generation to set a noise-free initial state.",
+      "Apply the denoising diffusion process only after the image has been fully generated to remove any remaining noise.",
+      "Apply the denoising diffusion process iteratively during image generation, gradually refining details and reducing noise at each step."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal AI tool that generates product descriptions for an e-commerce platform. The initial outputs are generic and do not highlight the unique features of each product. How can you use prompt engineering to ensure that the generated descriptions are more detailed and focus on the product's unique selling points?",
+    "a": [
+      "Use a prompt like \"Describe this product.\"",
+      "Use a prompt that is intentionally vague to allow for more creative interpretations.",
+      "Use a prompt that asks the model to generate multiple descriptions for the same product to provide variety.",
+      "Include specific product features and desired highlights in the prompt, such as \"Generate a detailed product description that emphasizes the product's water-resistant material and ergonomic design.\""
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You have completed an analysis of customer purchasing behavior and need to present your findings to a non-technical audience. The analysis revealed that customer age, income, and product preferences are strongly correlated with purchase frequency. Which visualization would be most effective in conveying these relationships to your audience?",
+    "a": [
+      "Use a scatter plot matrix to show the pairwise relationships between age, income, and purchase frequency",
+      "Create a pie chart for each variable showing its distribution",
+      "Create a box plot for each variable to show their statistical distribution",
+      "Design a bubble chart where each bubble's size represents purchase frequency, with age on one axis and income on the other"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following is the primary reason for using dropout in neural networks?",
+    "a": [
+      "To reduce the size of the neural network by removing neurons permanently.",
+      "To ensure the model is trained on only the most relevant data by discarding noise.",
+      "To introduce randomness in the network to prevent overfitting.",
+      "To accelerate the training process by skipping certain layers."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "While training a multimodal neural network that integrates audio and visual data for speech recognition, you observe frequent oscillations in the loss function, particularly during the fusion of modalities. Which approach is most likely to improve the stability of the training process?",
+    "a": [
+      "Use a smaller batch size to stabilize gradients",
+      "Apply gradient clipping across all layers",
+      "Train the audio and visual streams separately with independent loss functions",
+      "Normalize only the visual input data"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You're developing a multimodal AI system that can analyze customer support chats, identify product issues, and generate visual representations of the problem based on text input. To ensure the AI properly handles ambiguous requests, what key component should you include in your pipeline?",
+    "a": [
+      "ASR (Automatic Speech Recognition) Model",
+      "Anomaly Detection Module",
+      "Contextual NLP Model",
+      "Text-to-Image Synthesis Model"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are analyzing the results of a multimodal AI experiment that integrates text, audio, and video data. The goal is to identify how each modality contributes to the final model accuracy. Which approach would best allow you to identify relationships and trends between the different modalities and their impact on accuracy?",
+    "a": [
+      "Perform a correlation analysis between each modality and the accuracy score.",
+      "Create a pie chart showing the proportion of data from each modality.",
+      "Use a confusion matrix to compare the performance of each modality.",
+      "Apply a PCA (Principal Component Analysis) to reduce the dimensionality of the data."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal AI system that uses spaCy for natural language processing, NumPy for numerical data manipulation, and Keras for building a neural network model. The system is designed to predict customer churn based on both textual feedback and numerical data such as usage statistics. After training, you notice that the model performs well on the numerical data but struggles with predictions based on text data. What is the most likely cause of the poor performance on text-based predictions?",
+    "a": [
+      "The NumPy arrays for numerical data are not properly normalized before feeding into the model.",
+      "The spaCy model is using an inappropriate language model, leading to poor feature extraction from text data.",
+      "The dropout rate in the Keras model is set too low, resulting in poor generalization.",
+      "The Keras model is using a too complex architecture, causing overfitting to the training data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are collaborating with a client on a multimodal generative AI project. The client is concerned about the progress of the project, specifically regarding the integration of the AI model with their existing systems. They also want to ensure the model's outputs align with their business objectives. Which two actions should you take to address the client's concerns effectively? (Select two)",
+    "a": [
+      "Schedule regular progress meetings to update the client and gather feedback.",
+      "Limit communication with the client to avoid scope creep and delays.",
+      "Use the client's feedback only after deployment to make adjustments in the post-production phase.",
+      "Collaborate with the client's IT team to ensure seamless integration with existing systems.",
+      "Focus on completing the model training before discussing integration details with the client."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal AI system for a research institution that needs to analyze large datasets of satellite images (image data) and corresponding meteorological data (text and numerical data) to predict weather patterns. The system must process these datasets efficiently and provide accurate predictions in a timely manner. What hardware and software configuration would best meet these requirements?",
+    "a": [
+      "Implement a single-core CPU for all processing tasks, with a traditional HDD for storage and a flat file system for data management",
+      "Apply an FPGA for image processing, a high-end CPU for text analysis, and a relational database for storing meteorological data",
+      "Use a cloud-based GPU for image processing, a low-power CPU for numerical data analysis, and cloud storage for all data",
+      "Use a GPU with large VRAM for image processing, a multi-core CPU for text and numerical data analysis, and an SSD for fast data access"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with creating a predictive model for urban planning, using a combination of text data from city reports, geospatial data from city maps, and time-series data on traffic patterns. You discover that the geospatial data is incomplete due to outdated maps, and the text data contains inconsistencies in terminology. What strategy should you employ to ensure a reliable integration of these multimodal datasets?",
+    "a": [
+      "Remove inconsistencies in the text data and replace missing geospatial data with text descriptions.",
+      "Update the geospatial data with estimations based on time-series data and standardize the terminology in the text data.",
+      "Ignore the outdated geospatial data and focus on the time-series and text data.",
+      "Fill missing geospatial data with average values from similar locations and manually curate the text data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which ethical principle is essential in ensuring that an AI system's decision-making process is consistent with societal values and norms?",
+    "a": [
+      "Efficiency, to maximize the speed and productivity of AI systems.",
+      "Cost-effectiveness, to ensure the AI system remains affordable.",
+      "Complexity, to handle more nuanced decision-making processes.",
+      "Fairness, to prevent discrimination and ensure equitable outcomes across different user groups."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a computer vision-based industrial inspection system for detecting microscopic cracks in metal surfaces. Your model pipeline includes XGBoost for classification, autoencoders for anomaly detection, and GANs for generating synthetic images. During the evaluation phase, you notice that the model performs well on synthetic images generated by the GAN but struggles with real-world images, particularly in identifying cracks under varied lighting conditions. What would be the best approach to improve the model's performance on real-world data?",
+    "a": [
+      "Increase the complexity of the XGBoost model by adding more decision trees.",
+      "Use data augmentation techniques on the real-world dataset to simulate different lighting conditions.",
+      "Fine-tune the GAN to generate synthetic images that mimic the varied lighting conditions found in real-world images.",
+      "Adjust the model's thresholds to increase sensitivity to minor variations in the image."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following emerging technologies is most likely to enhance the performance of multimodal AI systems by improving the integration of diverse data types?",
+    "a": [
+      "Federated learning",
+      "Quantum computing",
+      "Reinforcement learning",
+      "Self-supervised learning"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During an experiment comparing several multimodal AI model architectures, you observe that one model performs significantly better on image and text data but poorly on audio data. What should be your primary focus in interpreting these results to improve the model's overall performance?",
+    "a": [
+      "Reduce the number of parameters in the text and image processing layers.",
+      "Remove the audio modality from the model to simplify training.",
+      "Analyze the audio data preprocessing steps for potential improvements.",
+      "Increase the learning rate for the audio processing layers."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A startup needs to develop a real-time language translation application that can handle multiple languages and dialects. They want to leverage an LLM to speed up the development process. What approach should they take to rapidly develop and deploy this application?",
+    "a": [
+      "Use a rule-based system to handle dialects and an LLM for standard language translation, ensuring comprehensive coverage.",
+      "Develop separate LLMs for each language and dialect, training each from scratch to ensure the highest accuracy.",
+      "Deploy an off-the-shelf LLM without any fine-tuning, relying on its general capabilities to handle all translation tasks.",
+      "Fine-tune a multilingual LLM on specific language pairs and dialects relevant to the target user base, allowing for rapid deployment with high accuracy."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A company wants to implement a generative AI system that can create text and images based on user inputs. The system needs to efficiently handle multimodal inputs (text and images) and generate high-quality outputs for both. Which of the following approaches is the most effective for handling multimodal data in this scenario?",
+    "a": [
+      "Train a single image-based model and use it for generating text captions.",
+      "Fine-tune a pre-trained language model only for text generation and use it to guide image generation.",
+      "Train a single multimodal model that processes both text and images together.",
+      "Use separate models for text and image generation and combine their outputs."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing an end-to-end customer service chatbot for a retail company using NVIDIA Riva. The chatbot pipeline includes ASR to transcribe customer speech, NLP to interpret and respond to queries, and TTS to generate spoken responses. What is the best approach to ensure that the chatbot provides accurate and contextually appropriate responses?",
+    "a": [
+      "Train the ASR, NLP, and TTS models separately on unrelated datasets.",
+      "Deploy the TTS model with a focus on speed rather than naturalness to ensure fast responses.",
+      "Use a general-purpose ASR model without domain-specific fine-tuning.",
+      "Fine-tune the NLP model on a dataset containing typical retail customer inquiries."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal neural network that uses images and structured data to predict real estate prices. The model is deep and includes several parallel branches for different data types. To improve training efficiency and model performance, you decide to use residual connections. Which of the following scenarios best illustrates the advantage of using residual connections in this model?",
+    "a": [
+      "Residual connections allow each branch to learn independently without interference",
+      "Residual connections enable easier optimization by allowing gradients to bypass certain layers",
+      "Residual connections remove the need for cross-modal data integration",
+      "Residual connections reduce the model's depth, making it simpler"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your team is tasked with developing an AI model that can generate comprehensive news reports by analyzing multimodal inputs, including text from articles, images, and video footage. The model must not only produce text summaries but also generate accompanying images and select relevant video clips. Which model architecture would be most suitable for generating such comprehensive multimodal reports?",
+    "a": [
+      "Long Short-Term Memory (LSTM)",
+      "Multimodal Variational Autoencoder (VAE)",
+      "Generative Adversarial Network (GAN)",
+      "K-Nearest Neighbors (KNN)"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You need to customize a TTS model using NVIDIA Riva to generate speech that conveys different emotions, such as happiness, sadness, and anger. Which strategy is most effective for this task?",
+    "a": [
+      "Fine-tune the TTS model on a dataset labeled with different emotional states.",
+      "Use a standard TTS model and manually adjust the pitch and speed for different emotions.",
+      "Use transfer learning from an ASR model trained on emotional speech.",
+      "Incorporate more training data without focusing on emotional content."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which approach is most effective in minimizing bias when developing a generative AI system that analyzes both text and image data for content moderation on a global platform?",
+    "a": [
+      "Prioritizing the moderation of content based on the language with the most users on the platform.",
+      "Using only the most popular content for training to ensure the system reflects mainstream views.",
+      "Regularly retraining the AI model with diverse and updated datasets from various cultural and geographical backgrounds.",
+      "Allowing the AI system to self-learn from user interactions without human oversight."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are building a multimodal AI system that needs to analyze text data from customer reviews, extract key phrases, and then correlate them with corresponding product images. The system should efficiently handle large datasets and provide accurate insights. Which combination of Python tools and libraries would be most appropriate for this task?",
+    "a": [
+      "Use spaCy for text processing, NumPy for handling numerical data, and a traditional SQL database for storing the data",
+      "Use NLTK for text processing, Matplotlib for visualizing correlations, and a relational database for storing the data",
+      "Apply NumPy for both text processing and numerical data handling, and store data in a NoSQL database",
+      "Implement spaCy for text processing, store image embeddings in a vector database, and use NumPy for numerical operations"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a generative AI model that processes both text and images to create descriptive captions for a photo-sharing app. The model is struggling to correctly caption images with complex backgrounds and multiple objects. Which approach is most effective for improving the model's performance in this multimodal scenario?",
+    "a": [
+      "Enhance the model by using a Transformer-based architecture that processes text and image data jointly",
+      "Increase the number of convolutional layers in the model",
+      "Use a larger text-only dataset for training",
+      "Train the model using only high-resolution images"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are designing a multimodal AI system for a smart city project. The system must process live video feeds from multiple cameras across the city to monitor traffic, while simultaneously analyzing sensor data from IoT devices to detect environmental changes. The system needs to provide real-time insights and alerts with minimal latency. Which combination of hardware and software components would best support this application?",
+    "a": [
+      "Use an integrated graphics CPU for video processing, with network-attached storage (NAS) and a relational database for data management",
+      "Use a high-end CPU for all processing tasks, with an SSD for storage and a centralized database",
+      "Use an edge GPU for video processing, a multi-core CPU for sensor data analysis, and a distributed database for storing and retrieving data",
+      "Implement a cloud-based GPU for video processing, a single-core CPU for sensor data, and an HDD for storage"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are working with a multimodal dataset for a healthcare application, which includes MRI images, patient medical records (text), and real-time sensor data (numerical). Upon inspection, you find that some MRI images have artifacts, the text data contains numerous typos, and the sensor data has occasional spikes that seem unrealistic. What is the most effective approach to address these quality issues before model training?",
+    "a": [
+      "Discard any data sample that contains an issue in any modality to ensure only high-quality data is used.",
+      "Apply image denoising techniques to remove artifacts from MRI images, perform text cleaning to correct typos, and use outlier detection to handle sensor data spikes.",
+      "Focus solely on improving the MRI image quality, as it is the most critical modality in healthcare applications.",
+      "Train separate models for each modality and then ensemble the results to overcome individual data quality issues."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following is a typical application of generative AI in the field of healthcare?",
+    "a": [
+      "Predicting patient outcomes based on historical health data.",
+      "Organizing and retrieving patient records using natural language processing.",
+      "Generating synthetic medical data to augment real datasets for research and training purposes.",
+      "Diagnosing diseases by analyzing medical images with deep learning."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which technique would most effectively speed up the deployment of an LLM-based application while ensuring that it performs well across a variety of tasks?",
+    "a": [
+      "Using transfer learning to apply a smaller LLM trained on one specific task to all other tasks.",
+      "Rewriting the LLM's architecture to make it more efficient before training it from scratch.",
+      "Manually coding responses for the LLM to handle different scenarios, ensuring accuracy for each task.",
+      "Fine-tuning the LLM on multiple relevant datasets simultaneously to quickly adapt it to a wide range of tasks."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a generative AI system that creates detailed architectural designs from textual descriptions. The system uses a U-Net architecture to refine generated images. After integrating the CLIP model to better align text prompts with the generated images, the outputs still lack the desired level of detail and accuracy. Under time constraints, what is the best approach to improve the text-to-image alignment and the overall quality of the generated designs?",
+    "a": [
+      "Switch from U-Net to a GAN-based architecture for better image generation.",
+      "Refine the text prompts using prompt engineering techniques to be more specific and detailed.",
+      "Increase the size of the U-Net architecture to add more layers for finer details.",
+      "Utilize the NVIDIA Triton Inference Server to speed up the generation process."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "In a project to develop a multimodal AI model that combines visual and textual data to improve e-commerce recommendations, you are tasked with selecting an optimal fusion strategy. The goal is to analyze both the product images and customer reviews to generate personalized product recommendations. Which fusion strategy is most appropriate for integrating visual and textual features in a manner that captures cross-modal dependencies effectively?",
+    "a": [
+      "Hierarchical Fusion with Attention Layers",
+      "Early Fusion by Concatenating Raw Features",
+      "Late Fusion using Separate Models",
+      "Parallel Fusion with Hard Voting"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following is a fundamental technique required to train a deep learning model effectively, and what is a primary challenge associated with it?",
+    "a": [
+      "Selecting the right activation function; Challenge: Ensuring low computational cost",
+      "Using large datasets; Challenge: Managing overfitting",
+      "Using transfer learning; Challenge: Avoiding data leakage",
+      "Choosing the correct optimizer; Challenge: Reducing bias in the model"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with generating high-quality images from English text prompts using a diffusion model guided by CLIP. If the generated images are not accurately representing the described objects in the prompts, which modification is most likely to improve the accuracy of object representation?",
+    "a": [
+      "Use a more complex text tokenization method",
+      "Switch to a different diffusion model with fewer parameters",
+      "Enhance the CLIP guidance by increasing the weight of the text-image alignment loss",
+      "Increase the learning rate during training"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A financial services company is deploying a multimodal AI system to detect fraudulent transactions by analyzing text inputs from customer communications, transaction logs, and video footage from ATMs. The system is highly accurate during testing but performs poorly during real-time deployment, especially during peak transaction hours. Additionally, the system's resource usage spikes during these periods, causing delays and increasing operational costs. What is the most likely reason for the system's poor real-time performance and high resource usage during peak hours?",
+    "a": [
+      "The text processing model is not optimized for real-time analysis.",
+      "The video analysis model is overfitting to the training data.",
+      "The system's models are running concurrently without any scheduling or prioritization mechanism.",
+      "The system was not tested with realistic data during development."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "After deploying a generative AI model into the client's production environment, the client reports that the model's outputs are not aligning with their business objectives. What is the best course of action to resolve this issue while maintaining client trust and satisfaction?",
+    "a": [
+      "Initiate a post-deployment review with the client to realign on goals and model performance",
+      "Increase the frequency of progress reports",
+      "Rollback to the previous system and discontinue the AI model",
+      "Modify the AI model independently based on your interpretation of the objectives"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are working on a multimodal emotion recognition system that uses both audio and video inputs. The model is trained to predict emotions such as happiness, sadness, and anger. During training, you observe that the model performs well on video data but poorly on audio data, leading to an overall decline in prediction accuracy. Which approach should you take to better balance the contributions of both modalities?",
+    "a": [
+      "Implement a multimodal attention mechanism in the loss function",
+      "Use a joint loss function that incorporates both audio and video losses equally",
+      "Apply a margin-based loss to the video modality",
+      "Use a single loss function focused only on the dominant modality"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with deploying a multimodal generative AI model in a production environment where the model processes both text and images to generate interactive content. The model is performing well in a controlled environment but exhibits unexpected latency and performance issues in production. What could be a primary cause of these issues?",
+    "a": [
+      "Improper Hardware Utilization",
+      "Inefficient Model Architecture",
+      "Network Bottlenecks",
+      "Inadequate Model Training Data"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You have deployed a multimodal AI model that processes both video and audio data to generate real-time subtitles for videos. During user testing, it is observed that the generated subtitles sometimes lag behind the video or appear before the corresponding audio is played. What could be causing this issue? (Select two)",
+    "a": [
+      "The model's input data streams are not synchronized.",
+      "The model was trained with different batch sizes for video and audio data.",
+      "The model's inference time is inconsistent.",
+      "The model was trained with an insufficient amount of video data.",
+      "The model's architecture doesn't support real-time processing."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are optimizing a multimodal AI model used for detecting fraudulent financial transactions. The model combines text analysis of transaction descriptions with numerical data analysis. After initial deployment, you notice the model is consuming more computational resources than expected. Which of the following strategies would most effectively reduce computational overhead while maintaining the model's trustworthiness and accuracy?",
+    "a": [
+      "Use a less complex model architecture, even if it slightly reduces accuracy.",
+      "Implement unsupervised training methods to reduce the need for labeled data.",
+      "Increase the size of the training dataset to include more diverse examples.",
+      "Fine-tune the model's hyperparameters, focusing on reducing unnecessary complexity."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with customizing an LLM to process and generate outputs based on both tabular data (e.g., spreadsheets) and textual reports. The system needs to interpret these diverse data types and produce coherent analyses efficiently. Which approach is most appropriate for this task?",
+    "a": [
+      "Fine-tune a text-based LLM and manually encode tabular data into textual descriptions.",
+      "Ignore tabular data and focus on generating insights solely from textual inputs.",
+      "Train a separate LLM for text and a different model for tabular data, combining their results.",
+      "Use a multimodal model that is pre-trained to handle both tabular and textual data together."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a generative AI model for disaster response, which integrates real-time data from social media (text), satellite imagery, and audio recordings from emergency calls. You find that some satellite images are missing, and many audio recordings contain background noise, making it difficult to extract useful information. What is the best approach to handle the missing and noisy data in this multimodal context?",
+    "a": [
+      "Replace missing satellite images with text descriptions from social media and ignore the noisy audio data.",
+      "Impute missing satellite images using generative models and apply noise reduction techniques to the audio data.",
+      "Use a deep learning model that automatically ignores missing satellite images and filters out noise in the audio.",
+      "Remove all data points with missing images and noisy audio."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are designing a multimodal AI system for a medical imaging application that needs to generate detailed reports based on X-ray images. The system must handle a wide range of medical conditions, and the reports must be accurate and comprehensive, including potential diagnoses, treatment options, and follow-up recommendations. Additionally, the system must prioritize the generation of reports for more critical cases. Which approach would be the most effective in ensuring that the system prioritizes critical cases while generating accurate and comprehensive reports?",
+    "a": [
+      "Implement a two-stage model where the first stage classifies the urgency level, and the second stage generates the report based on the urgency.",
+      "Use reinforcement learning with a reward function that emphasizes the accuracy of the diagnosis.",
+      "Use a pre-trained language model without any additional fine-tuning, as it can generalize to any medical condition.",
+      "Fine-tune the model on a dataset with equal representation of all medical conditions."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following best describes the role of the denoising diffusion process in enhancing the quality of images generated by diffusion models?",
+    "a": [
+      "The denoising diffusion process iteratively refines the image by reducing noise and enhancing details over multiple steps, leading to higher quality outputs.",
+      "The denoising diffusion process relies on pre-generated noise patterns to create detailed images.",
+      "The denoising diffusion process applies a single pass of noise reduction to the final image, enhancing sharpness and clarity.",
+      "The denoising diffusion process is used only at the beginning of image generation to set an initial low-noise state."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with designing prompts for a multimodal generative AI model that generates both text descriptions and corresponding images based on user inputs. However, you notice that the generated images often do not accurately reflect the text descriptions provided by the model. What is the most effective prompt engineering strategy to ensure the generated images better align with the text descriptions?",
+    "a": [
+      "Focus solely on the text without considering the image generation",
+      "Include explicit, detailed instructions in the prompt",
+      "Randomly vary the prompts to encourage creativity",
+      "Use shorter, concise prompts to avoid overloading the model"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are working on a multimodal AI project where the goal is to create a model that can recognize and describe emotions in video content by analyzing both facial expressions and voice tone. You decide to use transfer learning to fine-tune pre-trained models for both visual and audio data. After initial training, you notice that the model is significantly better at recognizing emotions from facial expressions than from voice tone. What is the most effective strategy to improve the model's performance on voice tone recognition?",
+    "a": [
+      "Combine the audio and visual features earlier in the network to leverage multimodal information.",
+      "Freeze the visual model layers and only fine-tune the audio model further.",
+      "Use a pre-trained model specifically designed for speech emotion recognition as the base for the audio model.",
+      "Increase the learning rate during fine-tuning of the audio model."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are designing a chatbot using a transformer-based LLM that needs to generate natural and contextually appropriate responses during a conversation. What aspect of transformer-based models ensures that the chatbot's responses are coherent and contextually relevant?",
+    "a": [
+      "The use of only the most recent part of the conversation to generate responses.",
+      "The self-attention mechanism that considers all previous parts of the conversation when generating a response.",
+      "The model's ability to memorize common phrases from the training data.",
+      "The use of a fixed response template for consistency."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Which of the following best defines generative AI and explains how it works?",
+    "a": [
+      "Generative AI creates new data by filtering and organizing existing data to extract meaningful patterns.",
+      "Generative AI models are designed to classify and predict outputs based on historical data patterns.",
+      "Generative AI is a type of artificial intelligence that generates new, synthetic data by learning patterns and structures from existing data.",
+      "Generative AI operates by copying and slightly altering existing data to create variations."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "How can transformer-based LLMs be effectively used for text-based data manipulation, and what is a primary challenge associated with this use?",
+    "a": [
+      "They use self-attention mechanisms for context understanding; Challenge: High computational resource requirements",
+      "They utilize decision trees for text classification; Challenge: Poor handling of unstructured text",
+      "They rely on LSTM networks for sequence processing; Challenge: Difficulty in parallelization",
+      "They implement rule-based systems for text generation; Challenge: Lack of flexibility in text manipulation"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal AI system for autonomous vehicles that must process real-time data from various sensors, including cameras, LiDAR, and GPS, to make quick and accurate driving decisions. The system must integrate this diverse data to understand the environment and predict potential hazards. What is the most critical aspect to consider when selecting a model architecture for this multimodal AI system?",
+    "a": [
+      "The model's training speed",
+      "The model's ability to fuse sensor data effectively",
+      "The model's use of attention mechanisms",
+      "The model's ability to handle large datasets"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your company is developing a multimodal AI application that combines text, image, and audio inputs. As part of the rapid development process, you are tasked with integrating a text-to-image model from HuggingFace and experimenting with it to see if it meets your needs. How can you most efficiently pull in and start experimenting with a text-to-image model from HuggingFace using the Transformers API?",
+    "a": [
+      "Use the AutoModelForImageAndText class to load the model and start experimenting.",
+      "Utilize the transformers.Pipeline with the text-to-image task and load the model directly from the HuggingFace repository.",
+      "Download the model's code and modify it to suit the text-to-image task within your application.",
+      "Use the AutoModelForVision class to load the text-to-image model and begin testing."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your team is tasked with developing a multimodal AI system that can generate captions for images and match those captions with relevant background music. The system's effectiveness depends on a well-annotated dataset that links images with appropriate text and audio labels. What is the most important step when defining and annotating this multimedia dataset?",
+    "a": [
+      "Curating a small but highly selective dataset",
+      "Ensuring that the captions accurately describe the image content",
+      "Annotating only the most visually striking images",
+      "Including a wide variety of musical genres"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with writing a Python script that processes both text and image data as input for a multimodal AI system. The system should extract features from the text using a transformer model and from the images using a convolutional neural network (CNN). The processed data is then fused and passed to a classifier. Which steps should you take to correctly implement this process under the supervision of a senior team member? (Select two)",
+    "a": [
+      "Normalize the text data using min-max scaling before inputting it into the transformer model.",
+      "Combine the outputs from the transformer and CNN using a simple concatenation technique before passing it to the classifier.",
+      "Directly input raw images into the classifier without any preprocessing.",
+      "Preprocess the text data by tokenizing and encoding it before feeding it into the transformer model.",
+      "Apply Principal Component Analysis (PCA) to the text data before inputting it into the transformer model."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are developing a multimodal AI model that combines text and video data. You notice that the text data has varying levels of quality and includes multiple languages, while the video data is consistently high-quality but from different domains. Which preprocessing steps should you take to ensure the model can effectively utilize both data types? (Select two)",
+    "a": [
+      "Perform domain adaptation on the video data",
+      "Standardize the frame rate of the video data",
+      "Crop the video data to reduce processing time",
+      "Translate all text data into a single language",
+      "Normalize the text data by converting all text to lowercase"
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with customizing a large language model (LLM) to generate specific content for a specialized domain, but you need to do so with limited computational resources. Which fine-tuning technique would be the most efficient in this context?",
+    "a": [
+      "Full model fine-tuning",
+      "Data augmentation",
+      "Knowledge distillation",
+      "Adapter-based fine-tuning"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are assigned to write a Python module that integrates with an existing AI pipeline, handling multimodal data consisting of video and text. The senior team member instructs you to focus on the feature extraction stage. What should be your primary considerations when developing the feature extraction module? (Select two)",
+    "a": [
+      "Ensure that both text and video features are extracted using models from the same family (e.g., both using transformer models).",
+      "Consider the synchronization of text and video features to maintain temporal alignment.",
+      "Ensure that video frames are extracted and processed individually to capture temporal features using a Recurrent Neural Network (RNN).",
+      "Use a pretrained BERT model to extract contextual embeddings from the text data.",
+      "Directly concatenate the raw text and video data without feature extraction for a simpler pipeline."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "You are training a large generative model for text generation, and your goal is to enhance computational efficiency without compromising the model's output quality. Which approach would be most effective?",
+    "a": [
+      "Using lower learning rates",
+      "Switching to FP16 precision for training",
+      "Increasing the number of training epochs",
+      "Implementing model parallelism"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "In a scenario where you are tasked with generating a coherent product description for an e-commerce platform using a generative AI model, which of the following steps is the most critical to ensure the generated text is both relevant and accurate?",
+    "a": [
+      "Training the model on a large dataset containing generic text from various unrelated domains.",
+      "Allowing the model to generate text without any human oversight or post-processing.",
+      "Fine-tuning the model using a dataset specifically curated from product descriptions within the relevant e-commerce domain.",
+      "Using a transformer-based model without any additional fine-tuning or domain-specific training."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with developing a multimodal AI system for autonomous drones that perform search and rescue operations in remote areas. The system must integrate visual input from cameras with audio signals to locate and identify distressed individuals. Given the energy constraints and the need for real-time decision-making, which approach should you prioritize to optimize the system for both performance and energy efficiency?",
+    "a": [
+      "Increase the resolution of camera inputs to enhance image quality and accuracy.",
+      "Employ a more complex multimodal fusion strategy to improve the integration of audio and visual data.",
+      "Disable the audio processing component to reduce energy consumption.",
+      "Utilize a lightweight model architecture specifically designed for mobile and edge devices."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a generative AI model for a company that specializes in multilingual customer support. The model needs to generate accurate and contextually appropriate responses in multiple languages while maintaining consistency across different cultural contexts. What is the most significant challenge in this scenario?",
+    "a": [
+      "Selecting the right hardware for deployment",
+      "Ensuring compliance with data privacy regulations",
+      "Managing the company's server infrastructure",
+      "Training the model with sufficient multilingual data"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are experimenting with different AI model architectures to determine which one performs best on a multimodal dataset consisting of text and images. After training multiple models, you calculate the accuracy, precision, recall, and F1-score for each model. However, you notice that one model has very high accuracy but significantly lower precision and recall compared to another model. What does this discrepancy most likely indicate?",
+    "a": [
+      "The model with high accuracy is definitely the best model to deploy.",
+      "The model with high accuracy but lower precision and recall might be overfitting to the training data.",
+      "The model with lower precision and recall is overfitting, not the model with high accuracy.",
+      "The model with high accuracy is likely better at handling noisy data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with deploying a multimodal generative AI model that processes both text and images to generate product descriptions for an e-commerce platform. The model is performing well on text data but generating low-quality images. Upon analyzing the model, you discover that the image generation sub-model is underfitting. Which of the following actions is most likely to improve the image quality?",
+    "a": [
+      "Use a larger batch size during training.",
+      "Decrease the learning rate.",
+      "Increase the model's complexity by adding more layers.",
+      "Increase the number of epochs during training."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are developing a multimodal generative AI system that generates realistic video sequences from a combination of text descriptions and images. The goal is to create diverse video content that is visually appealing and contextually accurate. Which data augmentation approach would be most effective in improving the diversity and quality of the generated video sequences?",
+    "a": [
+      "Applying random pixel-level noise to video frames to make the model more robust to variations.",
+      "Augmenting the dataset by adding random, unrelated video clips from different genres.",
+      "Using only text augmentation techniques to generate variations of the input text descriptions.",
+      "Applying image augmentations such as color jitter, flipping, and cropping to individual frames of existing video clips in the dataset."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with deploying a multimodal generative AI system that processes text and images to generate product descriptions for an e-commerce website. The AI model must integrate seamlessly into the existing workflow, which includes a custom-built database, image repository, and a content management system (CMS). What is the most critical consideration to ensure the success of this deployment?",
+    "a": [
+      "Optimizing the AI model's output for SEO to increase product visibility on search engines.",
+      "Integrating the AI model into the CMS via a RESTful API that supports both text and image inputs.",
+      "Guaranteeing the AI model is trained on both text and image datasets relevant to the products sold.",
+      "Ensuring the AI model has access to the internet for real-time data updates."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with optimizing the performance of a multimodal AI model that processes both text and image inputs. The model is showing poor performance in accurately classifying images based on textual descriptions. After reviewing the architecture, you suspect that the issue lies in how the text and image embeddings are being combined. What should be your first step in optimizing the model's performance?",
+    "a": [
+      "Experiment with different methods of embedding fusion (e.g., concatenation, attention-based).",
+      "Reduce the learning rate of the optimizer.",
+      "Increase the size of the text embedding.",
+      "Increase the number of hidden layers in the neural network."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Which of the following statements best describes the primary challenge and opportunity presented by generative AI in content creation for businesses?",
+    "a": [
+      "The challenge is finding enough data; the opportunity is improving operational efficiency.",
+      "The challenge is integrating AI into workflows; the opportunity is reducing manual labor.",
+      "The challenge is producing diverse content quickly; the opportunity is cost reduction.",
+      "The challenge is ethical content creation; the opportunity is enhancing creativity."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a multimodal AI system that integrates text, images, and voice commands to assist in autonomous driving. The system must make real-time decisions based on input from various sensors in different environments. Which strategy best ensures that the AI system remains reliable and trustworthy in diverse driving conditions?",
+    "a": [
+      "Relying solely on data collected from one geographical region to train the AI system.",
+      "Prioritizing the speed of decision-making over the accuracy of sensor interpretation.",
+      "Utilizing NVIDIA's DRIVE platform to simulate and test the AI system in various real-world scenarios before deployment.",
+      "Using a generic AI model without customizing it for different environments."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Which of the following best describes how a pretrained modern LLM can be leveraged to solve various NLP tasks such as token classification, text classification, summarization, and question-answering?",
+    "a": [
+      "Pretrained LLMs are only useful for text generation and cannot be adapted to tasks like token classification or summarization.",
+      "A pretrained LLM can be fine-tuned on specific datasets to perform token classification, text classification, summarization, and question-answering with high accuracy.",
+      "Pretrained LLMs require manual feature engineering to perform tasks such as token classification and summarization.",
+      "A pretrained LLM must be used in conjunction with RNNs to achieve effective text classification and summarization."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You have built an XGBoost-based model to predict failures in an assembly line using time-series sensor data. After deployment, you notice a significant drop in model performance over time. Which strategy is most likely to maintain the model's accuracy?",
+    "a": [
+      "Regularly retrain the model with the most recent data",
+      "Use cross-validation to tune hyperparameters",
+      "Increase the learning rate of the XGBoost model",
+      "Reduce the number of trees in the XGBoost model"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are testing the consistency of a multimodal dataset collected for a smart home system that includes video feeds, audio recordings, and temperature sensor data. You discover that the video and audio were recorded at different times, and the temperature sensor data is missing for several time intervals. What strategy should you use to ensure the data is consistent and suitable for training a multimodal model?",
+    "a": [
+      "Normalize all data to a standard format and combine them without addressing the timing discrepancies.",
+      "Train the model separately on each modality without synchronizing the data to allow the model to learn independently from each source.",
+      "Synchronize the video and audio data by aligning their timestamps and use data interpolation to fill in missing temperature sensor values.",
+      "Use only the complete temperature sensor data and discard any video or audio data that does not have matching timestamps."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "After fine-tuning a large language model (LLM) for a specific business application, which method would be most appropriate to assess whether the fine-tuning has improved the model's performance for the target tasks?",
+    "a": [
+      "Comparing the fine-tuned model's performance on a generic benchmark dataset unrelated to the business application.",
+      "Evaluating the model's performance using a dataset of real-world tasks relevant to the business domain.",
+      "Measuring the model's performance based solely on the speed of text generation after fine-tuning.",
+      "Testing the fine-tuned model on a dataset that only includes examples the model has seen during training."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with building a conversational AI application that requires both Automatic Speech Recognition (ASR) and Text-to-Speech (TTS) functionalities. You decide to customize and deploy these models using NVIDIA Riva. Which of the following steps would be most critical for ensuring that the ASR model performs accurately in your specific domain?",
+    "a": [
+      "Optimize the ASR model for low latency by reducing its accuracy.",
+      "Fine-tune the ASR model on a large, general-purpose speech dataset.",
+      "Deploy the ASR model without customization and rely on Riva's out-of-the-box capabilities.",
+      "Collect and fine-tune the ASR model on a domain-specific speech dataset relevant to your application."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are training a Generative Adversarial Network (GAN) to generate realistic images of human faces. After training, the generator consistently produces images with distorted or unrealistic features. Which of the following techniques is most likely to improve the quality of the generated images?",
+    "a": [
+      "Implement feature matching as a loss function in the generator",
+      "Increase the learning rate for both the generator and discriminator",
+      "Use dropout in the generator during inference",
+      "Use a deeper generator network with more layers"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "What is the primary function of generative AI in the context of multimodal models, and how does it operate?",
+    "a": [
+      "Generative AI creates predictive models by analyzing past data and forecasting future trends.",
+      "Generative AI synthesizes new data across multiple modalities, such as text, images, and audio, by learning from patterns in existing data.",
+      "Generative AI only functions within a single modality, generating new data from text inputs alone.",
+      "Generative AI is mainly used for filtering and organizing data in multimodal systems."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are developing a U-Net model for generating images from pure noise, with the goal of creating high-resolution images of human faces. After training the model, you notice that the generated images are blurry and lack fine details. Which modification to the U-Net architecture or training process is most likely to improve the sharpness and detail of the generated images?",
+    "a": [
+      "Increase the number of downsampling layers in the U-Net architecture.",
+      "Use skip connections between corresponding layers in the encoder and decoder.",
+      "Train the model on a smaller dataset to speed up the training process.",
+      "Reduce the number of convolutional layers to simplify the model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are using CLIP to generate images from English text prompts for a project that involves creating specific product visuals based on detailed descriptions. However, the images generated often fail to accurately capture the specific features described in the text, such as color or object placement. What strategy would best improve the accuracy of the generated images to match the text prompts?",
+    "a": [
+      "Use a larger batch size during training to capture more variations in image-text pairs.",
+      "Fine-tune the CLIP model on a domain-specific dataset where images and text are closely aligned with your project needs.",
+      "Increase the number of words in the text prompt to provide more detail.",
+      "Reduce the diversity of the dataset used to train CLIP to focus on specific types of images."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are working on a generative AI project that involves processing text, image, and audio data simultaneously. However, you notice that the model's performance is inconsistent, particularly when there are discrepancies in data quality across modalities. What is the most effective strategy to address this issue?",
+    "a": [
+      "Increase the model complexity to better handle diverse data inputs.",
+      "Use separate models for each modality and then ensemble their outputs.",
+      "Implement modality-specific preprocessing pipelines to handle inconsistencies.",
+      "Standardize the input size for all modalities before training."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "In a scenario where an AI system is generating a video from text input, which combination of techniques would most likely be used to ensure the generated video accurately reflects the input text, including correct context, object interactions, and background consistency?",
+    "a": [
+      "Transformer-based model for image generation, followed by a simple linear model for video synthesis.",
+      "LSTM for text analysis, followed by a VAE for image synthesis.",
+      "Transformer-based language model for text-to-image generation, followed by a GAN-based video synthesis model.",
+      "CNN for text analysis, followed by an RNN for video generation."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "During the experimentation phase of evaluating a multimodal AI model that processes both images and text, you notice that increasing the complexity of the model architecture does not lead to an improvement in the evaluation metrics (e.g., accuracy, precision, recall). Which of the following is the most likely explanation for this outcome?",
+    "a": [
+      "The model's loss function needs to be more complex to handle the data better.",
+      "The dataset may be too small to benefit from a more complex model.",
+      "The simpler model likely underfits the data, while the complex model overfits it.",
+      "The increase in complexity always leads to better performance if the model is trained for longer periods."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A marketing firm is using a multimodal AI system to generate product descriptions by combining textual data, product images, and customer reviews. The AI model often generates descriptions that are too generic and fail to capture unique product features. The team suspects that the issue lies in the way prompts are designed for the text generation model. Which prompt engineering approach is most likely to improve the specificity and relevance of the generated product descriptions?",
+    "a": [
+      "Including specific keywords related to the product features in the prompt.",
+      "Using a very short and broad prompt to allow the model more creative freedom.",
+      "Instructing the model to generate a general description for any product.",
+      "Asking the model to prioritize customer reviews over product images."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are developing a multimodal AI system that processes video footage along with audio transcripts to identify and categorize different events, such as car accidents and natural disasters. After deploying the system, you observe that it frequently misclassifies scenes where the audio is noisy or contains overlapping speech, leading to incorrect event categorization. What is the most likely cause of the misclassification issue in this multimodal system?",
+    "a": [
+      "The fusion method used for integrating video and audio data is not robust against noisy audio.",
+      "The audio preprocessing pipeline is removing essential background noise.",
+      "The AI system lacks sufficient training data for audio-based event detection.",
+      "The video processing model is not adequately trained on diverse scenes."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You have developed a multimodal AI model that integrates satellite imagery, weather data, and social media posts to predict natural disasters. During testing, you find that the model performs well on historical data but shows significant performance drops on recent data. What is the most likely reason for this drop in accuracy?",
+    "a": [
+      "The satellite imagery quality has deteriorated over time, reducing the model's accuracy.",
+      "The model may be overfitting to the historical data, and not generalizing well to new data.",
+      "The model is inherently unstable, and multimodal inputs make it difficult to maintain accuracy.",
+      "The social media posts are not relevant to predicting natural disasters, causing confusion in the model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You need to deploy an end-to-end conversational AI pipeline on NVIDIA Riva that supports multiple languages. What is the most effective approach to ensure accurate ASR, NLP, and TTS performance across different languages?",
+    "a": [
+      "Deploy separate ASR models for each language but use a common NLP and TTS model.",
+      "Use a multilingual dataset for training the ASR model and apply it to NLP and TTS as well.",
+      "Train a single model that can handle all languages for ASR, NLP, and TTS.",
+      "Fine-tune individual ASR, NLP, and TTS models for each language and deploy them in parallel."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are working on optimizing the performance of a generative AI model used for multimodal content creation. The model currently suffers from high latency and suboptimal accuracy in its outputs. Your senior team member suggests focusing on computational efficiency and model accuracy. Which strategies should you consider implementing? (Select two)",
+    "a": [
+      "Apply mixed precision training to speed up computations without significantly affecting model accuracy.",
+      "Increase the number of layers in the model to capture more complex patterns and improve accuracy.",
+      "Prune the model by removing less important neurons or layers to reduce the model size and inference time.",
+      "Reduce the batch size during training to decrease memory usage and improve training speed.",
+      "Use a simpler optimizer like Stochastic Gradient Descent (SGD) instead of Adam to speed up convergence."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "You are customizing a pretrained multimodal model to create an interactive application that can generate descriptive text from images, transcribe audio, and classify text documents. Which method would best allow you to leverage a single model for these diverse tasks?",
+    "a": [
+      "Use a pretrained multimodal transformer like DALL-E, which can be fine-tuned for text, images, and audio tasks.",
+      "Use an encoder-only model like BERT and extend it to handle image and audio tasks.",
+      "Use a sequence-to-sequence model like T5 and add image and audio processing capabilities.",
+      "Utilize a pretrained multimodal model like Florence that can handle multiple data types and fine-tune it for specific tasks."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a generative AI model in a healthcare application that generates patient reports based on multimodal inputs, including medical images and textual notes. Which method is most effective for ensuring the model generates accurate and contextually appropriate reports?",
+    "a": [
+      "Fine-tuning the model on a domain-specific dataset that includes both medical images and corresponding textual annotations.",
+      "Evaluating the model solely on its ability to generate coherent text, without considering the accuracy of the information.",
+      "Fine-tuning the model with a large dataset of generic text and images unrelated to healthcare.",
+      "Using a general-purpose pre-trained model without any fine-tuning."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with deploying a generative AI model for a video processing application. The model must handle multiple modalities, including text, images, and audio, and the deployment must be optimized for real-time inference in a cloud environment. What is the most critical factor to consider when deploying this generative AI model to meet the requirements of real-time inference?",
+    "a": [
+      "Network bandwidth",
+      "Data storage optimization",
+      "Latency minimization",
+      "Model complexity"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are part of a team that is deploying a multimodal AI system to analyze software architectures and generate detailed reports on whether they meet specified requirements. During the system analysis, the AI correctly identifies most of the system components but fails to detect certain interdependencies between modules, leading to incomplete reports. What is the most effective way to address this issue?",
+    "a": [
+      "Simplify the system architecture to reduce the number of interdependencies",
+      "Increase the training data with examples of complex interdependencies",
+      "Reduce the number of modules analyzed by the AI",
+      "Switch to a different AI model that specializes in single-module analysis"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Which strategy is most effective in designing an energy-efficient and trustworthy multimodal AI system for deployment in a resource-constrained environment?",
+    "a": [
+      "Implementing model compression techniques like pruning and quantization.",
+      "Using ensemble methods to improve accuracy and trustworthiness.",
+      "Running all models at full precision to ensure accuracy and trustworthiness.",
+      "Deploying all models on high-performance cloud servers to ensure maximum processing power."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A research team is building a generative AI system that processes multimodal data, including text, images, and sensor data from IoT devices. The system needs to perform complex data fusion, combining inputs from various modalities into a cohesive output that meets the project's goals. Which two software or hardware components are most essential to efficiently fuse and process multimodal data in this generative AI system? (Select two)",
+    "a": [
+      "Field-Programmable Gate Arrays (FPGAs)",
+      "Neural Network-based Data Fusion Algorithms",
+      "Distributed Computing Framework (e.g., Apache Spark)",
+      "Cloud-based Object Storage",
+      "Unified Memory Architecture (UMA)"
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "You are using a multimodal generative AI model that integrates both text and image inputs to generate detailed product descriptions and corresponding visuals. However, you observe that the generated images are high-quality, but the textual descriptions are vague and lack detail. What could be the primary cause of this issue?",
+    "a": [
+      "The image encoder is not properly aligned with the text encoder.",
+      "The model was not trained for enough epochs.",
+      "The text data used for training was not sufficiently diverse or detailed.",
+      "The learning rate used during training was too high."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are developing a multimodal AI system for content moderation on a social media platform. The system must analyze text, images, and videos to detect inappropriate content such as hate speech, violence, and explicit material. The effectiveness of the system relies heavily on the quality of the labeled dataset used for training. What is the most critical factor to consider when annotating a dataset for this content moderation system?",
+    "a": [
+      "Consistency in labeling across different types of content",
+      "Using automated tools to speed up the annotation process",
+      "Including a wide range of diverse content",
+      "Maximizing the size of the dataset"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "In a scenario where an AI system is designed to automate document processing by classifying, summarizing, and extracting key information from large volumes of legal documents, which combination of techniques leveraging pretrained modern LLMs would be most effective?",
+    "a": [
+      "Use a rule-based system for text classification, followed by a simple RNN for summarization, and a pretrained LLM for question-answering.",
+      "Utilize a pretrained LLM solely for text classification, with separate models for summarization and key information extraction.",
+      "Apply a CNN for text classification, a transformer model for summarization, and a simple linear model for question-answering.",
+      "Use a pretrained LLM for token classification, followed by text summarization, and then apply question-answering for key information extraction."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are optimizing a generative AI model's performance by tuning hyperparameters. Which of the following strategies is most likely to improve the model's training efficiency without compromising its ability to generalize?",
+    "a": [
+      "Reducing the Batch Size",
+      "Increasing the Learning Rate Significantly",
+      "Applying Regularization Techniques",
+      "Using a Lower Precision for Computation"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with building a U-Net model to generate images from pure noise, using it as a type of autoencoder. The goal is to ensure the model can produce high-quality images and effectively handle the transformation from noise to structured output. Which of the following considerations are essential when designing a U-Net model for generating images from pure noise? (Select two)",
+    "a": [
+      "Include skip connections between the encoder and decoder to retain image details.",
+      "Implement batch normalization to stabilize training.",
+      "Focus solely on increasing the depth of the network.",
+      "Employ data augmentation to improve the generalization of the model.",
+      "Use a high learning rate to accelerate convergence."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "Which approach best utilizes NVIDIA technologies to enhance the trustworthiness of an AI system that processes sensitive personal data?",
+    "a": [
+      "Relying on NVIDIA's deep learning frameworks without modifying them to address specific ethical concerns.",
+      "Using NVIDIA's GPUs to maximize processing speed without considering privacy safeguards.",
+      "Ignoring NVIDIA's AI toolkits and focusing solely on third-party solutions for privacy and security.",
+      "Implementing NVIDIA's AI-based differential privacy tools to anonymize data before processing."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A financial institution is deploying a generative AI model to automatically generate personalized investment advice for its clients. The model must account for each client's risk tolerance, investment goals, and current market conditions while remaining compliant with regulatory standards. What is the most significant challenge in this scenario?",
+    "a": [
+      "Optimizing the model for high-frequency trading",
+      "Scaling the model to process millions of transactions per second",
+      "Choosing the right programming language for model development",
+      "Ensuring the model adheres to regulatory compliance"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "During the preprocessing of a large dataset for training a generative AI model, you notice that some numerical features have vastly different scales. What is the best approach to handle this issue before training?",
+    "a": [
+      "Leave the data as is since neural networks can handle different scales inherently.",
+      "Apply logarithmic transformation to all features.",
+      "Standardize all features by subtracting the mean and dividing by the standard deviation.",
+      "Normalize all features to a range between 0 and 1."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are building a conversational AI system using NVIDIA Riva that integrates ASR, NLP, and TTS models. Users are experiencing delays in responses during conversations. What is the most effective approach to minimize latency in this pipeline?",
+    "a": [
+      "Optimize the models for low-latency inference and deploy them on GPUs.",
+      "Increase the model sizes for ASR, NLP, and TTS to improve accuracy.",
+      "Use a batch processing approach to handle multiple requests simultaneously.",
+      "Deploy the ASR, NLP, and TTS models on separate servers to distribute the load."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with developing a generative AI application that creates personalized summaries of articles, integrating both text and visual elements. The application should be capable of understanding the context, extracting relevant information, and generating a concise summary. Which combination of Python libraries and tools would best support the development of this application?",
+    "a": [
+      "Implement spaCy for text processing, TensorFlow for generating summaries, and CSV files for storing embeddings",
+      "Use NLTK for text processing, SQLite for database management, and Scikit-learn for generating summaries",
+      "Use spaCy for text processing, a vector database for storing and retrieving embeddings, and PyTorch for generating summaries",
+      "Utilize NumPy for text processing, OpenCV for visual data processing, and a relational database for storage"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are working on a predictive maintenance system for industrial machinery, using time-series data to predict equipment failures. The dataset contains several features, including temperature, vibration, and operating hours. However, the model's predictions are not accurate, possibly due to the time-dependent nature of the data. What preprocessing step should you take to improve the model's performance?",
+    "a": [
+      "Perform feature engineering to create lagged variables",
+      "Increase the number of training epochs",
+      "Normalize the data across all features",
+      "Switch to a deeper neural network model"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are working with a senior team member to evaluate the scalability of a multimodal AI model that processes text, video, and geospatial data for disaster response. The model needs to provide reliable outputs under varying data loads, but during testing, it shows a significant drop in performance as the volume of data increases, leading to concerns about its scalability. What is the best approach to address the model's scalability issues?",
+    "a": [
+      "Optimize the model's architecture by incorporating techniques like model quantization and pruning.",
+      "Limit the model's input to one modality at a time to manage data load.",
+      "Reduce the amount of data by randomly discarding portions of the input.",
+      "Increase the size of the input batch to maximize GPU utilization."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "In a scenario where you're developing a generative AI model for a company that creates virtual environments, you need to optimize the model's ability to generate high-quality 3D assets. The model frequently produces outputs with distorted textures and unrealistic lighting. Which of the following techniques would best address this issue?",
+    "a": [
+      "Use Generative Adversarial Networks (GANs) to refine the texture mapping.",
+      "Utilize image-to-image translation networks for texture correction.",
+      "Apply reinforcement learning to adjust lighting in the generated assets.",
+      "Increase the model's training data with a focus on higher quality and variety."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are building a multimodal generative model that combines text and visual inputs to create detailed descriptions of images. The model frequently generates descriptions that are textually rich but visually inaccurate. How can you modify the loss function to improve the accuracy of the visual components in the generated descriptions?",
+    "a": [
+      "Increase the weight of the text loss in the combined loss function",
+      "Apply an adversarial loss only to the text generation process",
+      "Use a contrastive loss to maximize the similarity between text and image features",
+      "Add a perceptual loss that compares generated images with reference images"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are part of a team tasked with writing the user manual for a generative AI tool that creates multimodal content, including text, images, and audio. The manual needs to be clear and accessible for both technical and non-technical users. What is the most important factor to consider when writing the section of the manual that explains how to train the model with multimodal data?",
+    "a": [
+      "Outlining the model's performance metrics",
+      "Detailing the underlying algorithms",
+      "Providing clear examples of input data formats",
+      "Listing hardware and software prerequisites"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with creating a multimodal AI model that integrates sensor data (e.g., temperature, humidity) and image data from various sources. The sensor data comes in irregular time intervals, and the image data varies in resolution. Which data preprocessing steps should you prioritize to prepare the data for model training? (Select two)",
+    "a": [
+      "Normalize the sensor data to a common scale",
+      "Downscale all images to the lowest resolution",
+      "Apply histogram equalization to all images",
+      "Remove outliers from the sensor data",
+      "Interpolate missing sensor data to create regular time intervals"
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "You are working on a multimodal AI system that combines textual data and audio recordings to generate transcripts and summaries of meetings. However, the system struggles with accurately summarizing the content when there are multiple speakers or background noise. Which approach would most effectively improve the accuracy and quality of the summaries generated by the system?",
+    "a": [
+      "Apply text-based data augmentation to create more diverse training examples",
+      "Train the model with a larger dataset containing diverse accents and speaking styles",
+      "Increase the number of hidden layers in the neural network to improve model complexity",
+      "Implement speaker diarization to distinguish between different speakers and use noise reduction techniques"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Which statistical method would be most appropriate for evaluating the performance of a multimodal AI pipeline that integrates both textual and visual data to predict customer sentiment?",
+    "a": [
+      "ANOVA (Analysis of Variance)",
+      "T-test",
+      "Cross-validation with multimodal data",
+      "Confusion matrix analysis"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with implementing a multimodal conversational AI system that can generate avatars and respond to user queries in real-time. The system needs to combine speech recognition, text generation, and avatar rendering using NVIDIA's SDKs. After integrating NVIDIA Riva for speech-to-text and NeMo for text processing, the avatar responses are slow, affecting the real-time interaction. Which strategy should you use to optimize the system's performance while maintaining high-quality output?",
+    "a": [
+      "Use NVIDIA Triton Inference Server to manage and optimize the inference processes.",
+      "Use a different text-to-image model instead of NeMo for text processing.",
+      "Switch to a simpler speech-to-text model that operates faster.",
+      "Reduce the complexity of the avatar rendering model to improve response times."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are testing a multimodal AI model designed to analyze social media posts that include text, images, and video. The model outputs a sentiment score for each post. During testing, you notice that the model's sentiment analysis accuracy varies significantly depending on the type of media in the post. What could be contributing to this issue? (Select two)",
+    "a": [
+      "The model's learning rate was too low during training.",
+      "The model's feature extraction process is different for each media type.",
+      "The model was trained with imbalanced datasets across different media types.",
+      "The test data includes posts with varying lengths of text.",
+      "The model was tested with a different sentiment analysis algorithm than it was trained on."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "A healthcare company is developing a generative AI system that can analyze multimodal data, including medical images (X-rays), patient history (text), and lab results (numerical data). The goal is to generate detailed reports that can help doctors make more accurate diagnoses. Which technique is most appropriate for integrating these diverse data types to generate comprehensive diagnostic reports?",
+    "a": [
+      "Use a GAN to generate synthetic data for each modality before analysis",
+      "Rely solely on a Transformer model designed for text data",
+      "Implement a multimodal fusion strategy that combines data representations from CNNs, RNNs, and dense layers",
+      "Use a convolutional neural network (CNN) for all data types"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are managing a production-level conversational AI application deployed with Helm in a Kubernetes cluster. You need to perform a rolling update to the ASR service without causing downtime. What is the best strategy to achieve this?",
+    "a": [
+      "Deploy the updated ASR service as a new Helm release, then manually switch traffic to the new service.",
+      ") Increase the number of replicas before starting the update to ensure availability.",
+      "Disable readiness probes during the update to prevent pods from being marked as unavailable.",
+      "Configure the maxUnavailable and maxSurge parameters in the Helm chart to control the rolling update process."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are using CLIP as part of a pipeline to train a text-to-image diffusion model. The model generates images from text prompts, but the images often lack coherence and do not accurately reflect the complexity of the prompts. How can you leverage CLIP to improve the training process and ensure that the generated images are more aligned with the text prompts?",
+    "a": [
+      "Train the diffusion model independently of CLIP and only use CLIP to evaluate the final outputs.",
+      "Use CLIP to generate initial images and then train the diffusion model to refine these images.",
+      "Reduce the complexity of the text prompts during training to help the model learn faster.",
+      "Employ CLIP to guide the diffusion model during training by matching the generated images with the text prompts and optimizing based on this match."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Which of the following statements best describes the advantages of using TensorFlow over PyTorch in a production environment?",
+    "a": [
+      "TensorFlow's eager execution mode provides faster prototyping compared to PyTorch's dynamic graph.",
+      "TensorFlow offers better support for dynamic computation graphs, making it ideal for tasks where the structure of the model changes frequently during execution.",
+      "TensorFlow has more mature support for deploying models to mobile and edge devices compared to PyTorch.",
+      "TensorFlow requires less code to implement complex models compared to PyTorch."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your team is tasked with integrating a new feature into an existing multimodal AI application that processes text, images, and video. The new feature involves real-time video analysis and reporting. A team member suggests bypassing the existing testing framework for faster deployment, claiming that the feature works perfectly on their local machine. What is the best course of action to ensure high software quality and reliability?",
+    "a": [
+      "Skip testing since the new feature is independent of the existing modules.",
+      "Insist on running the feature through the full suite of automated tests before deployment.",
+      "Integrate the feature into the main branch and rely on users to report any issues.",
+      "Deploy the feature immediately since it works well on the developer's machine."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are designing prompts for a multimodal generative AI model that produces visual art based on detailed text descriptions. However, the model frequently generates images that only partially match the provided descriptions, leading to dissatisfaction among users. What prompt engineering strategy is most likely to improve the alignment between the generated images and the text descriptions?",
+    "a": [
+      "Using vague and open-ended prompts to encourage creativity",
+      "Allowing the model to generate multiple images per prompt",
+      "Reducing the length of the prompt to avoid overwhelming the model",
+      "Incorporating specific keywords and phrases related to visual details"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "A healthcare startup is developing a multimodal AI system to assist in diagnosing diseases by analyzing medical images, patient records, and genomic data. The system performs well during testing but fails to provide accurate diagnoses when deployed in hospitals where genomic data is frequently incomplete or unavailable. What is the most likely reason for the system's poor performance in these real-world settings?",
+    "a": [
+      "The medical images are not being preprocessed correctly.",
+      "The patient records are not synchronized with the genomic data.",
+      "The system is overfitting to the patient records data.",
+      "The multimodal fusion strategy heavily relies on genomic data, leading to failures when it is missing."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a multimodal AI system that generates both text and images based on user input. The system is deployed in a public platform where users can create content freely. Which approach best ensures that the system avoids generating harmful or inappropriate content?",
+    "a": [
+      "Limiting the system's use to a small, selected group of trusted users.",
+      "Regularly updating the model with new data but not reviewing its outputs.",
+      "Implementing a robust filtering system that checks the outputs for harmful content before they are presented to the user.",
+      "Training the model on a large, general dataset without specific filtering."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a multimodal AI system that analyzes patient data, including text, images, and sensor data, to provide personalized treatment recommendations. How can you ensure that the system respects patient privacy while still delivering accurate and effective recommendations?",
+    "a": [
+      "Using patient data without explicit consent to improve the AI model's accuracy.",
+      "Aggregating data from multiple patients without any anonymization to enhance model training.",
+      "Restricting the system's access to data only from patients who have opted in to share their information.",
+      "Anonymizing all patient data before processing it within the AI system."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are optimizing a multimodal AI model that assists radiologists in diagnosing medical conditions by combining image analysis of MRI scans with patient medical history data. The model currently consumes excessive computational resources and sometimes produces inconsistent results. Which optimization strategy would best enhance the model's trustworthiness and reduce its computational burden?",
+    "a": [
+      "Apply transfer learning using a model pre-trained on medical imaging data to fine-tune on your dataset.",
+      "Switch to a different modality and use only text-based patient data for diagnosis.",
+      "Reduce the number of layers in the model to decrease computational requirements.",
+      "Increase the depth of the neural network to capture more complex patterns."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a project where you need to fine-tune a pre-trained large language model using a relatively small dataset specific to your domain. The dataset contains text data with some mislabeled examples. To avoid overfitting and ensure that the model generalizes well, you decide to employ regularization techniques and data augmentation. Which of the following methods would be most effective in this scenario?",
+    "a": [
+      "Dropout and back-translation",
+      "L2 Regularization and synonym replacement",
+      "Cross-entropy loss and random shuffling",
+      "Early stopping and tokenization"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with developing a multimodal AI model that processes both visual and textual data. The goal is to leverage pre-trained models through transfer learning to enhance performance. However, you need to adapt these models to work together effectively in a new task. What strategies should you implement for successful multimodal-specific transfer learning? (Select two)",
+    "a": [
+      "Fine-tune the entire pre-trained visual model without freezing any layers to maximize learning on the new task.",
+      "Apply domain-specific data augmentation techniques to both visual and textual data before fine-tuning.",
+      "Freeze the early layers of the pre-trained models and only fine-tune the later layers specific to the new task.",
+      "Use the same learning rate for both the visual and textual models during fine-tuning.",
+      "Use transfer learning only on the visual model and train the textual model from scratch."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "What is the primary advantage of using the denoising diffusion process during the image generation phase in generative AI models?",
+    "a": [
+      "The denoising diffusion process is a single-step operation that quickly reduces noise in any generated image.",
+      "The denoising diffusion process enhances the color vibrancy of generated images, making them more visually appealing.",
+      "The denoising diffusion process allows for incremental refinement of the image, reducing noise and enhancing details progressively, resulting in higher image quality.",
+      "The denoising diffusion process is only beneficial for removing artifacts after the image is fully generated."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a project that involves training a multimodal AI model combining natural language processing and computer vision to provide real-time captions for live video feeds. However, the captions generated often lag behind the video. Upon investigation, you find that the language model is causing the delay. Which of the following strategies is most likely to reduce the lag and improve synchronization?",
+    "a": [
+      "Reduce the input image resolution.",
+      "Switch to a smaller language model.",
+      "Use a more complex language model.",
+      "Increase the video frame rate."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are deploying a conversational AI system using NVIDIA Riva that integrates ASR, NLP, and TTS models. Users are reporting that the system fails to maintain context in multi-turn conversations, leading to irrelevant responses. What is the most effective approach to address this issue?",
+    "a": [
+      "Use a larger TTS model to generate more natural-sounding speech, which might improve user satisfaction.",
+      "Increase the complexity of the ASR model to capture more detailed input.",
+      "Deploy separate pipelines for each conversation topic to better manage context.",
+      "Implement a stateful NLP model that tracks conversation history across multiple turns."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with developing a generative image model that can transform textual descriptions into highly detailed images. You decide to utilize a neural network architecture specifically designed for such tasks. Which of the following architectures is best suited for this purpose, and why?",
+    "a": [
+      "GAN",
+      "U-Net",
+      "LSTM",
+      "ResNet"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are fine-tuning a pre-trained generative AI model on a highly specialized dataset. To avoid overfitting and ensure the model generalizes well to unseen data, which approach would be most effective?",
+    "a": [
+      "Implementing extensive data augmentation",
+      "Freezing most layers and fine-tuning only the last few layers",
+      "Reducing the size of the training dataset",
+      "Using a high learning rate"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "While deploying a multimodal generative AI model on a cloud-based infrastructure, you notice significant latency issues during the inference phase. The system uses a combination of GPU and CPU resources. Which of the following actions is most likely to reduce inference latency?",
+    "a": [
+      "Deploy the model on a higher-performance GPU.",
+      "Enable mixed-precision training during inference.",
+      "Offload more computations to the CPU.",
+      "Increase the GPU memory allocation."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are analyzing a large dataset of social media interactions to understand sentiment trends over time. The dataset includes timestamps, user demographics, text content, and engagement metrics. What combination of data mining and visualization techniques would be most effective for identifying trends in sentiment across different demographics over time?",
+    "a": [
+      "Use decision trees to categorize sentiment and create bar charts to display results",
+      "Apply sentiment analysis followed by a time series analysis, and visualize with line charts and heatmaps",
+      "Use K-Means clustering on the entire dataset and visualize results with scatter plots",
+      "Perform PCA for dimensionality reduction and plot the principal components"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "A company plans to deploy an LLM-based customer support system across multiple regions, each with unique requirements. What strategy should they use to quickly scale and optimize the LLM for these diverse needs?",
+    "a": [
+      "Train a new LLM from scratch for each region to ensure it fully understands the local context and nuances.",
+      "Implement a rule-based overlay for each region to modify the LLM's responses according to local needs.",
+      "Use the same LLM across all regions without customization, assuming its general training will cover all regional differences.",
+      "Fine-tune the LLM on region-specific datasets to quickly adapt it to the unique language and cultural nuances of each region."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "A retail company is using a generative AI system to create personalized shopping experiences by analyzing customer behavior, product images, and customer reviews. The system must generate recommendations that consider both visual preferences and textual feedback. What is the best strategy for integrating these multimodal inputs to generate personalized product recommendations?",
+    "a": [
+      "Use an unsupervised clustering algorithm to group products based on images alone",
+      "Use a k-nearest neighbors (KNN) algorithm to find similar customers and base recommendations on their preferences",
+      "Use a single LSTM model to process all inputs",
+      "Apply a hybrid model that combines CNNs for image data and Transformers for textual data"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "In transformer-based NLP models, what is the primary role of the \"positional encoding\" component?",
+    "a": [
+      "It adds information about the order of words in a sequence.",
+      "It adjusts the learning rate during training.",
+      "It reduces the dimensionality of the input data.",
+      "It determines the size of the input vocabulary."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a multimodal AI system that integrates image recognition and natural language processing (NLP) to generate product descriptions for an e-commerce platform. During testing, you notice that the system occasionally generates inaccurate or irrelevant descriptions, particularly when processing images with unusual features or text with ambiguous meanings. Which two actions should you take to improve the accuracy and reliability of the system's outputs? (Select two)",
+    "a": [
+      "Incorporate a feedback loop where incorrect outputs are reviewed and used to retrain the model.",
+      "Implement a robust validation set with edge cases that include unusual features and ambiguous text.",
+      "Increase the batch size during training to improve the model's generalization.",
+      "Reduce the model's complexity to simplify the processing of inputs.",
+      "Disable dropout during training to maintain full connectivity in the model."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a multimodal AI model that integrates text and image data to generate medical diagnoses. However, the model's predictions are not easily interpretable by medical professionals. Which strategies should you consider to improve the explainability of the model's predictions? (Select two)",
+    "a": [
+      "Implement attention mechanisms in the model",
+      "Use a more complex model architecture",
+      "Translate the text data into simpler language",
+      "Train the model with more epochs",
+      "Generate saliency maps for the image data"
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "When choosing between TensorFlow and PyTorch for a research project focused on rapid experimentation and prototyping of new neural network architectures, which factor would most likely influence your choice?",
+    "a": [
+      "TensorFlow's popularity in industry for large-scale model deployment.",
+      "PyTorch's seamless integration with NumPy and other Python libraries.",
+      "TensorFlow's extensive deployment capabilities for production environments.",
+      "TensorFlow's support for eager execution mode."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You have a dataset with missing values, outliers, and inconsistencies. Before training a machine learning model, you need to preprocess this data. What is the best approach to handle these issues to ensure the highest data quality and model performance?",
+    "a": [
+      "Impute missing values using k-NN, normalize the data, and correct inconsistencies",
+      "Impute missing values using the mean and remove outliers",
+      "Impute missing values with the median and scale the data",
+      "Ignore missing values, remove outliers, and apply one-hot encoding"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "A company is developing a large language model (LLM) to support a multilingual virtual assistant that can understand and generate responses in multiple languages. The model needs to maintain context across long conversations, manage different language structures, and provide accurate translations. What is the most significant challenge in this scenario when using transformers?",
+    "a": [
+      "Ensuring compatibility with cloud deployment services",
+      "Selecting the right tokenizer for each language",
+      "Optimizing the model for low-latency responses",
+      "Maintaining context over long sequences"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are a junior developer working on a generative AI project under the guidance of senior staff. Your task is to contribute to both the coding of the model and the creation of accompanying documentation that will be used by other developers and end-users. What should be your primary focus when documenting the code for the generative AI model to ensure it is useful for both developers and end-users?",
+    "a": [
+      "Describing the installation steps of all dependencies",
+      "Listing all software versions used during development",
+      "Clearly commenting on each function's purpose and parameters",
+      "Writing detailed explanations of the underlying AI algorithms"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "A financial institution is developing a generative AI model to assess loan applications. The model needs to process multimodal data, including applicant photos, scanned documents, financial history, and text-based references. The goal is to automatically generate a comprehensive risk assessment for each applicant. Which technique would be most effective for accurately integrating and analyzing these multimodal data sources?",
+    "a": [
+      "Use a multimodal neural network that employs CNNs for image data, RNNs for text, and dense layers for numerical data",
+      "Train a large Transformer model solely on the text-based references",
+      "Apply a CNN to all data types to extract relevant features",
+      "Generate synthetic data using GANs to improve the dataset quality"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "Which of the following statements best describes the key advantage of Transformer models over traditional RNN-based models in natural language processing?",
+    "a": [
+      "Transformers rely on recurrent connections, which help in capturing long-term dependencies better than RNNs.",
+      "Transformers can process sequences in parallel, leading to faster training times.",
+      "Transformers are limited to fixed-length sequences, making them less flexible than RNNs.",
+      "Transformers use less memory than RNNs, making them more efficient for training on large datasets."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "In developing a generative AI system, how can you balance the need for data privacy with the importance of obtaining data consent to ensure the ethical use of personal information?",
+    "a": [
+      "Collecting as much data as possible without informing users to improve AI accuracy.",
+      "Prioritizing the AI system's performance over user privacy concerns.",
+      "Ensuring that all data collection processes are transparent and that explicit consent is obtained from users before using their data.",
+      "Using default settings that automatically opt users into data sharing without their explicit knowledge."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with fine-tuning an ASR model for deployment in a noisy industrial environment. Which approach would most effectively improve the model's performance in this scenario?",
+    "a": [
+      "Increase the size of the training dataset by adding more clean speech samples.",
+      "Use data augmentation techniques to artificially introduce noise into the training data.",
+      "Reduce the model complexity by decreasing the number of layers in the neural network.",
+      "Utilize transfer learning with a pre-trained TTS model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with monitoring an AI-driven smart surveillance system that integrates video feeds, audio inputs, and textual metadata from various sensors to detect potential security threats in real-time. After a recent system update, the system's threat detection accuracy has dropped, and it frequently generates false alarms. What is the most likely cause of the increase in false alarms?",
+    "a": [
+      "The system is now using a different algorithm for compressing video data.",
+      "The textual metadata is now being collected from fewer sensors.",
+      "The audio data is not being synchronized correctly with the video feeds.",
+      "The video feeds are being transmitted at a lower resolution."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with optimizing a multimodal AI model that processes both audio and video data. The current implementation experiences significant delays during inference, and the accuracy of the model's predictions is not satisfactory. Under the supervision of a senior team member, what steps should you take to enhance computational efficiency and accuracy? (Select two)",
+    "a": [
+      "Implement early stopping during training to prevent overfitting and reduce training time.",
+      "Utilize model quantization to reduce the precision of model weights and activations for faster inference.",
+      "Increase the sampling rate of the audio data to capture more detailed features, improving accuracy.",
+      "Replace the current optimizer with a simpler one like SGD to reduce computational complexity.",
+      "Increase the resolution of the input video data to capture more details and improve accuracy."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "A utility company is implementing a predictive maintenance system for their power grid using anomaly detection with time-series autoencoders. The system needs to detect anomalies in voltage and current readings to predict potential failures. Given that failure data is extremely limited, which of the following steps is most important when training the autoencoder model?",
+    "a": [
+      "Apply dropout regularization heavily to prevent overfitting on the normal data.",
+      "Train the autoencoder primarily on normal operational data to learn typical patterns.",
+      "Use only the limited failure data to train the autoencoder to focus on recognizing failures.",
+      "Randomly combine normal and failure data to give the autoencoder a balanced view."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with developing a Retrieval-Augmented Generation (RAG) system for a chatbot that helps users troubleshoot technical issues. The chatbot needs to understand queries about a wide range of topics and respond with accurate, contextually relevant information. Which approach would best improve the chatbot's performance in handling diverse queries?",
+    "a": [
+      "Fine-tuning a pre-trained LLM specifically on a technical support knowledge base",
+      "Integrating a domain-specific knowledge graph with the RAG system",
+      "Using a hybrid retrieval model that combines both keyword-based search and semantic search",
+      "Implementing a multi-turn dialogue management system without retrieval"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are managing a multimodal dataset that includes text, image, and sensor data for a smart home system. During preprocessing, you notice that a significant portion of the sensor data is missing, but the text and image data are complete. What is the most effective strategy to handle this missing sensor data without significantly compromising model performance?",
+    "a": [
+      "Remove all samples with missing sensor data to ensure uniformity across the dataset.",
+      "Train separate models for each modality and combine their predictions at the final stage.",
+      "Use data imputation techniques to fill in the missing sensor data based on the available data.",
+      "Ignore the sensor data altogether and train the model only on text and image data."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing an AI-driven recommendation system that must analyze product descriptions (text) and customer-uploaded images to suggest similar products. The system needs to efficiently process large volumes of data and provide accurate recommendations based on both textual and visual content. Which Python tools and libraries would be most appropriate for this task?",
+    "a": [
+      "Implement NLTK for text processing, Matplotlib for image processing, and a relational database for storage",
+      "Utilize TensorFlow for text processing, OpenCV for image processing, and CSV files for storing data",
+      "Apply NumPy for text processing, spaCy for image processing, and a NoSQL database for storage",
+      "Use spaCy for text processing, NumPy for numerical operations, and a vector database to store and retrieve embeddings"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "Which of the following is a fundamental technique required for training deep learning models, and what is the associated challenge?",
+    "a": [
+      "Using batch normalization; Challenge: Reducing computational overhead",
+      "Applying gradient descent; Challenge: Ensuring convergence",
+      "Selecting the appropriate loss function; Challenge: Enhancing model speed",
+      "Utilizing data augmentation; Challenge: Reducing overfitting in small datasets"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are part of a team deploying a multimodal AI model that processes both text and image data to automatically tag content in a large-scale e-commerce platform. During peak usage times, users report slower response times and occasional errors in the tagging process. What could be contributing to these issues? (Select two)",
+    "a": [
+      "The model's computational resources are insufficient during peak times.",
+      "The deployment environment lacks real-time monitoring capabilities.",
+      "The model's load balancing mechanism is not optimized for high traffic.",
+      "The model's image processing module is using outdated algorithms.",
+      "The model was trained on a smaller dataset than required."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a multimodal AI model that uses transaction data, customer profiles, and surveillance video to detect fraudulent activities. The stakeholders are concerned about the explainability of the model's predictions. Which approach would best help in explaining how the model arrives at its decisions?",
+    "a": [
+      "Use a simple decision tree model instead, as it is inherently more interpretable than a multimodal model.",
+      "Implement Layer-wise Relevance Propagation (LRP) to highlight which parts of the transaction data, profile information, and video contribute most to the decision.",
+      "Use the model's accuracy score to justify the predictions, as higher accuracy usually indicates a more reliable model.",
+      "Train separate models on each data modality and compare their outputs to determine which modality is most influential."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working with an AI development team to integrate a multimodal generative AI model into an existing application. The model needs to generate both text and images based on user inputs. However, during the testing phase, the team encounters an issue where the image generation quality significantly degrades when the text prompts are complex. How should the team address this issue?",
+    "a": [
+      "Switch to a text-only generative model",
+      "Fine-tune the model on a more diverse dataset",
+      "Reduce the size of the model to increase speed",
+      "Simplify the text prompts"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "In an industrial setting, you are tasked with developing a computer vision system to detect anomalies in products on a production line. The available dataset consists of both labeled images of defective products and unlabeled images from various stages of production. Which approach would most effectively utilize both types of data to improve anomaly detection?",
+    "a": [
+      "Manually label the remaining unlabeled data to improve the model accuracy.",
+      "Train a semi-supervised learning model using the labeled and unlabeled data.",
+      "Use supervised learning exclusively on the labeled data for accurate results.",
+      "Apply unsupervised learning to cluster the data and identify anomalies."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are assisting in the training of a multimodal model that integrates text and image data to generate captions for images. The senior team member has identified that the model is overfitting the training data, leading to poor generalization on the validation set. What optimization step should you suggest to reduce overfitting while maintaining model accuracy?",
+    "a": [
+      "Use a smaller batch size during training.",
+      "Apply dropout to the fully connected layers of the model.",
+      "Reduce the learning rate to make training more gradual.",
+      "Increase the number of training epochs."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with building and deploying an end-to-end conversational AI pipeline on NVIDIA Riva, including ASR, NLP, and TTS models. To improve the accuracy of the ASR component in noisy environments, which approach would be most effective?",
+    "a": [
+      "Deploying multiple TTS models with varied voices",
+      "Training the ASR model on clean, high-quality audio only",
+      "Implementing a noise-cancellation preprocessing step",
+      "Using a generalized TTS model for voice output"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with improving the performance of a multimodal AI model that processes both audio and text data. The model is currently underperforming in accuracy and takes too long to train. Your senior team member advises tuning hyperparameters to optimize performance. What adjustments should you consider? (Select two)",
+    "a": [
+      "Remove regularization techniques to reduce training time.",
+      "Increase the learning rate to speed up convergence.",
+      "Decrease the batch size to improve model accuracy by providing more frequent updates.",
+      "Use a learning rate scheduler to decrease the learning rate gradually during training.",
+      "Increase the number of epochs to ensure the model fully learns from the data."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "You need to customize a pre-trained large language model (LLM) to answer domain-specific customer inquiries for a financial services company. The company requires the customization process to be efficient in both time and computational resources. Which method should you choose?",
+    "a": [
+      "Utilizing prompt engineering techniques with the pre-trained LLM.",
+      "Fine-tuning the entire LLM on the company's domain-specific data.",
+      "Using a smaller, domain-specific model and merging it with the LLM.",
+      "Applying few-shot learning by providing the model with a few examples of the desired output."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a team developing a multimodal generative AI application that combines text, image, and speech processing. The application must be deployed on edge devices with limited computational resources. You are tasked with optimizing the model to run efficiently on these devices while maintaining high performance. What is the most critical approach to ensure that the multimodal AI model runs efficiently on edge devices?",
+    "a": [
+      "Enhancing the data preprocessing pipeline",
+      "Using cloud-based inference",
+      "Model quantization",
+      "Increasing the model size"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are assisting in the deployment of a multimodal generative AI model that integrates text, image, and audio data for an interactive virtual assistant. During the testing phase, you notice that the model performs well on a small dataset but significantly slows down when processing larger volumes of multimodal data, leading to concerns about scalability. What is the most effective approach to improve the scalability of the model?",
+    "a": [
+      "Reduce the size of the input data by compressing the images and audio files.",
+      "Switch to a simpler model architecture that only processes smaller datasets.",
+      "Optimize the data pipelines and employ model parallelism to handle large-scale multimodal data.",
+      "Increase the computational resources by adding more GPUs to the processing cluster."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "When training a deep learning model for image recognition in a highly imbalanced dataset, where some classes have significantly fewer examples, which data augmentation strategy is most likely to improve the model's accuracy?",
+    "a": [
+      "Applying random noise to images in the majority classes to create more variations.",
+      "Reducing the size of the majority classes to balance the dataset.",
+      "Repeating images from minority classes without any augmentation to match the number of majority class images.",
+      "Using oversampling techniques on the minority classes by generating augmented images through rotations, flips, and color changes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "In the context of natural language processing (NLP), how do transformers contribute to the development of large language models (LLMs), and what is a primary challenge associated with their use?",
+    "a": [
+      "Transformers rely on recursive neural networks; Challenge: Limited to short sequences",
+      "Transformers use self-attention mechanisms; Challenge: High computational resource requirements",
+      "Transformers are based on reinforcement learning; Challenge: Balancing exploration and exploitation",
+      "Transformers use LSTM cells; Challenge: Difficulty in parallelization"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a generative AI system that needs to create text-based narratives based on a sequence of images. Which approach would best handle this multimodal task while ensuring accurate context understanding and efficient processing?",
+    "a": [
+      "Use a ResNet model to encode the images and a BERT model to generate the text.",
+      "Use a Vision Transformer (ViT) to encode the images and a GPT model fine-tuned on narrative generation to generate the text.",
+      "Use a CNN to encode the images and an RNN to generate the text.",
+      "Use a GAN to generate synthetic images and a rule-based system to generate text."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with improving the performance of a generative AI model that has been producing low-quality outputs. After analyzing the model's training process, you notice that the dataset is highly imbalanced, leading to poor generalization. Which of the following actions would most effectively address this issue?",
+    "a": [
+      "Increase the learning rate during training.",
+      "Reduce the model complexity by decreasing the number of layers.",
+      "Use data augmentation techniques to balance the dataset.",
+      "Switch to a different optimizer."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are conducting an experiment to train a generative AI model that requires both speech and image data inputs. After a software update, you notice that the model's ability to generate realistic visual representations from speech inputs has decreased, and there are frequent mismatches between the speech input and generated images. What is the most likely issue with the current setup?",
+    "a": [
+      "The synchronization between the speech and image data streams is misaligned.",
+      "The software update corrupted the image processing library, reducing image quality.",
+      "The model's training process is now using a different loss function.",
+      "The speech data is now being sampled at a lower frequency than before."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with building a multimodal machine learning model that combines text input processed by spaCy and numerical data processed using NumPy. The goal is to predict sales figures based on customer reviews and historical sales data. After implementing and training the model in Keras, you observe that the model consistently underestimates sales when the customer reviews are predominantly positive. What is the most likely reason for this consistent underestimation?",
+    "a": [
+      "The Keras model is using ReLU activation functions, which are not suitable for text data.",
+      "The positive sentiment in the text data is not being captured correctly due to inadequate spaCy sentiment analysis.",
+      "The NumPy operations are leading to overfitting on the numerical data, causing the model to rely less on text data.",
+      "The spaCy text vectors are not properly normalized before being input into the model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are working on a generative AI project that involves both natural language processing (NLP) and computer vision components. During integration testing, you discover that the performance of the application is significantly slower than expected, especially when processing large datasets. You suspect that the issue might be related to inefficient code in the image processing module. Which of the following best practices should be implemented to address this performance issue while ensuring code quality?",
+    "a": [
+      "Refactor the code to reduce complexity and optimize algorithms.",
+      "Increase the computational resources, such as adding more GPUs, to handle the load.",
+      "Reduce the image resolution to decrease processing time.",
+      "Disable certain features in the application to make it run faster."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "The AI development team is working on a multimodal AI system that performs system analysis and automatically generates compliance reports based on specified software requirements. However, during the evaluation phase, the team discovers that the AI often produces reports that miss critical compliance checks, especially when the software involves multi-tiered architectures. What should the team do to improve the accuracy of the compliance reports?",
+    "a": [
+      "Focus the AI on generating reports only for single-tiered architectures",
+      "Use a different AI model trained on general software analysis",
+      "Add more specific compliance criteria to the training data",
+      "Reduce the complexity of the software architectures analyzed"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a multimodal AI system that generates high-resolution images from complex English text prompts. The system must handle a variety of detailed descriptions and produce visually accurate results. What strategies are most effective for optimizing the performance of a text-to-image generation model in handling diverse and detailed English text prompts? (Select two)",
+    "a": [
+      "Incorporate a large and diverse set of image-text pairs for training.",
+      "Use a fixed text-to-image model without fine-tuning.",
+      "Use a transformer-based model for text encoding.",
+      "Implement a separate model for image refinement after initial generation.",
+      "Limit the model's training to simple, short text descriptions."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "set": "Set 6"
+  },
+  {
+    "q": "Which of the following best describes how transformer-based Large Language Models (LLMs) can be utilized to generate human-like text in response to a user query?",
+    "a": [
+      "The model applies a simple recurrent neural network (RNN) to process the input query, one word at a time, to generate the output.",
+      "The model breaks down the user query into individual words, assigns each word a fixed numerical value, and then maps these to a pre-defined response.",
+      "The model uses attention mechanisms to focus on different parts of the input sequence, enabling it to understand context and generate coherent text.",
+      "The model directly translates the input text into a different language using a predefined dictionary, and then translates it back to generate the response."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are developing a multimodal sentiment analysis model that uses both text and image data. During feature engineering, you notice that the text features are highly imbalanced due to the presence of rare words, leading to overfitting. Which technique would best help in reducing this imbalance and improving model performance?",
+    "a": [
+      "Apply dimensionality reduction techniques like PCA on text features",
+      "Increase the size of the text dataset by adding synthetic examples",
+      "Apply one-hot encoding to the text data",
+      "Use term frequency-inverse document frequency (TF-IDF) for text feature extraction"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are designing a multimodal network that integrates video, audio, and sensor data for real-time action recognition in autonomous vehicles. The network is extremely deep to capture complex temporal dependencies, but training is slow and the model struggles with convergence. How can you best leverage residual connections to improve training stability and convergence?",
+    "a": [
+      "Use residual connections only in the final layers of the network",
+      "Apply residual connections throughout the network, especially in the early layers",
+      "Avoid residual connections and reduce the network depth instead",
+      "Implement residual connections only in the audio processing branch"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are training a multimodal model that combines video and text data to automatically generate descriptive summaries of videos. During training, you notice that the model is highly sensitive to the initialization of parameters, leading to inconsistent results between training runs. What is the best approach to ensure more stable training?",
+    "a": [
+      "Use a pre-trained model for the text modality and fine-tune only the video modality",
+      "Apply layer normalization across both modalities",
+      "Increase the number of epochs to allow the model more time to converge",
+      "Randomly shuffle the data during every epoch to improve generalization"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with building a search engine that ranks results based on semantic similarity to a user's query. Your team decides to use an encoder model to generate embeddings for both the query and the documents in the search index. Which method would be most effective for generating embeddings that can be used for semantic search?",
+    "a": [
+      "Load an encoder model with AutoModelForTokenClassification and extract embeddings from the token output.",
+      "Use the AutoModelForSeq2SeqLM class to generate embeddings for the documents and queries.",
+      "Use AutoModelForCausalLM to generate embeddings by extracting the hidden states of the final layer.",
+      "Leverage the transformers.Pipeline with the feature-extraction task to produce embeddings using a pre-trained encoder model."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are part of a team developing a multimodal AI system that recommends music videos based on users' preferences, which include both visual aesthetics and musical genres. The system's success depends on how well the dataset is curated and labeled with both visual and audio features. What is the most important step when curating and labeling the dataset for this recommendation system?",
+    "a": [
+      "Prioritizing high-definition video content",
+      "Using short clips to save on storage space",
+      "Ensuring that both visual and audio elements are accurately labeled",
+      "Selecting only popular music videos for the dataset"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 6"
+  },
+  {
+    "q": "You are tasked with developing a U-Net model to function as an autoencoder, specifically designed for denoising images. During evaluation, the reconstructed images contain visible artifacts and do not fully remove the noise. What adjustment should you make to the U-Net model or training process to improve the quality of the denoised images?",
+    "a": [
+      "Increase the size of the convolutional filters in the encoder.",
+      "Remove the skip connections between the encoder and decoder.",
+      "Train the model for fewer epochs to avoid overfitting.",
+      "Use batch normalization after each convolutional layer."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "Which emerging technology is most likely to significantly enhance the capabilities of multimodal AI systems by enabling better contextual understanding across diverse data types?",
+    "a": [
+      "Generative adversarial networks (GANs)",
+      "Recurrent neural networks (RNNs)",
+      "Graph neural networks (GNNs)",
+      "Blockchain technology"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "A marketing agency is using a transformer-based large language model (LLM) to generate personalized email campaigns for thousands of clients. The model needs to maintain each client's unique tone and style, analyze customer feedback, and suggest improvements for future campaigns. What is the most significant challenge in this scenario when using a transformer-based LLM?",
+    "a": [
+      "Optimizing the model for multilingual email generation",
+      "Training the model with only a small amount of data",
+      "Ensuring the model maintains consistency in tone and style across different clients",
+      "Reducing the computational cost of generating emails"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are testing the robustness of a multimodal AI model designed for autonomous driving, which integrates camera feeds, LiDAR data, and GPS information. During adverse weather conditions, such as heavy rain, the model's accuracy drops significantly. What should be your next step to improve the model's robustness?",
+    "a": [
+      "Focus on optimizing the model for clear weather conditions to ensure high accuracy in most scenarios.",
+      "Remove the GPS information, as it might be confusing the model during adverse weather.",
+      "Simplify the model by using only the camera feeds and LiDAR data for all conditions.",
+      "Increase the size of the training dataset by including more samples with adverse weather conditions."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are tasked with building a text classification model to categorize news articles into various topics. During model evaluation, you notice that the model has high accuracy but low recall. Which technique should you consider to improve recall?",
+    "a": [
+      "Adjust the decision threshold to favor the positive class",
+      "Apply feature scaling using standardization techniques",
+      "Increase the size of the training dataset by generating synthetic samples",
+      "Reduce the number of features using Principal Component Analysis (PCA)"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "When designing a prompt to generate a multimodal AI output that combines detailed textual analysis with visual data interpretation, which of the following strategies is most effective?",
+    "a": [
+      "Using a prompt that instructs the model to focus solely on the textual data.",
+      "Using a general prompt that leaves the model to decide how to integrate the data.",
+      "Creating a prompt that explicitly instructs the model to integrate insights from both textual and visual data to form a cohesive analysis.",
+      "Designing a prompt that equally weights textual and visual data without specifying their interaction."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are comparing several multimodal models to determine the best architecture for predicting user preferences based on text, image, and audio inputs. You notice that one model performs exceptionally well on the training set but poorly on the validation set. Which cross-validation technique should you use to better assess this model's generalization ability?",
+    "a": [
+      "Random Train-Test Split",
+      "Shuffle Split Cross-Validation",
+      "Stratified K-Fold Cross-Validation",
+      "Leave-One-Out Cross-Validation (LOO-CV)"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are designing a summarization tool that leverages multimodal data, including text, images, and videos, for corporate training materials. The tool should provide concise and accurate summaries of complex training sessions. What is the most effective strategy for building this tool?",
+    "a": [
+      "Implement a separate summarization model for each data modality and merge the outputs",
+      "Leverage a multimodal LLM capable of processing and summarizing text, images, and video simultaneously",
+      "A multimodal LLM can integrate information from various sources, providing a more comprehensive and coherent summary.",
+      "Develop a custom rule-based system for each modality to generate summaries"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing content for a multimodal AI model that uses transfer learning to integrate speech and image data. The model needs to perform well in a specialized task, such as generating captions for images based on speech inputs. What steps should you take to optimize the performance of transfer learning in this multimodal context? (Select two)",
+    "a": [
+      "Use a pre-trained speech-to-text model as an intermediary between the speech and image models to improve task-specific learning.",
+      "Use modality-specific loss functions during training to better align the features extracted from each modality.",
+      "Apply transfer learning to the image model only, and train the speech model from scratch to avoid overfitting.",
+      "Avoid using any pre-trained models and start training from scratch to ensure maximum control over the model's learning process.",
+      "Fine-tune the speech model with a high learning rate to speed up adaptation to the new task."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "You are assisting in the development of a new AI-driven content generation tool for marketing teams, which requires integrating a large language model into the existing content management system (CMS). After integration, the model generates content that is technically correct but lacks the brand-specific tone and style required. What is the most effective solution to align the AI-generated content with the brand's tone?",
+    "a": [
+      "Reduce the length of the AI-generated content to focus on accuracy",
+      "Fine-tune the AI model with a corpus of brand-specific content",
+      "Manually edit all AI-generated content before publication",
+      "Switch to a simpler AI model that generates less complex content"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a virtual assistant application that requires real-time speech-to-text conversion and natural-sounding text-to-speech responses. You decide to use NVIDIA Riva for deploying ASR and TTS models. Which approach will most effectively enhance the naturalness and intelligibility of the TTS output?",
+    "a": [
+      "Use a generic TTS model without customization to ensure broad applicability.",
+      "Use a TTS model designed specifically for generating high-speed, low-latency responses.",
+      "Fine-tune the TTS model on a dataset that includes diverse speech styles relevant to your application.",
+      "Integrate a pre-trained ASR model with the TTS model to improve output quality."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "As a part of your role, you need to stay current with the latest developments in AI, particularly those related to language learning models. Which of the following actions would be the most effective way to stay informed about new AI models and research advancements?",
+    "a": [
+      "Regularly attend AI conferences and workshops.",
+      "Only read academic journals and papers.",
+      "Rely exclusively on online forums and social media discussions.",
+      "Subscribe to newsletters from AI-related companies."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal AI model that processes both speech and video data for emotion recognition. During experimentation, you notice that the model performs well on video-only inputs but struggles significantly when both modalities are present. What is the most likely cause of this issue?",
+    "a": [
+      "The model might be overfitting to the video data and underfitting to the speech data.",
+      "There may be a mismatch in the temporal alignment between the speech and video data.",
+      "The speech data might have more noise, which the model is unable to handle.",
+      "The model architecture is likely not complex enough to handle multimodal inputs."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "A company is using a generative AI model to create marketing content across different platforms, including social media, blogs, and email campaigns. The content needs to be customized for different audience segments while maintaining brand consistency. What is the primary challenge in this scenario?",
+    "a": [
+      "Scaling the model to handle large amounts of data",
+      "Training the model to generate content for a single platform",
+      "Ensuring the content complies with regional advertising regulations",
+      "Ensuring the model generates content that adheres to brand guidelines"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal model that integrates audio, text, and image data for a sentiment analysis task. During training, you observe that the model's loss function is fluctuating significantly, particularly when fusing the different modalities. Which technique is most likely to improve the stability of the model during training?",
+    "a": [
+      "Use early stopping to prevent overfitting",
+      "Apply weight regularization only to the text processing layers",
+      "Separate the training of each modality and combine them at the end of training",
+      "Implement a gradual learning rate schedule with warm-up phases"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a multimodal AI system that needs to integrate audio, text, and image data to generate comprehensive reports from meetings. The system should be able to understand and synthesize information from various input types and generate accurate and coherent summaries. Which strategies are most effective for improving the performance of a multimodal AI system in generating comprehensive meeting reports from audio, text, and image inputs? (Select two)",
+    "a": [
+      "Use separate models for each input modality and then combine their outputs.",
+      "Focus on optimizing individual models for each modality before combining them.",
+      "Integrate a unified model that processes all modalities simultaneously.",
+      "Employ early fusion techniques to combine inputs at the feature level before processing.",
+      "Limit the system to processing only one modality at a time."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "In a complex AI system designed for customer service automation, the system needs to classify incoming emails by topic, summarize key points, and generate accurate responses to common questions. Which combination of tasks leveraging a pretrained modern LLM would be most effective in this scenario?",
+    "a": [
+      "Use a pretrained LLM for text classification, apply it again for summarization, and finally fine-tune it for question-answering.",
+      "Utilize an LSTM for text classification, a CNN for summarization, and a rule-based system for question-answering.",
+      "Use a rule-based system for classification, followed by an LSTM for summarization, and a pretrained LLM for question-answering.",
+      "Implement a pretrained LLM solely for text classification and use separate traditional models for summarization and question-answering."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "When developing a multimodal AI system, which of the following approaches is most effective for transferring knowledge from a pre-trained unimodal model to a multimodal model?",
+    "a": [
+      "Freezing the unimodal model's layers and only training a multimodal classifier.",
+      "Using the unimodal model's intermediate representations as input to a multimodal fusion layer.",
+      "Transferring the unimodal model's output directly as the final output for the multimodal model.",
+      "Fine-tuning the entire unimodal model on the multimodal dataset."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are tasked with creating a multimodal generative AI system that must interpret both spoken language and visual cues to assist in an automated customer service environment. Which strategy would best ensure that the system effectively understands and responds to customer inquiries in this complex scenario?",
+    "a": [
+      "Fine-tuning a multimodal model with a dataset that includes synchronized audio and visual data relevant to customer interactions.",
+      "Using separate models for processing spoken language and visual data without any integration between them.",
+      "Relying on a pre-trained model that was trained on general multimodal data without any additional fine-tuning.",
+      "Training the model only on textual data from customer interactions, ignoring visual and audio inputs."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal AI system that processes both images and text to generate detailed captions for social media posts. However, the system often generates captions that are too generic, missing key details from the images. Which technique would most effectively help the model focus on the important parts of the images to generate more accurate and detailed captions?",
+    "a": [
+      "Use a larger dataset with more diverse images and captions",
+      "Implement an attention mechanism that highlights relevant regions of the image during caption generation",
+      "Apply dropout to the image features before feeding them into the captioning model",
+      "Increase the size of the convolutional layers in the image processing module"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal AI system for personalized online shopping, which generates product recommendations based on user interactions, including text queries, image searches, and voice commands. To improve the system's accuracy, your team decides to run A/B testing with two different recommendation models: one that prioritizes visual similarity and another that prioritizes textual relevance. What is the most critical factor to monitor during A/B testing to determine which recommendation model performs better?",
+    "a": [
+      "The average length of user sessions",
+      "User engagement and conversion rates",
+      "The speed of generating recommendations",
+      "The variety of products recommended"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal generative AI system to assist with autonomous vehicle navigation by generating both visual and sensor data predictions. After deploying the system, you notice that the generated sensor data is accurate, but the visual data does not match the real-world environment, causing navigation errors. What is the most likely cause of this issue?",
+    "a": [
+      "The model architecture was designed for image generation only, not multimodal data.",
+      "The sensor data and visual data were processed separately, leading to misalignment between the two.",
+      "The visual data used for training was not representative of the real-world environment.",
+      "The model was trained for too many epochs, leading to overfitting on the sensor data."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "In a scenario where an AI system is tasked with generating custom product images based on user preferences (such as color, style, and environment), how can context embeddings be utilized within the diffusion model to control the image output according to these preferences?",
+    "a": [
+      "Context embeddings can be incorporated into the diffusion process to influence the image generation at each step, ensuring that the final image aligns with the user's preferences.",
+      "Context embeddings are irrelevant to the diffusion process and should be used separately to adjust the final output.",
+      "Context embeddings are only used to enhance the image's resolution, not to control specific attributes like color or style.",
+      "Context embeddings are used only after the image is generated to modify it according to user preferences."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multi-language code generation tool using a rapid application development approach. The tool must generate syntactically correct code snippets in various programming languages based on user input. Which type of model architecture would be the most effective for this task?",
+    "a": [
+      "Use an encoder-only model like BERT for code generation in multiple languages.",
+      "Use a decoder-only model like GPT for code generation across languages.",
+      "Use a convolutional neural network (CNN) to generate code snippets in multiple languages.",
+      "Use a transformer model with both encoder and decoder components, such as BART, for code generation."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "Your team is developing a generative AI application that synthesizes new images based on text descriptions. During a code review, a team member points out that the function responsible for generating images has multiple nested loops and a high cyclomatic complexity. This could lead to maintainability issues and potential bugs. Which action should you take to ensure adherence to best practices and maintain high standards of software quality?",
+    "a": [
+      "Add more unit tests to cover all possible scenarios in the complex function.",
+      "Increase the number of comments in the code to clarify the logic.",
+      "Use a higher level of abstraction to hide the complex logic.",
+      "Break down the function into smaller, more manageable functions."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working with a generative AI model that synthesizes images from textual descriptions. However, the generated images lack detail, and the training process is taking longer than expected. You suspect that the issue is related to the hyperparameters of the model. Which of the following hyperparameter adjustments would most likely improve both the image quality and training speed?",
+    "a": [
+      "Switch to a different optimizer, such as from Adam to SGD.",
+      "Decrease the learning rate.",
+      "Increase the batch size during training.",
+      "Adjust the image resolution used for training."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a Rapid Application Development (RAD) project where you need to quickly prototype an AI-based application that uses a pre-trained model for natural language understanding tasks. You decide to leverage the HuggingFace model repository and the associated Transformers API. Which of the following steps should you take to quickly pull in and experiment with a specific pre-trained model from HuggingFace using the Transformers API?",
+    "a": [
+      "Use the transformers.HubModel class to load the model directly from the HuggingFace repository.",
+      "Use the transformers.Pipeline class directly with the model name to load and experiment with the model.",
+      "Import the AutoModel class from the transformers library and use AutoModel.from_pretrained() to load the model.",
+      "First, download the model files manually from the HuggingFace website, then load them using the transformers.ModelLoader class."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are responsible for maintaining a multimodal generative AI system that processes customer service requests by analyzing both text and voice inputs. The system must categorize the requests, generate appropriate responses, and then forward them to the relevant department. However, the system is struggling with the accurate categorization of requests when the voice data contains background noise. What is the best approach to improve the system's performance in this scenario?",
+    "a": [
+      "Increase the amount of text data used for training the model.",
+      "Fine-tune the model using a larger multimodal dataset with diverse noise conditions.",
+      "Replace the voice recognition module with a newer, more complex one.",
+      "Implement noise reduction techniques on the voice input before feeding it into the model."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a generative AI model for creating realistic human avatars for a virtual reality platform. The model often generates avatars with unnatural facial expressions and incorrect proportions, particularly when blending features from different source datasets. What is the most effective technique to address this issue?",
+    "a": [
+      "Use a Variational Autoencoder (VAE) to smooth out the blending of features.",
+      "Apply data augmentation to the source datasets to improve model generalization.",
+      "Train a multi-modal model to better align different data modalities.",
+      "Implement adversarial training to enhance the realism of facial features."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are building a text-to-image diffusion model using CLIP (Contrastive Language-Image Pretraining) for training. The goal is to leverage CLIP's capabilities to enhance the quality of image generation from text prompts. Which approaches are crucial when integrating CLIP with a diffusion model for generating images from text prompts? (Select two)",
+    "a": [
+      "Exclude CLIP's image encoder from the training process of the diffusion model.",
+      "Ensure that CLIP's text encoder and the diffusion model's image decoder are aligned in terms of latent space.",
+      "Train the diffusion model without using any text embeddings from CLIP.",
+      "Use CLIP embeddings to guide the image generation process in the diffusion model.",
+      "Use CLIP's pre-trained image encoder to directly generate images from text prompts."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "You are part of a team developing a generative AI system for automated content creation. The project is under tight deadlines, and there is pressure to prioritize rapid development over thorough testing. However, you are concerned about the potential impact on software quality and reliability. Which two actions should you advocate for to ensure the project adheres to best practices in software quality and reliability? (Select two)",
+    "a": [
+      "Skip documentation to speed up development and focus on coding.",
+      "Defer all testing until the final stages of development to meet tight deadlines.",
+      "Focus on manual testing only to save time during development.",
+      "Implement continuous integration and continuous deployment (CI/CD) pipelines with automated testing.",
+      "Enforce code reviews and pair programming to catch issues early in the development process."
+    ],
+    "c": [
+      3,
+      4
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "You are integrating CLIP into a pipeline to train a text-to-image diffusion model for generating images based on English text prompts. The goal is to produce highly detailed and accurate images that match complex descriptions. Despite training, the generated images often miss important aspects of the prompts, such as object relations or fine details. How can you effectively use CLIP to improve the training of the diffusion model?",
+    "a": [
+      "Randomize the order of text prompts during training to improve the model's generalization.",
+      "Train the diffusion model and CLIP separately and combine their outputs post-training.",
+      "Use CLIP embeddings as a loss function during the diffusion model's training to ensure that the generated images match the text prompts closely.",
+      "Use CLIP to filter out images that do not closely match the text prompts after the diffusion model generates them."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "Your team is working on a customer support system that needs to understand user queries and provide accurate answers. The system should leverage a pre-trained encoder model to perform semantic analysis on the queries, generating embeddings that can be compared against a knowledge base of predefined responses. Which approach should your team take to effectively generate embeddings for semantic analysis using an encoder model?",
+    "a": [
+      "Leverage AutoModel with a pre-trained encoder like BERT and extract embeddings from the output of the last hidden layer.",
+      "Use AutoModelForSequenceClassification to generate embeddings directly from the output logits.",
+      "Utilize transformers.Pipeline with the text-generation task to create embeddings based on generated text.",
+      "Use AutoModelForQuestionAnswering to generate embeddings from the context and question inputs."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "While assisting in the training of a multimodal AI model that processes text and speech data for a conversational agent, the senior team member points out that the model's training process is taking too long and that the performance on the training set is not improving as expected. Under their supervision, what would be the most effective adjustment to optimize the training time and performance?",
+    "a": [
+      "Decrease the number of layers in the model to make it simpler.",
+      "Increase the batch size to process more samples in parallel during training.",
+      "Use a higher learning rate to make larger updates to the model weights.",
+      "Switch to a more computationally intensive optimizer like Adam."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on optimizing a generative AI model that integrates text and image data. The model currently takes too long to train and suffers from overfitting. Your senior team member suggests focusing on hyperparameter tuning to address these issues. Which hyperparameter adjustments should you consider? (Select two)",
+    "a": [
+      "Increase the batch size to reduce memory usage and prevent overfitting.",
+      "Increase the model's complexity by adding more layers to capture more features.",
+      "Reduce the learning rate to allow the model to converge more slowly and carefully.",
+      "Increase the dropout rate to reduce overfitting.",
+      "Increase the learning rate to speed up the training process."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "In creating a generative AI system that integrates text, audio, and video data, what is the most effective strategy to ensure the system remains energy-efficient, ethical, and transparent?",
+    "a": [
+      "Training the model using unsupervised learning to avoid bias.",
+      "Prioritizing the use of complex models to achieve the highest possible accuracy.",
+      "Ensuring the model is trained on a proprietary dataset to maintain control over data quality.",
+      "Developing the model on a cloud-based platform that uses renewable energy sources."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You have developed a multimodal AI model that integrates audio and text data to predict customer sentiment. However, stakeholders require a better understanding of how the model reaches its conclusions. Which methods would you use to enhance the explainability of this multimodal model? (Select two)",
+    "a": [
+      "Integrate a black-box ensemble model to improve accuracy",
+      "Reduce the number of input features to simplify the model",
+      "Use SHAP (SHapley Additive exPlanations) to explain the contribution of each feature",
+      "Create an interactive dashboard to visualize model outputs",
+      "Employ LIME (Local Interpretable Model-agnostic Explanations) for local model interpretability"
+    ],
+    "c": [
+      2,
+      4
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "After training a generative AI model, you need to visualize its performance across different metrics. Which type of chart would best represent the comparison of model accuracy, loss, and F1-score over multiple epochs?",
+    "a": [
+      "Heatmap",
+      "Pie chart",
+      "Bar chart",
+      "Line chart"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are tasked with deploying a conversational AI pipeline using NVIDIA Riva that integrates ASR, NLP, and TTS models. The system must handle a high volume of concurrent users. What is the most effective strategy to ensure scalability while maintaining performance?",
+    "a": [
+      "Increase the batch size for processing multiple user inputs simultaneously.",
+      "Use microservices architecture to deploy ASR, NLP, and TTS models on separate nodes, scaling each component independently.",
+      "Optimize the NLP model by reducing its complexity to handle more users at once.",
+      "Deploy the entire pipeline on a single powerful GPU to maximize performance."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are supporting the evaluation of a multimodal AI model designed to process and generate content from text, images, and geospatial data. The model needs to operate reliably in real-time applications, but initial tests show inconsistent performance under varying network conditions and data loads. Which approach should be taken to ensure reliable model performance and scalability in real-time applications?",
+    "a": [
+      "Use a single, high-performance server to handle all data processing and model inference.",
+      "Disable real-time processing and switch to batch processing to reduce network dependency.",
+      "Deploy the model on a distributed cloud infrastructure and implement load balancing.",
+      "Restrict the model to operate only during off-peak hours to avoid network congestion."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are designing a generative AI system that needs to interpret and generate both textual descriptions and corresponding images. The system must integrate these diverse data types into a coherent model framework. Which of the following is the most effective approach for achieving this integration?",
+    "a": [
+      "Use a separate pipeline for each data type and merge the outputs at the final stage.",
+      "Implement a multimodal transformer that processes text and image data together.",
+      "Convert all data types into a common format, such as text, before feeding them into the model.",
+      "Use a pre-trained text model and extend it with additional layers to process images."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are integrating text-to-image AI models into a generative system that needs to respond to user inputs dynamically. This system must generate accurate and contextually relevant images based on user prompts. Which NVIDIA SDK should you primarily consider to implement this functionality, and why?",
+    "a": [
+      "NVIDIA NeMo",
+      "NVIDIA Riva",
+      "NVIDIA Nsight",
+      "NVIDIA Avatar Cloud Engine (ACE)"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are building an AI tool to analyze scientific research papers. The tool needs to extract relevant sections from the text, process embedded graphs and charts, and correlate these with the textual content to generate summaries. What combination of Python libraries would be most effective for developing this tool?",
+    "a": [
+      "Utilize TensorFlow for text processing, OpenCV for processing graphs, and CSV files for data storage",
+      "Apply NumPy for text extraction, PyTorch for processing graphs, and a flat file system for storage",
+      "Implement NLTK for text extraction, Matplotlib for processing graphs, and a relational database for data storage",
+      "Use spaCy for extracting relevant text, NumPy for numerical operations, and a vector database for embedding storage and retrieval"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "To enhance the trustworthiness of an AI system used for healthcare diagnostics, which approach involving NVIDIA technologies is most appropriate?",
+    "a": [
+      "Implementing NVIDIA Clara's privacy-preserving federated learning to train the AI on sensitive patient data across multiple institutions without sharing the data.",
+      "Training the AI solely on data from a single medical institution to streamline the process.",
+      "Using NVIDIA GPUs to increase the speed of diagnosis without focusing on data security.",
+      "Prioritizing the collection of large amounts of patient data over maintaining patient privacy."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are using a multimodal AI model to recognize emotions based on facial expressions (images) and voice tone (audio) in customer service calls. The model works well but needs to be more interpretable to gain the trust of users. Which method would best improve the explainability of the model's predictions?",
+    "a": [
+      "Remove the audio data and rely solely on facial expressions, which are more straightforward to interpret.",
+      "Train a simpler model using only the facial expression data, as it is easier to explain visual features.",
+      "Use Grad-CAM (Gradient-weighted Class Activation Mapping) to visualize which areas of the face image and segments of the audio are influencing the emotion prediction.",
+      "Show confusion matrices to stakeholders to explain how often the model makes correct predictions."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "As part of a project to build a customer service bot, the AI development team has implemented a multimodal AI model that can generate text responses and corresponding visual content. During the deployment phase, the bot produces inconsistent results, sometimes generating irrelevant images that do not match the context of the text. What is the most effective strategy to resolve this issue?",
+    "a": [
+      "Implement a post-processing filter to remove irrelevant images",
+      "Manually review and adjust each generated image",
+      "Use a separate AI model for text generation and image generation",
+      "Train the model with additional data that pairs text with appropriate images"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a project where a multimodal AI system is being developed to assist doctors by analyzing patient data, including medical images, lab results, and patient history, to provide diagnostic suggestions. The system must be highly accurate and capable of integrating different data types efficiently. What is the most critical factor to consider when selecting a model for this multimodal AI system to ensure high diagnostic accuracy?",
+    "a": [
+      "The model's speed of inference",
+      "The model's ability to generate human-like responses",
+      "The size of the model's pre-trained dataset",
+      "The model's ability to handle and integrate multiple data types"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are designing a multimodal AI system for a smart city project that monitors traffic, air quality, and public safety using video feeds, sensor data, and social media analysis. The system needs to operate continuously with high accuracy while minimizing energy consumption across multiple edge devices. Which strategy should you prioritize to achieve the best balance between energy efficiency and system performance?",
+    "a": [
+      "Deploy separate models for each data modality (video, sensor, social media) without integration.",
+      "Implement model pruning to reduce the size of the neural networks used in the system.",
+      "Use high-resolution sensors to improve the accuracy of air quality measurements.",
+      "Increase the frame rate of video feeds to capture more detailed data."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a generative AI model that creates captions for images. The initial results are inconsistent in tone and occasionally include irrelevant information. To improve the quality of the captions, you decide to apply prompt engineering techniques. Which approach would best influence the output of the generative model to produce more relevant and consistent captions?",
+    "a": [
+      "Use a simple and generic prompt like \"Describe this image.\"",
+      "Provide the model with a random set of images and ask it to generate captions without any additional context.",
+      "Increase the length of the prompt to include detailed descriptions of potential caption content.",
+      "Specify the desired tone and focus in the prompt, such as \"Generate a concise and professional caption that describes the key elements of the image.\""
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a generative AI system that creates images based on English text prompts for an e-commerce platform. The platform demands a highly accurate representation of product details (e.g., texture, color) in the generated images. Which strategy would most effectively improve the alignment between text descriptions and generated images?",
+    "a": [
+      "Integrate a high-resolution GAN model for image generation",
+      "Fine-tune the CLIP model specifically on e-commerce product descriptions",
+      "Increase the training dataset size with more product images",
+      "Apply transfer learning with a pre-trained diffusion model"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "While preprocessing a multimodal dataset consisting of numerical sensor data, categorical text data, and pixel-based image data, you realize that the data ranges across these modalities vary significantly. Which preprocessing step is most appropriate to ensure the model can effectively learn from all data sources?",
+    "a": [
+      "Normalize all data to the range [0,1] regardless of modality.",
+      "Normalize the text data to a common scale using word embeddings.",
+      "Standardize the numerical data, use one-hot encoding for categorical data, and normalize pixel values.",
+      "Apply Min-Max scaling only to the numerical sensor data and leave other modalities unchanged."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are working on a multimodal AI project that involves integrating image data with textual descriptions for a product recommendation system. Under the supervision of a senior team member, you are tasked with writing a Python script to preprocess the image data and textual data before they are fed into the model. After running your preprocessing script, the model's performance on the test set is significantly lower than expected. What is the most likely issue with your preprocessing script?",
+    "a": [
+      "The image data was resized using incorrect interpolation methods, leading to distorted images.",
+      "The script failed to normalize the numerical data, leading to poor convergence during training.",
+      "The text data was converted to lowercase without removing punctuation.",
+      "The image data was converted to grayscale, which is unsuitable for this type of multimodal task."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a multimodal Generative AI system for predictive maintenance in a fleet of autonomous vehicles. The system uses time-series data from sensors (e.g., engine temperature, speed, and vibration) and text reports from drivers to detect potential failures. Given the limited available failure data, you decide to use an anomaly detection approach with time-series autoencoders. After deployment, the system frequently flags non-critical anomalies, leading to unnecessary maintenance checks. What is the best approach to reduce these non-critical flags while still maintaining the ability to detect true failures?",
+    "a": [
+      "Incorporate domain knowledge to adjust the anomaly thresholds for different types of data.",
+      "Add an additional neural network layer to the autoencoder to increase its complexity.",
+      "Train the autoencoder with augmented failure data to increase its sensitivity.",
+      "Randomly drop a portion of normal data during training to force the autoencoder to learn only the most critical patterns."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "During the analysis of your generative AI model's performance, you notice that the model accuracy significantly drops when processing videos from different lighting conditions. What would be the best approach to identify and mitigate the factors causing this drop in performance?",
+    "a": [
+      "Reduce the learning rate to improve model robustness.",
+      "Apply feature scaling to the video data.",
+      "Increase the training data by including more videos with varied lighting conditions.",
+      "Perform a sensitivity analysis on the input video data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "Your team is tasked with integrating a new AI language model into an existing customer support chatbot system. The goal is to improve the chatbot's ability to understand and respond to complex customer inquiries. However, after integration, the chatbot frequently misinterprets queries that involve domain-specific terminology. What is the best approach to resolve this issue?",
+    "a": [
+      "Implement a rule-based system to handle queries with domain-specific terminology",
+      "Reduce the complexity of customer inquiries by limiting user input",
+      "Increase the training time of the AI model to improve overall performance",
+      "Fine-tune the AI model using a dataset that includes domain-specific terminology"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are designing a generative AI system that can create descriptive paragraphs based on input images. The system needs to understand the visual content and generate coherent text that accurately describes the scene. How can a transformer-based model be effectively utilized in this multimodal scenario?",
+    "a": [
+      "Apply a transformer model only to the image data, ignoring text altogether.",
+      "Implement a transformer-based Vision-Language model that jointly processes images and text.",
+      "Train a transformer model on a large text dataset and then manually add visual descriptions.",
+      "Use a transformer model exclusively for text generation after converting images to text using a separate model."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are assisting in the deployment of a multimodal AI model designed to provide real-time insights from video, text, and audio data streams in a smart city application. During testing, the model performs well with small datasets, but as the data scale increases, performance degrades significantly. What could be the underlying reasons for this performance drop? (Select two)",
+    "a": [
+      "The model's hyperparameters were tuned for small datasets only.",
+      "The model's data pipeline lacks parallel processing capabilities.",
+      "The model is using pre-trained embeddings that are too large for the available memory.",
+      "The model was tested on synthetic data instead of real-world data.",
+      "The model's architecture is not optimized for large-scale data processing."
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 7"
+  },
+  {
+    "q": "You are developing a chatbot for customer service using a generative AI model. The chatbot must handle a wide range of queries with high accuracy. Which of the following strategies would be most effective in improving the chatbot's performance for handling specific, domain-related queries?",
+    "a": [
+      "Fine-tuning the model using a large, domain-specific dataset of past customer queries and responses.",
+      "Fine-tuning the model with a small dataset of general customer service interactions.",
+      "Using a large, pre-trained generative model without any further customization.",
+      "Relying solely on post-processing techniques to correct the model's responses."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are tasked with optimizing a large-scale generative AI model deployed on cloud infrastructure. Your goal is to reduce memory usage and computational cost during inference. Which approach would best achieve this?",
+    "a": [
+      "Using batch normalization during inference",
+      "Increasing the complexity of the model's architecture",
+      "Implementing model pruning techniques",
+      "Reducing the number of layers in the model"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 7"
+  },
+  {
+    "q": "You are tasked with improving a multimodal neural network used for predicting patient outcomes based on medical imaging, lab results, and clinical notes. The current model struggles with learning complex features due to the depth of the network. Which benefit of residual connections would most directly address this problem?",
+    "a": [
+      "Residual connections reduce the number of parameters in the network",
+      "Residual connections enable the network to learn complex features without degradation of performance",
+      "Residual connections allow for sequential processing of each modality independently",
+      "Residual connections improve the interpretability of the model's outputs"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 7"
+  }
+];
+const SETS = ["Set 1", "Set 2", "Set 3", "Set 4", "Set 5", "Set 6", "Set 7"];
+
+const quiz = document.getElementById('quiz');
+const scoreEl = document.getElementById('score');
+let activeSet = 'all';  // 'all' or a set name like 'set1'
+
+function letter(i) { return String.fromCharCode(65 + i); }
+
+function renderQuestion(q, qi) {
+  const isMulti = !!q.multi;
+  const type = isMulti ? 'checkbox' : 'radio';
+  const opts = q.a.map((text, oi) => `
+    <li>
+      <label data-qi="${qi}" data-oi="${oi}">
+        <input type="${type}" name="q${qi}" value="${oi}">
+        <strong>${letter(oi)}.</strong> ${escapeHtml(text)}
+      </label>
+    </li>`).join('');
+  const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
+  const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
+  const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  return `
+    <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
+      <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
+      <ul class="opts">${opts}</ul>
+      <div class="actions">
+        <button data-check="${qi}">Check</button>
+        <button data-reset="${qi}">Reset</button>
+      </div>
+    </div>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  })[c]);
+}
+
+function checkQuestion(qi) {
+  const q = QUESTIONS[qi];
+  const correct = new Set(q.c);
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    const oi = +label.dataset.oi;
+    const input = label.querySelector('input');
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    if (input.checked) {
+      if (correct.has(oi)) label.classList.add('correct');
+      else label.classList.add('wrong');
+    } else if (correct.has(oi)) {
+      label.classList.add('reveal-correct');
+    }
+  });
+  updateScore();
+}
+
+function resetQuestion(qi) {
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    label.querySelector('input').checked = false;
+  });
+  updateScore();
+}
+
+function inActiveSet(q) {
+  return activeSet === 'all' || q.set === activeSet;
+}
+
+function updateScore() {
+  let answered = 0, correct = 0, total = 0;
+  QUESTIONS.forEach((q, qi) => {
+    if (!inActiveSet(q)) return;
+    total++;
+    const inputs = document.querySelectorAll(`#q${qi} input`);
+    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    if (picked.length === 0) return;
+    answered++;
+    const expected = new Set(q.c);
+    const isExactMatch =
+      picked.length === expected.size &&
+      picked.every(p => expected.has(p));
+    if (isExactMatch) correct++;
+  });
+  const label = activeSet === 'all' ? 'overall' : activeSet;
+  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+}
+
+function applyFilter() {
+  QUESTIONS.forEach((q, qi) => {
+    const el = document.getElementById(`q${qi}`);
+    if (!el) return;
+    el.classList.toggle('hidden', !inActiveSet(q));
+  });
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.set === activeSet);
+  });
+  updateScore();
+}
+
+// ── Cache: persist answers + checked state across reloads ────────────────────
+const CACHE_KEY = 'quiz-cache-nca-generative-ai-multimodal-practice-quiz';
+
+function saveCache() {
+  const answers = {};   // qi -> [oi, ...]
+  const checked = {};   // qi -> true
+  QUESTIONS.forEach((q, qi) => {
+    const picked = [...document.querySelectorAll(`#q${qi} input:checked`)]
+      .map(i => +i.value);
+    if (picked.length) answers[qi] = picked;
+    // A question is "checked" if any label has a result class.
+    const el = document.getElementById(`q${qi}`);
+    if (el && el.querySelector('.correct, .wrong, .reveal-correct')) checked[qi] = true;
+  });
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ answers, checked })); } catch(_) {}
+}
+
+function loadCache() {
+  let cache;
+  try { cache = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch(_) {}
+  if (!cache) return;
+  const { answers = {}, checked = {} } = cache;
+  // Restore selections first.
+  Object.entries(answers).forEach(([qi, ois]) => {
+    ois.forEach(oi => {
+      const input = document.querySelector(`#q${qi} input[value="${oi}"]`);
+      if (input) input.checked = true;
+    });
+  });
+  // Restore checked visual state.
+  Object.keys(checked).forEach(qi => checkQuestion(+qi));
+}
+
+quiz.innerHTML = QUESTIONS.map(renderQuestion).join('');
+
+// Restore cache after DOM is built.
+loadCache();
+
+quiz.addEventListener('click', e => {
+  const t = e.target;
+  if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
+  else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+});
+quiz.addEventListener('change', () => { updateScore(); saveCache(); });
+
+document.getElementById('checkAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) checkQuestion(qi); });
+  saveCache();
+});
+document.getElementById('resetAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  saveCache();
+});
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    activeSet = tab.dataset.set;
+    applyFilter();
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  });
+});
+
+if (SETS.length > 1) applyFilter();
+else updateScore();
+
+// Dark-mode toggle. Persists across reloads in localStorage but falls back
+// to prefers-color-scheme when no preference is stored.
+const THEME_KEY = 'quiz-theme';
+function applyTheme(theme) {
+  const html = document.documentElement;
+  if (theme === 'dark' || theme === 'light') {
+    html.setAttribute('data-theme', theme);
+  } else {
+    html.removeAttribute('data-theme');
+  }
+  const isDark = theme === 'dark'
+    || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.getElementById('themeIcon').textContent = isDark ? '☀️' : '🌙';
+  document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+}
+applyTheme(localStorage.getItem(THEME_KEY));
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const isCurrentlyDark = current === 'dark'
+    || (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const next = isCurrentlyDark ? 'light' : 'dark';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+});
+</script>
+</body>
+</html>

--- a/public/ncp-aai/index.html
+++ b/public/ncp-aai/index.html
@@ -1,0 +1,2059 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NCP-AAI Practice Test</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --border: #ddd;
+    --hover: rgba(0, 0, 0, 0.04);
+    --card: #fafafa;
+    --accent: #2563eb;
+    --correct-bg: #16a34a;
+    --correct-fg: #ffffff;
+    --correct-border: #15803d;
+    --wrong-bg: #dc2626;
+    --wrong-fg: #ffffff;
+    --wrong-border: #b91c1c;
+    --reveal: #16a34a;
+    --multi-bg: #2563eb;
+  }
+  html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --fg: #e7e9ee;
+    --muted: #9aa3b2;
+    --border: #2a2f3a;
+    --hover: rgba(255, 255, 255, 0.05);
+    --card: #161a21;
+    --accent: #60a5fa;
+    --correct-bg: #166534;
+    --correct-fg: #ecfdf5;
+    --correct-border: #22c55e;
+    --wrong-bg: #7f1d1d;
+    --wrong-fg: #fee2e2;
+    --wrong-border: #ef4444;
+    --reveal: #22c55e;
+    --multi-bg: #3b82f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme]) {
+      color-scheme: dark;
+      --bg: #0f1115;
+      --fg: #e7e9ee;
+      --muted: #9aa3b2;
+      --border: #2a2f3a;
+      --hover: rgba(255, 255, 255, 0.05);
+      --card: #161a21;
+      --accent: #60a5fa;
+      --correct-bg: #166534;
+      --correct-fg: #ecfdf5;
+      --correct-border: #22c55e;
+      --wrong-bg: #7f1d1d;
+      --wrong-fg: #fee2e2;
+      --wrong-border: #ef4444;
+      --reveal: #22c55e;
+      --multi-bg: #3b82f6;
+    }
+  }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    max-width: 880px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .subtitle { color: var(--muted); margin: 0 0 1rem; }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .q {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    background: var(--card);
+  }
+  .q h2 { font-size: 1rem; margin: 0 0 .75rem; }
+  .opts { list-style: none; padding: 0; margin: 0; }
+  .opts li { margin: .35rem 0; }
+  .opts label {
+    display: block;
+    padding: .5rem .75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    color: var(--fg);
+  }
+  .opts label:hover { background: var(--hover); }
+  .opts input { margin-right: .5rem; }
+  .opts label.correct {
+    background: var(--correct-bg);
+    color: var(--correct-fg);
+    border-color: var(--correct-border);
+  }
+  .opts label.wrong {
+    background: var(--wrong-bg);
+    color: var(--wrong-fg);
+    border-color: var(--wrong-border);
+  }
+  .opts label.reveal-correct { outline: 2px dashed var(--reveal); }
+  .actions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+    margin-top: .75rem;
+  }
+  button {
+    padding: .4rem .8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--fg);
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover { background: var(--hover); }
+  button.primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  button.primary:hover { filter: brightness(1.1); }
+  .note { font-size: .85rem; color: var(--muted); }
+  #score {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: .5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-weight: bold;
+    z-index: 10;
+  }
+  .multi-tag {
+    font-size: .75rem;
+    background: var(--multi-bg);
+    color: white;
+    padding: .1rem .4rem;
+    border-radius: 3px;
+    margin-left: .5rem;
+    vertical-align: middle;
+  }
+  .set-tag {
+    font-size: .7rem;
+    color: var(--muted);
+    margin-left: .5rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+  }
+  .tabs {
+    display: flex;
+    gap: .25rem;
+    flex-wrap: wrap;
+    margin: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: .5rem;
+  }
+  .tab {
+    padding: .35rem .7rem;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: .9rem;
+  }
+  .tab:hover { background: var(--hover); color: var(--fg); }
+  .tab.active {
+    background: var(--card);
+    border-color: var(--border);
+    border-bottom-color: var(--card);
+    color: var(--fg);
+    font-weight: 600;
+  }
+  .q.hidden { display: none; }
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+  .explanation {
+    margin-top: .85rem;
+    padding: .7rem .95rem;
+    border-left: 3px solid var(--accent);
+    background: var(--hover);
+    border-radius: 6px;
+    font-size: .9rem;
+    color: var(--fg);
+    white-space: pre-wrap;
+  }
+  .explanation[hidden] { display: none; }
+  .explanation .exp-label {
+    display: block;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: .3rem;
+    text-transform: uppercase;
+    font-size: .7rem;
+    letter-spacing: .05em;
+  }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <div>
+    <h1>NCP-AAI Practice Test</h1>
+    <p class="subtitle">NVIDIA Agentic AI Exam - 121 questions with explanations</p>
+  </div>
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">
+    <span id="themeIcon">🌙</span>
+    <span id="themeLabel">Dark</span>
+  </button>
+</div>
+<p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
+
+<div id="score">Score: 0 / 0 answered</div>
+<div id="quiz"></div>
+<div class="actions" style="margin: 2rem 0;">
+  <button id="checkAll" class="primary">Check all</button>
+  <button id="resetAll">Reset</button>
+</div>
+
+<script>
+const QUESTIONS = [
+  {
+    "q": "When designing tool integration for an agent that needs to perform mathematical calculations, web searches, and API calls, which architecture pattern provides the most scalable and maintainable approach?",
+    "a": [
+      "External tool services with manual configuration for each agent instance",
+      "Microservice-based tool architecture with standardized interfaces",
+      "Monolithic tool handler with conditional logic for different tool types",
+      "Embedded tool functions within the main agent code"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Microservice-based tool architecture with standardized interfaces, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: External tool services with manual configuration for each agent instance; C: Monolithic tool handler with conditional logic for different tool types; D: Embedded tool functions within the main agent code, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A company is deploying an AI-powered customer support agent that integrates external APIs and handles a wide range of customer inputs dynamically. Which of the following strategies are appropriate when designing an AI agent for dynamic conversation management and external system interaction? (Choose two.)",
+    "a": [
+      "Integrating a feedback loop from user interactions to iteratively improve agent behavior .",
+      "Using rule-based logic as the primary framework to maintain consistency in agent decisions.",
+      "Implementing retry logic for API failures to ensure robustness in external communications.",
+      "Preferring hardcoded responses for frequent queries to deliver reliable and low-latency answers."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The selected design maps to Integrating a feedback loop from user interactions to iteratively improve agent behavior and Implementing retry logic for API failures to ensure robustness in external communications, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Using rule-based logic as the primary framework to maintain consistency in agent...; D: Preferring hardcoded responses for frequent queries to deliver reliable and low-latency answers, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In the context of agent development, how does an autonomous agent differ from a predefined workflow when applied to complex enterprise tasks?",
+    "a": [
+      "Agents optimize for execution speed under fixed input-output mappings, while workflows prioritize goal alignment through adaptive reasoning and memory mechanisms.",
+      "Workflows provide deterministic task sequencing with conditional branching, while agents adapt decisions dynamically based on goals, context, and environment feedback.",
+      "Workflows emphasize parallelism and distributed coordination of processes, while agents emphasize serialization and isolated problem solving."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Workflows provide deterministic task sequencing with conditional branching while agents adapt decisions dynamically based on goals context and..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Agents optimize for execution speed under fixed input-output mappings while workflows prioritize...; C: Workflows emphasize parallelism and distributed coordination of processes while agents emphasize serialization..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A Lead AI Architect at a global financial institution is designing a multi-agent fraud detection system using an agentic AI framework. The system must operate in real time, with distinct agents working collaboratively to monitor and analyze transactional patterns across accounts, retain and share contextual information over time, and escalate suspicious behaviors to a human fraud analyst when needed. Which architectural approach enables intelligent specialization, shared memory, and inter-agent coordination in a dynamic and evolving threat environment?",
+    "a": [
+      "Design a modular multi-agent system where individual agents collaborate asynchronously using shared memory and structured messaging.",
+      "Design a multi-agent system where individual agents collaborate synchronously using shared memory and structured messaging.",
+      "Design a centralized rule-based service that checks all transactions against static fraud indicators and sends alerts when thresholds are exceeded.",
+      "Design an agentic workflow where each agent acts independently on isolated data slices with no inter-agent communication to reduce latency and model complexity.",
+      "Design monolithic LLM-based agents that handle all fraud detection tasks within a single loop, without modular roles or multi-agent coordination."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Design a modular multi-agent system where individual agents collaborate asynchronously using shared memory and structured messaging, which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Design a multi-agent system where individual agents collaborate synchronously using shared memory...; C: Design a centralized rule-based service that checks all transactions against static fraud...; D: Design an agentic workflow where each agent acts independently on isolated data...; others are variants of the same weak pattern, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When designing complex agentic workflows that include both sequential and parallel task execution, which orchestration pattern offers the greatest flexibility?",
+    "a": [
+      "Graph-based workflow orchestration incorporating conditional branches",
+      "Linear pipeline orchestration with a fixed task sequence",
+      "Event-driven orchestration that triggers tasks reactively, in series or in parallel"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Graph-based workflow orchestration incorporating conditional branches, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. At NVIDIA scale, this is the difference between an agent loop that merely calls an LLM and a production agent service that can coordinate reasoning, actions, memory, and handoffs across concurrent sessions. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Linear pipeline orchestration with a fixed task sequence; C: Event-driven orchestration that triggers tasks reactively in series or in parallel, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When implementing inter-agent communication for a distributed agentic system running across multiple NVIDIA GPU nodes, which message routing pattern provides the best balance of reliability and performance?",
+    "a": [
+      "Database-based message queuing with polling",
+      "Direct TCP connections between all agent pairs",
+      "Event-driven message routing with distributed broker clusters",
+      "Centralized message broker with topic-based routing"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Event-driven message routing with distributed broker clusters, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Database-based message queuing with polling; B: Direct TCP connections between all agent pairs; D: Centralized message broker with topic-based routing, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two orchestration methods are MOST suitable for implementing complex agentic workflows that require both external data access and specialized task delegation? (Choose two.)",
+    "a": [
+      "Agentic orchestration with specialized expert system delegation",
+      "Prompt chaining to accomplish state management",
+      "Manual workflow coordination without automation",
+      "Retrieval-based orchestration for external data",
+      "Static rule-based routing with predefined pathways"
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Agentic orchestration with specialized expert system delegation and Retrieval-based orchestration for external data, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Prompt chaining to accomplish state management; C: Manual workflow coordination without automation; E: Static rule- based routing with predefined pathways, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating coordination failures in a multi-agent system managing distributed manufacturing workflows, which analysis approach best identifies state management and planning synchronization issues?",
+    "a": [
+      "Monitor agent outputs individually to confirm local correctness and examine results of specific workflow steps.",
+      "Deploy distributed state tracing across agents, analyze transition timing, study communication overhead, and verify synchronization accuracy.",
+      "Assess synchronization methods during design reviews and use simulations to evaluate coordination across representative workflow scenarios.",
+      "Track workflow throughput and task completions to measure performance trends and highlight workflow outcomes."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Deploy distributed state tracing across agents analyze transition timing study communication overhead and verify synchronization accuracy, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Monitor agent outputs individually to confirm local correctness and examine results of...; C: Assess synchronization methods during design reviews and use simulations to evaluate coordination...; D: Track workflow throughput and task completions to measure performance trends and highlight..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are designing an AI agent for summarizing medical documents that include images and text as well. It must extract key information and recognize dates. Which feature is most critical for ensuring the agent performs well across multiple input and output formats?",
+    "a": [
+      "Use of guardrails to filter out hallucinated content",
+      "Retry logic implementation to ensure robustness during API failures",
+      "Chain-of-thought prompting for reasoning accuracy",
+      "Multi-modal model integration to handle both text and vision inputs"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Multi-modal model integration to handle both text and vision inputs, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. At NVIDIA scale, this is the difference between an agent loop that merely calls an LLM and a production agent service that can coordinate reasoning, actions, memory, and handoffs across concurrent sessions. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Use of guardrails to filter out hallucinated content; B: Retry logic implementation to ensure robustness during API failures; C: Chain-of-thought prompting for reasoning accuracy, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two coordination patterns are MOST effective for implementing a multi-agent system where agents have different specializations (Research Analyst, Content Writer, Quality Validator)?",
+    "a": [
+      "Sequential pipeline coordination with crew-based structured handoffs",
+      "Peer-to-peer coordination with consensus mechanisms",
+      "Random task distribution with load balancing",
+      "Hierarchical coordination with crew-based task delegation"
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Sequential pipeline coordination with crew-based structured handoffs and Hierarchical coordination with crew-based task delegation, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. At NVIDIA scale, this is the difference between an agent loop that merely calls an LLM and a production agent service that can coordinate reasoning, actions, memory, and handoffs across concurrent sessions. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Peer-to-peer coordination with consensus mechanisms; C: Random task distribution with load balancing, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A senior AI architect at a public electricity utility is designing an AI system to automate grid operations such as outage detection, load balancing, and escalation handling. The system involves multiple intelligent agents that must operate concurrently, respond to changing data in real time, and collaborate on tasks that evolve over multiple interaction steps. The architect must choose a design pattern that supports coordination, flexible task delegation, and responsiveness without sacrificing maintainability. Which design approach is most appropriate for this scenario?",
+    "a": [
+      "Use an agent service architecture with decoupled execution units managed by a shared interface layer that handles communication and task routing.",
+      "Build a rule-driven control structure that maps task flows to predefined paths for fast and efficient execution under known operating conditions.",
+      "Design the system as a stepwise sequence of agent functions, where each stage processes and passes data to the next in a fixed functional chain.",
+      "Adopt a role-based agent model coordinated through a shared task planner, where agent decisions are informed by centralized policy logic and runtime context signals."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Adopt a role-based agent model coordinated through a shared task planner where agent decisions are informed by centralized..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. At NVIDIA scale, this is the difference between an agent loop that merely calls an LLM and a production agent service that can coordinate reasoning, actions, memory, and handoffs across concurrent sessions. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Use an agent service architecture with decoupled execution units managed by a...; B: Build a rule- driven control structure that maps task flows to predefined paths...; C: Design the system as a stepwise sequence of agent functions where each..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI engineer is evaluating an underperforming multi-agent workflow built with NVIDIA agentic frameworks. Which analysis approach most effectively identifies optimization opportunities in agent coordination and communication patterns?",
+    "a": [
+      "Monitor workflow completion times using analysis that subsumes inter-agent communication costs, coordination overhead, and task allocation balance.",
+      "Focus exclusively on individual agent accuracy without analyzing workflow-level efficiency, coordination costs, or overall system throughput.",
+      "Evaluate agents individually, allowing the toolkit to automatically infer interaction effects, communication patterns, and emergent behaviors from coordination.",
+      "Trace agent interaction patterns using observability features, measure communication overhead, identify redundant operations, and analyze task distribution efficiency."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Trace agent interaction patterns using observability features measure communication overhead identify redundant operations and analyze task distribution efficiency, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Monitor workflow completion times using analysis that subsumes inter-agent communication costs coordination...; B: Focus exclusively on individual agent accuracy without analyzing workflow-level efficiency coordination costs...; C: Evaluate agents individually allowing the toolkit to automatically infer interaction effects communication..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are designing a virtual assistant that helps users check weather updates via external APIs. During testing, the agent frequently calls the incorrect tools, often hallucinating endpoints or returning incorrect formats. You suspect the prompt structure might be the root cause of these failures. Which prompt design best supports consistent tool invocation in this agent?",
+    "a": [
+      "Rely on the agent’s internal knowledge to infer tool usage",
+      "Include tool names in natural language but without parameter examples",
+      "Provide only a generic system instruction with no examples",
+      "Use structured prompt templates with few-shot tool usage examples"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Use structured prompt templates with few-shot tool usage examples, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Rely on the agent s internal knowledge to infer tool usage; B: Include tool names in natural language but without parameter examples; C: Provide only a generic system instruction with no examples, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re working with an LLM to automatically summarize research papers. The summaries often omit critical findings. What’s the best way to ensure that the summaries accurately reflect the core insights of the research papers?",
+    "a": [
+      "Asking the LLM to “summarize the paper .”",
+      "Asking the LLM to “understand” the paper to generate a summary.",
+      "Having the LLM generate the summaries and then manually review every output.",
+      "Asking the LLM to “extract the key findings.”"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Asking the LLM to extract the key findings, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Asking the LLM to summarize the paper; B: Asking the LLM to understand the paper to generate a summary; C: Having the LLM generate the summaries and then manually review every output, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When implementing tool orchestration for an agent that needs to dynamically select from multiple tools (calculator, web search, API calls), which selection strategy provides the most reliable results?",
+    "a": [
+      "Random dynamic tool selection with retry mechanisms and usage examples",
+      "LLM-based tool selection with structured tool descriptions and usage examples",
+      "Rule-based selection with predefined tool mappings and usage examples",
+      "Configuration-based tool selection with manual specifications and usage examples"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to LLM-based tool selection with structured tool descriptions and usage examples, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Random dynamic tool selection with retry mechanisms and usage examples; C: Rule-based selection with predefined tool mappings and usage examples; D: Configuration-based tool selection with manual specifications and usage examples, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An engineer has created a working AI agent solution providing helpful services to users. However, during live testing, the AI agent does not perform tasks consistently. Which two potential solutions might help with this issue? (Choose two.)",
+    "a": [
+      "Remove schema validations and assertions on tool outputs to avoid inconsistency.",
+      "Increase randomness (e.g., temperature) and remove fixed seeds to avoid determinism.",
+      "Identify where dividing the tasks into subtasks and handling them by multiple agents can help.",
+      "Refine the prompt given to the AI Agent; be clear on objectives"
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Identify where dividing the tasks into subtasks and handling them by multiple agents can help and Refine the prompt given to the AI Agent be clear on objectives, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Remove schema validations and assertions on tool outputs to avoid inconsistency; B: Increase randomness e g temperature and remove fixed seeds to avoid determinism, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A development team is building a customer support agent that interacts with users via chat. The agent must reliably fetch information from external databases, handle occasional API failures without crashing, and improve its responses by learning from user feedback over time. Which of the following tasks is most critical when enhancing an AI agent to handle real-world interactions and improve over time?",
+    "a": [
+      "Applying a well-structured training process with foundational generative models and prompt engineering",
+      "Utilizing internal knowledge bases to support agent responses alongside external APIs",
+      "Implementing retry logic for error handling and integrating user feedback loops for iterative improvement",
+      "Designing conversation flows that provide consistent responses based on predefined scripts"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Implementing retry logic for error handling and integrating user feedback loops for iterative improvement, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Applying a well-structured training process with foundational generative models and prompt engineering; B: Utilizing internal knowledge bases to support agent responses alongside external APIs; D: Designing conversation flows that provide consistent responses based on predefined scripts, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "What NVIDIA framework can be used to train a better agent?",
+    "a": [
+      "NeMo-RL",
+      "NeMo Guardrails",
+      "TensorRT-LLM"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to NeMo-RL, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For learning and adaptation, NeMo RL, NeMo Gym, and NeMo Framework fine-tuning provide the training path, while deployment still requires external state and guardrailed execution. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on B: NeMo Guardrails; C: TensorRT-LLM, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. In a NeMo Agent Toolkit workflow, tools, retrievers, parsers, and prompt templates must be explicit functions with schemas so the runtime can trace inputs, validate outputs, and recover from external-system faults."
+  },
+  {
+    "q": "You are evaluating your RAG pipeline. You notice that the LLM-as-a-Judge consistently assigns high similarity scores to responses that contain irrelevant information. What should you investigate as the most likely potential cause with the least development effort?",
+    "a": [
+      "The temperature setting used by the LLM during response generation.",
+      "The size of the knowledge base used to power the RAG pipeline.",
+      "The quality of the synthetic questions used for evaluation.",
+      "The prompt used to instruct the LLM-as-a-Judge to assess the response."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to The prompt used to instruct the LLM-as-a-Judge to assess the response, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: The temperature setting used by the LLM during response generation; B: The size of the knowledge base used to power the RAG pipeline; C: The quality of the synthetic questions used for evaluation, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re managing an agentic AI responsible for customer support ticket triage. The agent has been consistently accurate in routing tickets to the appropriate departments. However, a team leader has noticed a significant increase in the number of tickets requiring “escalation” – cases where the agent initially misclassified a complex issue as a simple, routine one, leading to delays and frustrated customers. What would be an appropriate first step in resolving this issue?",
+    "a": [
+      "Analyzing the agent’s decision-making process, focusing on the specific criteria it uses to classify tickets, and identifying potential biases or blind spots.",
+      "Adjusting the agent’s reward function to prioritize speed of resolution over accuracy, as a first step in analysis of the problem.",
+      "Increasing the agent’s autonomy, granting it more decision-making power during triage to improve its efficiency.",
+      "Conducting a “red-teaming” exercise, having human agents deliberately create complex and ambiguous scenarios to analyze the agent’s robustness."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Analyzing the agent s decision-making process focusing on the specific criteria it uses to classify tickets and identifying..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. NeMo Agent Toolkit evaluation, profiling, and OpenTelemetry-style observability are built for workflow-level measurement, not just isolated answer inspection. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Adjusting the agent s reward function to prioritize speed of resolution over ...;C: Increasing the agent s autonomy granting it more decision-making power during triage...; D: Conducting a red-teaming exercise having human agents deliberately create complex and ambiguous..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A customer service agentic AI is designed to resolve billing inquiries. It consistently resolves inquiries accurately and efficiently. However, a significant number of customers are reporting frustration due to the agent’s tendency to repeatedly ask for the same information (account number, address) during each interaction, even after it’s already been provided. Which evaluation method would be most effective for addressing this issue?",
+    "a": [
+      "Adjusting the agent’s reward function to prioritize speed of resolution over customer satisfaction.",
+      "Analyzing the agent’s dialogue transcripts to identify patterns in its questioning techniques.",
+      "Implementing a “conversational flow” analysis to optimize the order of questions asked during each interaction.",
+      "Increasing the agent’s processing speed to reduce the time it takes to handle each inquiry and increase customer satisfaction."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Analyzing the agent s dialogue transcripts to identify patterns in its questioning techniques, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Adjusting the agent s reward function to prioritize speed of resolution over ...;C: Implementing a conversational flow analysis to optimize the order of questions asked...; D: Increasing the agent s processing speed to reduce the time it takes..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A financial services agentic AI is being used to automate initial customer onboarding. The agent is completing the process efficiently and accurately, but reviews of its conversations reveal it often uses overly formal and complex language that confuses customers. Which type of evaluation is best suited to address this issue?",
+    "a": [
+      "Controlled user testing sessions to collect user feedback on the clarity and tone of responses",
+      "Compliance review of the agent’s access to regulatory guidelines and policy documentation",
+      "Continuous user feedback collection, specifically gathering subjective assessments of the agent’s communication style",
+      "Statistical analysis of the agent’s decision-making patterns to detect overly formal and complex response choices"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Controlled user testing sessions to collect user feedback on the clarity and tone of responses, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Compliance review of the agent s access to regulatory guidelines and policy...; C: Continuous user feedback collection specifically gathering subjective assessments of the agent s...; D: Statistical analysis of the agent s decision-making patterns to detect overly formal..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re evaluating the performance of a tool-using agent (e.g., one that issues API calls or executes functions). From the list below, what are two important features to evaluate? (Choose two.)",
+    "a": [
+      "Tool use accuracy",
+      "Tokens per second",
+      "Tool use rate",
+      "Task completion rate"
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Tool use accuracy and Task completion rate, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Tokens per second; C: Tool use rate, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. NeMo Agent Toolkit evaluation, profiling, and OpenTelemetry-style observability are built for workflow-level measurement, not just isolated answer inspection."
+  },
+  {
+    "q": "When analyzing user feedback patterns to improve a technical documentation agent, which evaluation methods effectively translate feedback into actionable optimization strategies? (Choose two.)",
+    "a": [
+      "Collect broad user feedback as-is, enabling rapid accumulation of suggestions and diverse perspectives for potential future analysis.",
+      "Design iterative feedback loops with version tracking, A/B testing of improvements, and regression monitoring to ensure changes enhance rather than degrade performance",
+      "Incorporate user suggestions rapidly to maximize responsiveness and demonstrate continuous adaptation to evolving user needs.",
+      "Implement feedback categorization systems grouping issues by type (accuracy, clarity, completeness) with quantitative impact scoring and improvement prioritization matrices"
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Design iterative feedback loops with version tracking A/B testing of improvements and regression monitoring to ensure changes enhance... and Implement feedback categorization systems grouping issues by type accuracy clarity completeness with quantitative impact scoring and improvement prioritization..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single- output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Collect broad user feedback as-is enabling rapid accumulation of suggestions and diverse...; C: Incorporate user suggestions rapidly to maximize responsiveness and demonstrate continuous adaptation to..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing an agent’s failure to complete multi-step financial analysis tasks, which evaluation approach best identifies prompt engineering improvements needed for reliable task decomposition and execution?",
+    "a": [
+      "Implement systematic prompt testing with chain-of-thought reasoning templates, step-by-step decomposition analysis, and success rate tracking across tasks of varying complexity.",
+      "Focus primarily on response speed optimization as a primary focus over reasoning quality, step completion accuracy, and prompt clarity for complex analytical requirements.",
+      "Test only final output accuracy as this will automatically include intermediate reasoning steps, decomposition quality, and prompt structure effectiveness for complex workflows.",
+      "Rely on generic prompt templates which are by default already optimized for general use, instead of tailoring them to financial terminology, calculation needs, or specialized multi-step analysis patterns."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Implement systematic prompt testing with chain-of-thought reasoning templates step-by-step decomposition analysis and success rate tracking across tasks of..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Focus primarily on response speed optimization as a primary focus over reasoning...; C: Test only final output accuracy as this will automatically include intermediate reasoning...; D: Rely on generic prompt templates which are by default already optimized for ...,which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An agentic AI is tasked with generating marketing copy for various campaigns. It’s consistently producing high-quality text and generating significant engagement. However, qualitative feedback from brand managers indicates that the content lacks a distinct “brand voice” and feels generic. Which of the following metrics would be most valuable for evaluating the agent’s adherence to the brand’s established voice?",
+    "a": [
+      "A metric assessing the agent’s ability to tailor its language and messaging for distinct audience segments based on demographic and psychographic data.",
+      "A metric evaluating the agent’s textual similarity to a formalized brand style guide, analyzing factors such as tone, approved vocabulary, and prescribed sentence structures.",
+      "A metric tracking the average word count and sentence length of the agent’s copy, focusing on stylistic efficiency as a potential proxy for brand alignment.",
+      "A metric quantifying how frequently the agent’s output is shared, liked, or reposted on major social platforms, using this as an indicator of effective brand representation."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to A metric evaluating the agent s textual similarity to a formalized brand style guide analyzing factors such as..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: A metric assessing the agent s ability to tailor its language and...; C: A metric tracking the average word count and sentence length of the...; D: A metric quantifying how frequently the agent s output is shared liked..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing suboptimal agent response quality after deployment, which parameter tuning evaluation methods effectively identify the optimal configuration adjustments? (Choose two.)",
+    "a": [
+      "Design ablation studies systematically varying individual parameters while holding others constant to isolate each parameter’s impact on agent behavior and performance.",
+      "Apply identical parameter settings across all agent types and tasks, promoting consistency and simplifying comparison across different use cases.",
+      "Implement A/B testing frameworks comparing temperature, top-k, and top-p variations while measuring task-specific quality metrics and user satisfaction scores.",
+      "Use production traffic directly for parameter experiments, enabling real-world insights and faster identification of impactful settings.",
+      "Randomly adjust all parameters simultaneously, allowing for broader exploration of the parameter space in a shorter time frame."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The selected design maps to Design ablation studies systematically varying individual parameters while holding others constant to isolate each parameter s impact on... and Implement A/B testing frameworks comparing temperature top-k and top-p variations while measuring task-specific quality metrics and user satisfaction..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. NeMo Agent Toolkit evaluation, profiling, and OpenTelemetry-style observability are built for workflow-level measurement, not just isolated answer inspection."
+  },
+  {
+    "q": "You are tasked with comparing two agentic AI systems – System A and System B – both designed to generate marketing copy. You’ve run identical prompts and have recorded the generated outputs. To objectively assess which system is performing better, what is the most appropriate approach?",
+    "a": [
+      "Measure the click-through rate for each system’s marketing copy as the primary indicator of performance.",
+      "Implement a human-in-the-loop to subjectively rate each output on a scale of 1 to 5 based on the user’s personal preference.",
+      "Implement a benchmark pipeline that automatically compares the generated outputs using metrics like relevance, creativity, and grammatical correctness.",
+      "Gather ratings from a panel of users, with each rating marketing copy on a 1 to 5 scale for overall impression of relevance, creativity, and grammatical correctness."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Implement a benchmark pipeline that automatically compares the generated outputs using metrics like relevance creativity and grammatical correctness, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Measure the click- through rate for each system s marketing copy as the...; B: Implement a human-in-the-loop to subjectively rate each output on a scale of...; D: Gather ratings from a panel of users with each rating marketing copy..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re evaluating the RAG pipeline by comparing its responses to synthetic questions. You’ve collected a large set of similarity scores. What’s the primary benefit of aggregating these scores into a single metric (e.g., average similarity)?",
+    "a": [
+      "Aggregation identifies the specific chunks within the RAG pipeline that are contributing to the highest similarity scores.",
+      "Aggregation reduces the complexity of the evaluation process and allows for a more overall assessment of the pipeline’s effectiveness.",
+      "Aggregation provides a more accurate representation of the RAG pipeline’s performance.",
+      "Aggregation eliminates the need for qualitative analysis of the RAG pipeline’s responses."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Aggregation reduces the complexity of the evaluation process and allows for a more overall assessment of the pipeline..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Aggregation identifies the specific chunks within the RAG pipeline that are contributing...; C: Aggregation provides a more accurate representation of the RAG pipeline s performance; D: Aggregation eliminates the need for qualitative analysis of the RAG pipeline s..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In designing an AI workflow which of the following best describes a comprehensive approach to improving the performance of AI agents?",
+    "a": [
+      "Implementing benchmarking pipelines, deploying physical agents and monitoring user engagement metrics",
+      "Implementing benchmarking pipelines, collecting user feedback, and tuning model parameters iteratively",
+      "Implementing benchmarking pipelines and incorporating a dynamic dataset for a real-time fall- back",
+      "Monitoring agents’ throughput and time-to-first-token from the scoring engine"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implementing benchmarking pipelines collecting user feedback and tuning model parameters iteratively, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Implementing benchmarking pipelines deploying physical agents and monitoring user engagement metrics; C: Implementing benchmarking pipelines and incorporating a dynamic dataset for a real-time fall-back; D: Monitoring agents throughput and time- to-first-token from the scoring engine, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re employing an LLM to automate the generation of email responses for a customer service team. The generated responses frequently miss the mark, failing to address the customer’s underlying concerns. What’s the most crucial element to add to the prompt to enhance the quality of the email responses?",
+    "a": [
+      "Instructing the LLM with a detailed prompt containing instructions on how to format and compose the response in an easy-to-understand structure.",
+      "Instructing the LLM to use a simple template for all email replies before generating a response.",
+      "Instructing the LLM to “understand the customer’s issue” before generating a response.",
+      "Instructing the LLM to provide a response that “is the most helpful” before generating a response."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Instructing the LLM with a detailed prompt containing instructions on how to format and compose the response in..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For learning and adaptation, NeMo RL, NeMo Gym, and NeMo Framework fine-tuning provide the training path, while deployment still requires external state and guardrailed execution. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Instructing the LLM to use a simple template for all email replies...; C: Instructing the LLM to understand the customer s issue before generating a...; D: Instructing the LLM to provide a response that is the most helpful..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "After a series of adjustments in a supply chain agentic system, the agent has dramatically reduced shipping times and minimized costs, but the team is receiving a high volume of complaints from customers regarding delayed deliveries. Which metric is MOST important to prioritize when investigating this situation?",
+    "a": [
+      "The agent’s ability to predict future demand fluctuations, as accurate forecasting is crucial for effective logistics.",
+      "The total cost savings achieved through the agent’s optimization, which represents a significant financial benefit.",
+      "The percentage of delivery times that fall within the acceptable delay window, considering customer satisfaction as a key factor .",
+      "The agent’s adherence to the prescribed delivery schedules, as it’s demonstrably improving efficiency."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to The percentage of delivery times that fall within the acceptable delay window considering customer satisfaction as a key..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: The agent s ability to predict future demand fluctuations as accurate forecasting...; B: The total cost savings achieved through the agent s optimization which represents...; D: The agent s adherence to the prescribed delivery schedules as it s..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A recently deployed Agentic AI system designed for automated incident response within a cloud infrastructure has been consistently failing to identify and resolve ‘high-priority’ alerts – specifically, those related to increased CPU utilization across several virtual machines. Initial logs show the agent is primarily focusing on alerts with related network traffic spikes, ignoring the CPU metrics. What is the most appropriate initial step for a senior Agentic AI engineer to take to resolve this issue, considering the system’s reliance on benchmarking and iterative improvement?",
+    "a": [
+      "Review the agent’s evaluation framework, focusing on the defined benchmarks used to assess its response efficiency and impact on overall system performance.",
+      "Replace the agent’s underlying AI model with a more powerful, general-purpose machine learning engine as a first step in investigating current benchmarks.",
+      "Implement a new synthetic data set containing a wide variety of CPU load profiles to train the agent’s decision-making model.",
+      "Review the agent’s sensitivity thresholds, focusing on CPU utilization alerts to maximize detection accuracy."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Review the agent s evaluation framework focusing on the defined benchmarks used to assess its response efficiency and..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Replace the agent s underlying AI model with a more powerful general-purpose...; C: Implement a new synthetic data set containing a wide variety of CPU...; D: Review the agent s sensitivity thresholds focusing on CPU utilization alerts to..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A team is evaluating multiple versions of an AI agent designed for customer support. They want to identify which version completes tasks more efficiently, responds accurately, and improves over time using user feedback. Which practice is most important to ensure continuous refinement and optimal performance of the AI agent?",
+    "a": [
+      "Comparing agents on isolated tasks without standardized benchmarking pipelines",
+      "Relying solely on offline benchmarks without incorporating live user feedback during tuning",
+      "Implementing an evaluation framework that quantifies task efficiency and incorporates human-in- the-loop feedback",
+      "Tuning model parameters once before deployment to maximize initial accuracy"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Implementing an evaluation framework that quantifies task efficiency and incorporates human-in-the-loop feedback, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Comparing agents on isolated tasks without standardized benchmarking pipelines; B: Relying solely on offline benchmarks without incorporating live user feedback during tuning; D: Tuning model parameters once before deployment to maximize initial accuracy, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing inconsistent performance across a fleet of customer service agents handling similar queries, which evaluation approach most effectively identifies root causes and optimization opportunities?",
+    "a": [
+      "Assess performance data from recently improved agents and highlight strong results, using outcome comparisons to identify areas with the greatest impact on service quality.",
+      "Average performance metrics across all agents as this will smooth individual variations, query distribution differences, and temporal factors affecting agent behavior and accuracy.",
+      "Deploy stratified evaluation sampling across agent variants, query complexity levels, and temporal patterns while tracking decision paths using comparative analytics.",
+      "Review performance across both high- and low-accuracy agent groups, comparing case outcomes and identifying patterns contributing to top and bottom results."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Deploy stratified evaluation sampling across agent variants query complexity levels and temporal patterns while tracking decision paths using..., which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Assess performance data from recently improved agents and highlight strong results using...; B: Average performance metrics across all agents as this will smooth individual variations...; D: Review performance across both high and low- accuracy agent groups comparing case outcomes..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are using an LLM-as-a-Judge to evaluate a RAG pipeline. What is the primary benefit of synthetically generating question-answer pairs, rather than relying solely on human-created test cases?",
+    "a": [
+      "Synthetically generated questions are more challenging and reveal deeper flaws in the RAG pipeline.",
+      "Synthetic generation eliminates the need for any human validation of the RAG pipeline’s output.",
+      "Synthetically generated answers are inherently more accurate than those produced by the LLM.",
+      "Synthetic generation allows for systematic testing of the RAG pipeline across a wider range of scenarios and query types."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Synthetic generation allows for systematic testing of the RAG pipeline across a wider range of scenarios and query..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Synthetically generated questions are more challenging and reveal deeper flaws in the...; B: Synthetic generation eliminates the need for any human validation of the RAG...; C: Synthetically generated answers are inherently more accurate than those produced by the..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your agent is generating inconsistent and contradictory statements. Which approach would be most suitable to improve the agent’s output?",
+    "a": [
+      "Employing Reflexion",
+      "Increasing the number of generated plans",
+      "Using Decomposition-First Planning",
+      "Decreasing the length of prompts"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Employing Reflexion, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Increasing the number of generated plans; C: Using Decomposition-First Planning; D: Decreasing the length of prompts, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. NeMo Agent Toolkit evaluation, profiling, and OpenTelemetry-style observability are built for workflow-level measurement, not just isolated answer inspection."
+  },
+  {
+    "q": "You’re utilizing an LLM to translate complex technical documentation into multiple languages. The translations often lack nuance and fail to capture the original intent. What’s the most effective strategy for improving the quality of the translations?",
+    "a": [
+      "Providing the LLM with a glossary of key terms, concepts in all languages and the dataset of previously translated text.",
+      "Training the LLM on a dataset of translated texts.",
+      "Providing the LLM with guidance to “translate the documents” without additional guidance, so it can use trained knowledge.",
+      "Providing the LLM with guidance to translate “with high accuracy” without additional guidance, so it can use trained knowledge."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Providing the LLM with a glossary of key terms concepts in all languages and the dataset of previously..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. NeMo Agent Toolkit evaluation, profiling, and OpenTelemetry-style observability are built for workflow-level measurement, not just isolated answer inspection. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Training the LLM on a dataset of translated texts; C: Providing the LLM with guidance to translate the documents without additional guidance...; D: Providing the LLM with guidance to translate with high accuracy without additional..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An e-commerce platform is implementing an AI-powered customer support system that handles inquiries ranging from simple FAQ responses to complex product recommendations and technical troubleshooting. The system experiences unpredictable traffic patterns with sudden spikes during sales events and varying complexity requirements. Simple questions comprise the majority of requests but require minimal compute, while complex product recommendations need sophisticated reasoning. The company wants to optimize costs while maintaining service quality across all query types. Which approach would provide the MOST cost-optimized scaling strategy for this variable-workload, mixed-complexity environment?",
+    "a": [
+      "Deploy specialized NVIDIA NIM microservices using a single large model configuration that handles all agent functions on high-capacity GPUs, with auto-scaling infrastructure that maintains constant resource allocation across all traffic patterns.",
+      "Deploy specialized NVIDIA NIM microservices on CPU-optimized infrastructure with auto-scaling capabilities to minimize hardware costs, while accepting longer inference times for cost optimization benefits.",
+      "Deploy specialized NVIDIA NIM microservices with an LLM router to dynamically route requests to appropriate models based on complexity, combined with auto-scaling infrastructure that scales different model types independently.",
+      "Deploy multiple specialized NVIDIA NIM microservices with identical high-capacity models across all available GPUs, implementing auto-scaling infrastructure without request complexity differentiation or dynamic model selection capabilities."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Deploy specialized NVIDIA NIM microservices with an LLM router to dynamically route requests to appropriate models based on..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Deploy specialized NVIDIA NIM microservices using a single large model configuration that...; B: Deploy specialized NVIDIA NIM microservices on CPU-optimized infrastructure with auto-scaling capabilities to...; D: Deploy multiple specialized NVIDIA NIM microservices with identical high-capacity models across all..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A technology startup is preparing to launch an AI agent platform to serve clients with unpredictable usage patterns. They face periods of high user activity and low demand, so their deployment approach must minimize wasted resources during slow times and automatically allocate more resources during busy periods – all while keeping operational costs reasonable. Given these requirements, which deployment strategy most effectively ensures both cost- effectiveness and adaptability for scaling agentic AI systems?",
+    "a": [
+      "Scheduling periodic manual reviews to increase or decrease infrastructure based on predicted user numbers",
+      "Monitoring system logs for usage patterns and making infrastructure changes after monthly analysis",
+      "Using fixed-size virtual machine clusters to guarantee consistent resource allocation at all times",
+      "Implementing autoscaling policies in a container orchestration environment to automatically adjust resources according to workload changes"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Implementing autoscaling policies in a container orchestration environment to automatically adjust resources according to workload changes, which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Scheduling periodic manual reviews to increase or decrease infrastructure based on predicted...; B: Monitoring system logs for usage patterns and making infrastructure changes after monthly...; C: Using fixed-size virtual machine clusters to guarantee consistent resource allocation at all..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating a multi-agent customer service system experiencing unpredictable scaling costs and performance bottlenecks during peak hours, which analysis approaches effectively identify optimization opportunities for both infrastructure efficiency and service reliability? (Choose two.)",
+    "a": [
+      "Maintain consistent resource allocation across all service hours, for a more precise view of baseline traffic impact on long-term infrastructure efficiency.",
+      "Scale agent infrastructure based on aggregate performance trends, using system-wide monitoring tools to identify broader optimization patterns across resources.",
+      "Deploy agents with configurable scaling workflows, allowing analysis of resource adjustment strategies and their effects on service stability during variable demand periods.",
+      "Deploy distributed tracing with cost attribution per agent type, correlating resource consumption with business value metrics to identify optimization opportunities in agent deployment strategies.",
+      "Implement comprehensive workload profiling using NVIDIA Nsight to analyze GPU utilization patterns, identify underutilized resources, and optimize batch sizing for dynamic scaling with Kubernetes HPA."
+    ],
+    "c": [
+      3,
+      4
+    ],
+    "multi": true,
+    "e": "The selected design maps to Deploy distributed tracing with cost attribution per agent type correlating resource consumption with business value metrics to identify... and Implement comprehensive workload profiling using NVIDIA Nsight to analyze GPU utilization patterns identify underutilized resources and optimize batch..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. The NVIDIA deployment path is optimized when NIM microservices, Triton Inference Server, TensorRT-LLM engines, Kubernetes scheduling, and GPU telemetry are treated as one latency and throughput envelope."
+  },
+  {
+    "q": "When analyzing throughput bottlenecks in a multi-modal agent processing text, images, and audio, which Triton configuration evaluations identify optimization opportunities? (Choose two.)",
+    "a": [
+      "Analyze model ensemble pipelines for sequential dependencies, identify parallelization opportunities, and optimize inter-model data transfer using Triton’s scheduler .",
+      "Profile GPU memory allocation patterns across modalities, implement model instance batching strategies, and tune concurrency limits to maximize utilization.",
+      "Deploy each modality on separate Triton instances, allowing Triton to automatically manage ensemble coordination, shared memory usage, and pipeline integration.",
+      "Use a single model instance per GPU, allowing Triton to automatically optimize concurrency, batching, and multi-instance settings for throughput scaling."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "e": "The selected design maps to Analyze model ensemble pipelines for sequential dependencies identify parallelization opportunities and optimize inter-model data transfer using Triton s... and Profile GPU memory allocation patterns across modalities implement model instance batching strategies and tune concurrency limits to maximize..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on C: Deploy each modality on separate Triton instances allowing Triton to automatically manage...; D: Use a single model instance per GPU allowing Triton to automatically optimize..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing performance bottlenecks in a multi-modal agent processing customer support tickets with text, images, and voice inputs, which evaluation approach most effectively identifies optimization opportunities?",
+    "a": [
+      "Measure total response time as this analyzes aggregated performance trends across modalities, model loading times, and opportunities for parallel execution.",
+      "Profile end-to-end latency across modalities, measure model switching overhead, analyze batch processing opportunities, and evaluate Triton’s dynamic batching for multi-modal workloads.",
+      "Optimize each modality independently using dedicated profiling of cross-modal interactions, shared resource constraints, and pipeline execution strategies.",
+      "Extend evaluation to accuracy and quality metrics, incorporating resource usage patterns, latency observations, and their impact on user experience."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Profile end-to-end latency across modalities measure model switching overhead analyze batch processing opportunities and evaluate Triton s dynamic..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Measure total response time as this analyzes aggregated performance trends across modalities...; C: Optimize each modality independently using dedicated profiling of cross-modal interactions shared resource...; D: Extend evaluation to accuracy and quality metrics incorporating resource usage patterns latency..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "What benefits does a Kubernetes deployment offer over Slurm?",
+    "a": [
+      "Kubernetes provides autoscaling, auto-restarts, dynamic task scheduling, error isolation with containers, and integrated monitoring.",
+      "Kubernetes is the best option for both training and inference, offering advantages for resource management and workload visibility over traditional HPC schedulers like Slurm.",
+      "Kubernetes is more optimized for batch jobs to achieve high throughput, and also provides for monitoring and failover in large-scale workloads."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Kubernetes provides autoscaling auto-restarts dynamic task scheduling error isolation with containers and integrated monitoring, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on B: Kubernetes is the best option for both training and inference offering advantages...; C: Kubernetes is more optimized for batch jobs to achieve high throughput and..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A company plans to launch a multi-agent system that must serve thousands of users simultaneously. The team needs to ensure the system remains reliable, scales efficiently as demand increases, and operates in a cost-effective manner . Which approach is most effective for achieving robust and scalable deployment of an agentic AI system in production?",
+    "a": [
+      "Running agents without load balancing to reduce infrastructure complexity and achieve robust and scalable deployment of an agentic system",
+      "Establishing a continuous monitoring framework to track system performance and adapt resources as usage patterns evolve",
+      "Deploying all agents on a single server with ongoing performance monitoring to maximize hardware utilization",
+      "Orchestrating agents using containerization platforms, combined with load balancing and ongoing performance monitoring"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Orchestrating agents using containerization platforms combined with load balancing and ongoing performance monitoring, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Running agents without load balancing to reduce infrastructure complexity and achieve robust...; B: Establishing a continuous monitoring framework to track system performance and adapt resources...; C: Deploying all agents on a single server with ongoing performance monitoring to..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A social media company wants to expand its agentic system to support global users, minimize downtime, and ensure smooth operation during usage spikes. The team is considering various deployment and scaling strategies to achieve these goals. Which solution most effectively supports reliable and scalable deployment for an agentic AI system serving a global user base?",
+    "a": [
+      "Integrating MLOps practices for continuous deployment and rapid model updates in production environments",
+      "Designing a distributed system architecture with multi-region deployment, automated failover, and dynamic resource allocation",
+      "Implementing containerization with Docker to simplify deployment and streamline updates",
+      "Using hardware profiling to optimize agent workloads for efficient GPU utilization across all deployed instances"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Designing a distributed system architecture with multi-region deployment automated failover and dynamic resource allocation, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Integrating MLOps practices for continuous deployment and rapid model updates in production...; C: Implementing containerization with Docker to simplify deployment and streamline updates; D: Using hardware profiling to optimize agent workloads for efficient GPU utilization across..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A company is deploying a multi-agent AI system to handle large-scale customer interactions. They want to ensure the system is highly available, cost-effective, and scalable across multiple NVIDIA GPUs using container orchestration tools. Which practice is most crucial for successfully deploying and scaling an agentic AI system in production?",
+    "a": [
+      "Use a static assignment of requests across agents to maintain consistent agent operation and simplify coordination while scaling infrastructure resources as needed.",
+      "Optimize GPU utilization frameworks with workload optimization separate from cost analysis, prioritizing resource performance for peak load scenarios in deployment.",
+      "Deploy agents on a single machine to obtain a dimensioning baseline and thereby reduce setup complexity before expanding system scope.",
+      "Implementing automated workload management and resource scheduling frameworks to optimize GPU utilization and maintain service availability."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Implementing automated workload management and resource scheduling frameworks to optimize GPU utilization and maintain service availability, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Use a static assignment of requests across agents to maintain consistent agent...; B: Optimize GPU utilization frameworks with workload optimization separate from cost analysis prioritizing...; C: Deploy agents on a single machine to obtain a dimensioning baseline and..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are deploying a multi-agent customer-support system on Kubernetes using NVIDIA GPU nodes and Triton Inference Server .Traffic spikes during product launches. You need <100ms response times, zero downtime, automatic GPU scaling, and full monitoring. Which deployment setup best achieves cost-effective, reliable, low-latency scaling?",
+    "a": [
+      "Set up one mixed GPU node pool with Cluster Autoscaler min=0, scale by network throughput, monitor via metrics-server and logs, and skip readiness probes for fast startup.",
+      "Place GPU pods on on-demand nodes in one zone, disable Cluster Autoscaler, run a fixed pod count for bursts, scale on CPU usage, and monitor with default health checks.",
+      "Deploy GPU pods in a node pool spanning all zones, mix GPU types, enable Cluster and Horizontal Pod Autoscalers using Prometheus GPU and latency metrics, and monitor with NVIDIA DCGM and Grafana.",
+      "Use spot-instance node pools across zones, enable Cluster Autoscaler with capped nodes, scale on memory usage, and monitor with logs and cluster events."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Deploy GPU pods in a node pool spanning all zones mix GPU types enable Cluster and Horizontal Pod..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Set up one mixed GPU node pool with Cluster Autoscaler min 0...; B: Place GPU pods on on-demand nodes in one zone disable Cluster Autoscaler ...;D: Use spot-instance node pools across zones enable Cluster Autoscaler with capped nodes..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two deployment patterns are MOST suitable for scaling agentic workloads on NVIDIA Infrastructure? (Choose two.)",
+    "a": [
+      "Bare metal deployment with manual resource allocation",
+      "Static virtual machine deployment with fixed resources",
+      "Serverless deployment without GPU acceleration",
+      "Containerized deployment with NIM (NVIDIA Inference Microservices)",
+      "Kubernetes orchestration with Horizontal Pod Autoscaling (HPA)"
+    ],
+    "c": [
+      3,
+      4
+    ],
+    "multi": true,
+    "e": "The selected design maps to Containerized deployment with NIM NVIDIA Inference Microservices and Kubernetes orchestration with Horizontal Pod Autoscaling HPA, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Bare metal deployment with manual resource allocation; B: Static virtual machine deployment with fixed resources; C: Serverless deployment without GPU acceleration, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating an agent’s degrading response times under increasing load, which analysis approach most effectively identifies scalability bottlenecks and optimization opportunities?",
+    "a": [
+      "Track average response time while examining stage-by-stage processing metrics, resource usage trends, and potential components impacting scalability.",
+      "Test at fixed, low load levels while using controlled stress scenarios to compare with performance under production-like traffic patterns.",
+      "Profile each major system stage using distributed tracing, analyze GPU utilization with NVIDIA performance tools, and map queuing delays against varying workload patterns.",
+      "Focus on model inference duration while also measuring preprocessing time, tool-calling latency, and response formatting in the end-to-end pipeline."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Profile each major system stage using distributed tracing analyze GPU utilization with NVIDIA performance tools and map queuing..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Track average response time while examining stage-by-stage processing metrics resource usage trends...; B: Test at fixed low load levels while using controlled stress scenarios to...; D: Focus on model inference duration while also measuring preprocessing time tool-calling latency..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A company operates agent-based workloads in multiple data centers. They want to minimize latency for users in different regions, maintain continuous service during infrastructure upgrades, and keep operational costs predictable. Which deployment practice best supports low-latency, resilient, and cost-efficient agent operations at scale?",
+    "a": [
+      "Schedule regular agent downtime for system updates and operational recalibration.",
+      "Implement geo-distributed deployments with rolling updates and resource usage monitoring.",
+      "Prioritize high-performance GPUs for all agents in geo-distributed deployments.",
+      "Apply static infrastructure allocation with centralized resource usage monitoring at a single data center ."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implement geo-distributed deployments with rolling updates and resource usage monitoring, which is the highest-control path for this scenario rather than a prompt- only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Schedule regular agent downtime for system updates and operational recalibration; C: Prioritize high-performance GPUs for all agents in geo-distributed deployments; D: Apply static infrastructure allocation with centralized resource usage monitoring at a single..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When implementing stateful orchestration for agentic workflows using LangGraph, which memory management approach provides the best balance of performance and context retention?",
+    "a": [
+      "Store complete conversation history in memory with periodic database syncing",
+      "Implement rolling window memory with fixed conversation length limits",
+      "Use session-ID based checkpointer with user-defined schema for selective state persistence"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Use session-ID based checkpointer with user-defined schema for selective state persistence, which is the highest-control path for this scenario rather than a prompt- only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Store complete conversation history in memory with periodic database syncing; B: Implement rolling window memory with fixed conversation length limits, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI Engineer at an automotive company is developing an inventory restocking assistant for parts that must plan reordering of parts over multiple days, factoring in stock levels, predicted demand, and supplier lead time. Which approach best equips the agent for sequential decision-making?",
+    "a": [
+      "Reinforcement learning sequence model using only a custom PyTorch Decision Transformer",
+      "Rule-based reorder strategy with fixed thresholds implemented via NVIDIA Triton Inference Server",
+      "Hybrid supervised/RL-trained model using NeMo-Aligner for policy alignment",
+      "Reinforcement learning sequence model such as NVIDIA’S NeMo-RL framework"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Reinforcement learning sequence model such as NVIDIA S NeMo-RL framework, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. For learning and adaptation, NeMo RL, NeMo Gym, and NeMo Framework fine- tuning provide the training path, while deployment still requires external state and guardrailed execution. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Reinforcement learning sequence model using only a custom PyTorch Decision Transformer; B: Rule-based reorder strategy with fixed thresholds implemented via NVIDIA Triton Inference Server; C: Hybrid supervised/RL-trained model using NeMo-Aligner for policy alignment, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI Engineer at a retail company is developing a customer support AI agent that needs to handle multi-turn conversations while keeping track of customers’ previous queries, preferences, and unresolved issues across multiple sessions. Which approach is most effective for managing context retention and enabling the agent to respond coherently in real time?",
+    "a": [
+      "Use a sliding window of recent conversation tokens in memory to track only the last few exchanges.",
+      "Retrain the model periodically using historical logs to improve long-term contextual understanding.",
+      "Implement a hybrid memory system with vector-based search and key-value storage to retrieve relevant past interactions.",
+      "Increase the maximum context window size so the full conversation history is processed each time."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Implement a hybrid memory system with vector-based search and key- value storage to retrieve relevant past interactions, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Use a sliding window of recent conversation tokens in memory to track...; B: Retrain the model periodically using historical logs to improve long-term contextual understanding; D: Increase the maximum context window size so the full conversation history is..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI engineer at an oil and gas company is designing a multi-agent AI system to support drilling operations. Different agents are responsible for subsurface modeling, risk analysis, and resource allocation. These agents must share operational context, reason through interdependent planning steps, and justify their collaborative decisions using structured, transparent logic. The architecture must support memory persistence, sequential decision-making and chain-of-thought prompting across agents. Which implementation best supports this design?",
+    "a": [
+      "Orchestrate NeMo agents via Triton, use vector memory for shared context, ReAct planning, and NeMo Guardrails for reasoning.",
+      "Use stateless LLM endpoints behind an API gateway and pass shared prompts across agents to simulate context and reasoning.",
+      "Use LangChain to coordinate third-party agent APIs and store shared information in external memory, with logic encoded in static prompt chains.",
+      "Fine-tune separate NeMo models for each agent role using LoRA, with pre-scripted action flows deployed via TensorRT for latency reduction."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Orchestrate NeMo agents via Triton use vector memory for shared context ReAct planning and NeMo Guardrails for reasoning, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Use stateless LLM endpoints behind an API gateway and pass shared prompts...; C: Use LangChain to coordinate third- party agent APIs and store shared information in...; D: Fine-tune separate NeMo models for each agent role using LoRA with pre-scripted..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In a global financial firm, an AI Architect is building a multi-agent compliance assistant using an agentic AI framework. The system must manage short-term memory for multi-turn interactions and long-term memory for persistent user and policy context. It should enable contextual recall and adaptation across sessions using NVIDIA’s tool stack. Which architectural approach best supports these requirements?",
+    "a": [
+      "Leverage NVIDIA NeMo Framework with modular memory management, integrating conversational state tracking, knowledge graphs, and vector store retrieval, while using LoRA-tuned models to adapt responses overtime.",
+      "Leverage RAPIDS cuDF for memory tracking by streaming multi-turn conversation logs as GPU- resident data frames, assuming transactional history can be recalled and reasoned over using dataframe operations.",
+      "Rely exclusively on TensorRT to encode all prior knowledge into compiled model weights, allowing inference-only execution with no external memory dependencies across sessions.",
+      "Leverage NVIDIA Triton Inference Server with dynamic batching to cache session-level inputs between inference calls, and use an external Redis store for long-term memory."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Leverage NVIDIA NeMo Framework with modular memory management integrating conversational state tracking knowledge graphs and vector store retrieval..., which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Leverage RAPIDS cuDF for memory tracking by streaming multi-turn conversation logs as...; C: Rely exclusively on TensorRT to encode all prior knowledge into compiled model...; D: Leverage NVIDIA Triton Inference Server with dynamic batching to cache session-level inputs..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are creating a virtual assistant agent that needs to handle an increasingly wide range of tasks over an extended period. What is the primary benefit of combining external storage (like RAG) with fine-tuning (embodied memory) in this context?",
+    "a": [
+      "To enhance long-term reasoning capabilities and adaptability",
+      "To accelerate the agent’s initial response time",
+      "To ensure the agent doesn’t make any errors",
+      "To eliminate the need for external knowledge"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to To enhance long-term reasoning capabilities and adaptability, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: To accelerate the agent s initial response time; C: To ensure the agent doesn t make any errors; D: To eliminate the need for external knowledge, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A development team is building an AI agent capable of autonomously planning and executing multi- step tasks while retaining context and learning from past interactions. Which practice is most important to enable the agent to effectively manage long-term memory and complex tasks?",
+    "a": [
+      "Implement memory mechanisms for context retention and apply chain-of-thought prompts to enhance reasoning.",
+      "Use basic rule-based decision methods that emphasize fast responses over adaptive planning.",
+      "Apply short-term memory approaches that handle each interaction independently of previous ones.",
+      "Reduce planning features and memory management to keep the system streamlined."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Implement memory mechanisms for context retention and apply chain- of-thought prompts to enhance reasoning, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session- scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Use basic rule-based decision methods that emphasize fast responses over adaptive planning; C: Apply short-term memory approaches that handle each interaction independently of previous ones; D: Reduce planning features and memory management to keep the system streamlined, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are developing an agent that needs to perform a complex set of tasks repeatedly. Why is periodic fine-tuning an important aspect of long-term knowledge retention for this type of agent?",
+    "a": [
+      "It prevents the agent from becoming overly specialized to a single task.",
+      "It eliminates the need for external storage like RAG.",
+      "It prevents the agent from forgetting past successes and failures.",
+      "It guarantees the agent will produce the same output for the same input."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to It prevents the agent from forgetting past successes and failures, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: It prevents the agent from becoming overly specialized to a single task; B: It eliminates the need for external storage like RAG; D: It guarantees the agent will produce the same output for the same..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An agent is tasked with solving a series of complex mathematical problems that require external tools to find information. It often struggles to keep track of intermediate steps and reasoning. Which prompting technique would be MOST effective in improving the agent’s clarity and reducing errors in its reasoning?",
+    "a": [
+      "ReAct",
+      "Symbolic Planning",
+      "Zero-shot CoT",
+      "Multi-Plan Generation"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to ReAct, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on B: Symbolic Planning; C: Zero-shot CoT; D: Multi-Plan Generation, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. At NVIDIA scale, this is the difference between an agent loop that merely calls an LLM and a production agent service that can coordinate reasoning, actions, memory, and handoffs across concurrent sessions."
+  },
+  {
+    "q": "When analyzing memory-related performance degradation in agents handling extended customer support sessions, which evaluation methods effectively identify optimization opportunities for context retention? (Choose two.)",
+    "a": [
+      "Clear memory after each interaction and reset session state, removing historical context needed for personalized tasks to identify optimization opportunities.",
+      "Profile memory access patterns by measuring retrieval latency, relevance scoring accuracy, and storage efficiency while monitoring context window utilization to identify optimization opportunities.",
+      "Use fixed memory allocation including all conversation types, topic changes, and user needs, allowing adaptive-free observation of interaction patterns to identify optimization opportunities.",
+      "Implement sliding window analysis comparing context compression strategies, summarization quality, and information preservation rates across varying conversation lengths to identify optimization opportunities.",
+      "Store all conversation history including all interactions, allowing adaptive-free observation of data to identify optimization opportunities."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Profile memory access patterns by measuring retrieval latency relevance scoring accuracy and storage efficiency while monitoring context window... and Implement sliding window analysis comparing context compression strategies summarization quality and information preservation rates across varying conversation lengths..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A team is designing an AI assistant that helps users with travel planning. The assistant should remember user preferences, build personalized itineraries, and update plans when users provide new requirements. Which approach best equips the AI assistant to provide personalized and adaptive travel recommendations?",
+    "a": [
+      "Using a single-step question-answering system enhanced with session-level keyword tracking to improve relevance during ongoing interactions.",
+      "Designing the assistant to handle each user request independently, while using implicit signals within each session to suggest relevant options.",
+      "Engineering multi-step reasoning frameworks with persistent memory systems to store and utilize user preferences.",
+      "Providing the same set of travel options to every user but sorting them based on recent popular destinations."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Engineering multi-step reasoning frameworks with persistent memory systems to store and utilize user preferences, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Using a single-step question-answering system enhanced with session-level keyword tracking to improve...; B: Designing the assistant to handle each user request independently while using implicit...; D: Providing the same set of travel options to every user but sorting..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which memory architecture is most appropriate for an agent that must track conversation flow and remember user preferences across multiple interactions?",
+    "a": [
+      "Implement shared memory using NVSHMEM for short- and long-term context",
+      "Single unified memory store with time-based expiration policies",
+      "Hierarchical memory with separate short-term and long-term layers",
+      "Distributed memory with full replication across all nodes"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Hierarchical memory with separate short-term and long-term layers, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Implement shared memory using NVSHMEM for short and long-term context; B: Single unified memory store with time-based expiration policies; D: Distributed memory with full replication across all nodes, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Implement Memory Systems for Contextual Awareness An enterprise AI system needs to maintain contextual information over multiple interactions with users. Which memory implementation approach would be MOST effective for managing both immediate context and long-term historical interactions within an agentic workflow?",
+    "a": [
+      "Rely predominantly on the context window of the base LLM model to store all historical interactions with minimal external memory supplementation.",
+      "Implement a hybrid memory system with short-term memory for immediate context and a vector database for long-term memory with semantic retrieval capabilities.",
+      "Use a static prompt template with fixed context for all interactions, thereby providing memory information in that form across conversation sessions.",
+      "Store all user interactions in a simple key-value database which will by default provide organization and retrieval strategy for historical context management."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implement a hybrid memory system with short-term memory for immediate context and a vector database for long-term memory..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Rely predominantly on the context window of the base LLM model to...; C: Use a static prompt template with fixed context for all interactions thereby...; D: Store all user interactions in a simple key-value database which will by..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An enterprise wants their AI agent to support complex project management tasks. The agent should remember ongoing project details, adjust its plans based on new information, and break down large goals into actionable steps. Which strategy best enables the AI agent to autonomously decompose tasks and adapt to new Information over time?",
+    "a": [
+      "Predefining static workflows for each project type to guarantee consistent execution",
+      "Developing long-term knowledge retention strategies and dynamic state management for adaptive planning",
+      "Storing recent user interactions in a temporary cache for immediate retrieval",
+      "Applying rule-based logic to each new request isolated from previous project data"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Developing long-term knowledge retention strategies and dynamic state management for adaptive planning, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Predefining static workflows for each project type to guarantee consistent execution; C: Storing recent user interactions in a temporary cache for immediate retrieval; D: Applying rule-based logic to each new request isolated from previous project data, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In a ReAct (Reasoning-Acting) agent architecture, what is the correct sequence of operations when the agent encounters a complex multi-step problem requiring external tool usage?",
+    "a": [
+      "Thought --> Answer --> Action --> Observation",
+      "Action --> Thought --> Observation --> Action --> Thought --> Observation --> Answer",
+      "Observation --> Thought --> Action --> Observation --> Thought --> Action --> Answer",
+      "Thought --> Action --> Observation --> Thought --> Action --> Observation --> Answer"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Thought Action Observation Thought Action Observation Answer, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Thought Answer Action Observation; B: Action Thought Observation Action Thought Observation Answer; C: Observation Thought Action Observation Thought Action Answer, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "What is a key limitation of Chain-of-Thought (CoT) prompting when using smaller language models for reasoning tasks?",
+    "a": [
+      "CoT prompting simplifies error analysis for small models, making it easy to identify and correct mistakes at each reasoning step.",
+      "CoT prompting ensures step-by-step outputs, enabling even small models to solve complex problems reliably.",
+      "CoT prompting requires relatively large models; smaller models may produce reasoning chains that appear logical but are actually incorrect, leading to poorer performance.",
+      "CoT prompting consistently improves the logical accuracy of outputs for both small and large language models."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to CoT prompting requires relatively large models smaller models may produce reasoning chains that appear logical but are actually..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: CoT prompting simplifies error analysis for small models making it easy to...; B: CoT prompting ensures step-by-step outputs enabling even small models to solve complex...; D: CoT prompting consistently improves the logical accuracy of outputs for both small..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In a production agentic system handling thousands of concurrent conversations, which state management strategy provides optimal performance while ensuring context preservation?",
+    "a": [
+      "Global shared state with locks for concurrent access",
+      "Session-isolated state with serialization and lazy loading",
+      "Stateless design with context reconstruction from message history"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Session-isolated state with serialization and lazy loading, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For stateful agents, memory must be explicit: session-scoped state, selective persistence, vector recall, and compact summaries prevent context loss without bloating every prompt. Agentic systems need explicit decomposition: a planner or coordinator defines the work, specialized agents or tools execute bounded actions, and memory/state is preserved only where it improves the next decision. That structure increases maintainability because each agent role, message contract, and state transition can be tested independently under load. The distractors are weaker because they lean on A: Global shared state with locks for concurrent access; C: Stateless design with context reconstruction from message history, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A company is building an AI agent that must retrieve information from large document collections and client databases in real time. The team wants to ensure fast, accurate retrieval and maintain high data quality. Which approach best supports efficient knowledge integration and effective data handling for such an agent?",
+    "a": [
+      "Using traditional relational databases because they don’t need specialized retrieval mechanisms for all data queries",
+      "Integrating client data sources as they already incorporate data quality checks or augmentation to speed up deployment",
+      "Relying on pre-trained models instead of connecting to external knowledge sources during inference",
+      "Implementing retrieval-augmented generation (RAG) pipelines combined with vector databases to accelerate access to relevant information"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Implementing retrieval-augmented generation RAG pipelines combined with vector databases to accelerate access to relevant information, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Using traditional relational databases because they don t need specialized retrieval mechanisms...; B: Integrating client data sources as they already incorporate data quality checks or ...; C: Relying on pre-trained models instead of connecting to external knowledge sources during..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "What is RAG Fusion primarily designed to achieve?",
+    "a": [
+      "Creating a separate, dedicated database for storing all the retrieved chunks.",
+      "Minimizing the need for retrieval, allowing the LLM to generate responses directly from its internal knowledge.",
+      "Blending information from multiple retrieved chunks into a single response generated by the LLM.",
+      "Automatically translating and integrating all retrieved chunks into a single language."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Blending information from multiple retrieved chunks into a single response generated by the LLM, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Creating a separate dedicated database for storing all the retrieved chunks; B: Minimizing the need for retrieval allowing the LLM to generate responses directly...; D: Automatically translating and integrating all retrieved chunks into a single language, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI agent is being built to execute database queries, generate reports, and interact with cloud services. Which design choice best improves long-term scalability and maintainability when adding new tools?",
+    "a": [
+      "Hardcoding each new tool directly into the agent’s core logic",
+      "Using a plugin-based system with uniform tool registration and invocation",
+      "Implementing all tools inside a single large function with many if-else branches",
+      "Storing tool parameters as unstructured text parsed at runtime"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Using a plugin-based system with uniform tool registration and invocation, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Hardcoding each new tool directly into the agent s core logic; C: Implementing all tools inside a single large function with many if-else branches; D: Storing tool parameters as unstructured text parsed at runtime, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI agent must interact with multiple external services, handle variable user requests, and maintain reliable operation in production. Which design principle is most critical for ensuring stable and resilient integration with external systems?",
+    "a": [
+      "Bypassing error handling to reduce latency during API calls",
+      "Implementing timeouts and circuit breakers for external service calls",
+      "Storing all external credentials directly in the agent’s source code",
+      "Using hardcoded endpoints without configuration management"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implementing timeouts and circuit breakers for external service calls, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Bypassing error handling to reduce latency during API calls; C: Storing all external credentials directly in the agent s source code; D: Using hardcoded endpoints without configuration management, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "In your RAG deployment, you’ve identified a performance bottleneck in the retrieval phase – specifically, the time it takes to access the vector database. Which of the following optimization strategies is most aligned with micro-service best practices, considering your RAG architecture?",
+    "a": [
+      "Implement a “cache-and-check” mechanism where the retrieval microservice immediately returns the first matching chunk, regardless of relevance.",
+      "Increase the size of the LLM model itself, because it will automatically accelerate the overall response time.",
+      "Introduce a dedicated service responsible solely for querying the vector database and returning relevant chunks.",
+      "Optimize the LLM prompt to be shorter and more concise, significantly reducing the computational load."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Introduce a dedicated service responsible solely for querying the vector database and returning relevant chunks, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Implement a cache-and-check mechanism where the retrieval microservice immediately returns the first...; B: Increase the size of the LLM model itself because it will automatically...; D: Optimize the LLM prompt to be shorter and more concise significantly reducing..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your agent is designed to manage tasks through a service management API. The API responds with detailed event logs, but these logs contain both metadata and structured data. To ensure the agent correctly interprets and processes the data from these logs, what’s the most prudent approach?",
+    "a": [
+      "Employ a specialized parser that adheres to the API’s documentation, to insure strict adherence to structured data.",
+      "Employing a modular design that allows the agent to dynamically adjust its parsing logic.",
+      "Using a human-in-the-loop approach, manually inspecting and interpreting each log entry.",
+      "Employ a specialized parser that extracts all data fields, regardless of their type."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Employ a specialized parser that adheres to the API s documentation to insure strict adherence to structured data, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema- bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on B: Employing a modular design that allows the agent to dynamically adjust its...; C: Using a human-in-the-loop approach manually inspecting and interpreting each log entry; D: Employ a specialized parser that extracts all data fields regardless of their ...,which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your deployed legal assistant shows great performance but occasionally repeats incorrect legal terms. Which tuning method best improves factual reliability?",
+    "a": [
+      "Replace retrieval with static hard-coded text snippets",
+      "Use more verbose prompts to reinforce correct definitions",
+      "Increase output randomness to improve exploration",
+      "Add fact-checking steps using external tools during generation"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Add fact-checking steps using external tools during generation, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Replace retrieval with static hard-coded text snippets; B: Use more verbose prompts to reinforce correct definitions; C: Increase output randomness to improve exploration, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI Engineer is experimenting with data retrieval performance within a RAG system. Which of the following techniques is most likely to improve the quality of the retrieved chunks?",
+    "a": [
+      "Adding clarifying keywords and synonyms to the original query to broaden the search.",
+      "Truncating long queries to fit within the LLM’s context window.",
+      "Using a single, highly specific keyword to guarantee a precise match.",
+      "Directly feeding the original query to the LLM without any modification."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Adding clarifying keywords and synonyms to the original query to broaden the search, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on B: Truncating long queries to fit within the LLM s context window; C: Using a single highly specific keyword to guarantee a precise match; D: Directly feeding the original query to the LLM without any modification, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re building a RAG system that uses RAG Fusion. Which of the following approaches would be most effective in determining how to combine information from multiple retrieved chunks?",
+    "a": [
+      "Filtering out chunks considered inconsistent with others before presenting information to the LLM.",
+      "Using the LLM to automatically identify the most important sentences within each chunk and combine them.",
+      "Manually selecting the most relevant sentences from each chunk and inserting them into the LLM prompt.",
+      "Concatenating the text from all retrieved chunks into a single block to form the response."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Using the LLM to automatically identify the most important sentences within each chunk and combine them, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Filtering out chunks considered inconsistent with others before presenting information to the...; C: Manually selecting the most relevant sentences from each chunk and inserting them...; D: Concatenating the text from all retrieved chunks into a single block to..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are designing the architecture for a RAG (Retrieval-Augmented Generation) system, and you are concerned about ensuring data freshness and minimizing latency. Which of the following is the most important consideration when designing the architecture?",
+    "a": [
+      "Employing a consolidated architecture with a large service handling all data retrieval and LLM interaction. This ensures consistent performance and simplifies debugging.",
+      "Using a synchronous, block-level approach, where the LLM continuously monitors the database for updates and retrieves the entire dataset with each prompt.",
+      "Implementing a single, centralized database for all data, updated with a synchronous polling mechanism for the LLM to retrieve the latest information.",
+      "Use a loosely coupled, event-driven micro-service architecture where separate services handle data indexing, retrieval, and LLM prompting."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Use a loosely coupled event-driven micro-service architecture where separate services handle data indexing retrieval and LLM prompting, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Employing a consolidated architecture with a large service handling all data retrieval...; B: Using a synchronous block-level approach where the LLM continuously monitors the database...; C: Implementing a single centralized database for all data updated with a synchronous..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re developing an agent that monitors social media mentions of your brand. The social media platform’s API returns data mentioning your brand with varying confidence scores that the brand was actually being mentioned, but these scores aren’t consistently calibrated. Considering the unreliability of these confidence scores, what’s the most reliable way for the agent to insure it is truly processing media mentions of the brand?",
+    "a": [
+      "Using an approach that filters mentions with basic keyword search and removes those with exceptionally low confidence scores, relying on the API data as a first-pass filter .",
+      "Using an approach that treats all mentions as equally reliable, regardless of their confidence scores, and applies a uniform data processing workflow to minimize inconsistency.",
+      "Using a threshold-based approach, accepting mentions only if their confidence score exceeds a predefined level that aligns with typical thresholds used for well-calibrated APIs.",
+      "Using an approach that combines the agent’s text analysis with the API’s confidence score, weighing the agent’s assessment more heavily when identifying mentions."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Using an approach that combines the agent s text analysis with the API s confidence score weighing the..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: Using an approach that filters mentions with basic keyword search and removes...; B: Using an approach that treats all mentions as equally reliable regardless of...; C: Using a threshold-based approach accepting mentions only if their confidence score exceeds..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Optimize agentic workflow performance with the NVIDIA Agent Intelligence Toolkit. Your organization is building a complex multi-agent system that needs to connect agents built on different frameworks while maintaining optimal performance. Which key features of the NVIDIA Agent Intelligence Toolkit would be MOST beneficial for this implementation?",
+    "a": [
+      "The toolkit is limited to simple agent-to-agent communication but cannot orchestrate complex multi-agent workflows.",
+      "The toolkit provides framework-agnostic integration ensuring reusability of components.",
+      "The toolkit is designed exclusively for NVIDIA framework agents and cannot integrate with other frameworks.",
+      "The toolkit focuses primarily on agent development but lacks evaluation capabilities."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to The toolkit provides framework-agnostic integration ensuring reusability of components, which is the highest-control path for this scenario rather than a prompt- only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The agent should not infer operational details from latent model knowledge when it can bind to structured tools, retrievers, schemas, and examples. This reduces hallucinated endpoints, malformed parameters, stale facts, and brittle parsing when APIs, documents, or user inputs change. The distractors are weaker because they lean on A: The toolkit is limited to simple agent-to-agent communication but cannot orchestrate complex...; C: The toolkit is designed exclusively for NVIDIA framework agents and cannot integrate...; D: The toolkit focuses primarily on agent development but lacks evaluation capabilities, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two optimization strategies are MOST effective for improving agent performance on NVIDIA GPU infrastructure? (Choose two.)",
+    "a": [
+      "Using multi-GPU coordination to distribute workloads, enabling higher throughput and efficiency for scaling agent tasks.",
+      "Applying TensorRT-LLM optimizations to reduce inference latency by improving kernel efficiency and memory usage.",
+      "Expanding GPU memory capacity to support larger models, assuming this alone guarantees meaningful performance improvements.",
+      "Manually tuning kernel launch parameters to optimize individual operations while overlooking overall pipeline performance dynamics."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "e": "The selected design maps to Using multi-GPU coordination to distribute workloads enabling higher throughput and efficiency for scaling agent tasks and Applying TensorRT-LLM optimizations to reduce inference latency by improving kernel efficiency and memory usage, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on C: Expanding GPU memory capacity to support larger models assuming this alone guarantees...; D: Manually tuning kernel launch parameters to optimize individual operations while overlooking overall..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are rolling out a multimodal conversational agent on NVIDIA’s stack: the model is containerized as a TensorRT-LLM engine, served via Triton Inference Server behind NIM microservices for routing and scaling, and protected by NeMo Guardrails for safety and compliance. During early testing, end- to-end latency exceeds your target budget, and you need to tune batching, model precision, and guardrail checks while maintaining both throughput and enforcement of safety policies. Which configuration change is most effective for reducing latency under these constraints while still enforcing NeMo Guardrails policies?",
+    "a": [
+      "Quantize the TensorRT-LLM engine to FP16, tune Triton’s dynamic batching, and integrate NeMo Guardrails alongside inference to run policy checks in parallel.",
+      "Quantize the TensorRT-LLM engine to INT8, disable dynamic batching, and invoke Guardrails checks synchronously within the inference path.",
+      "Deploy separate Triton servers for model inference and guardrail validation, routing requests sequentially and merging outputs at the application layer .",
+      "Keep FP32 precision, increase batch size aggressively, and perform Guardrails checks in a downstream microservice after inference."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Quantize the TensorRT-LLM engine to FP16 tune Triton s dynamic batching and integrate NeMo Guardrails alongside inference to..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after- the-fact tuning knobs. The distractors are weaker because they lean on B: Quantize the TensorRT-LLM engine to INT8 disable dynamic batching and invoke Guardrails...; C: Deploy separate Triton servers for model inference and guardrail validation routing requests...; D: Keep FP32 precision increase batch size aggressively and perform Guardrails checks in..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A healthcare AI company is deploying diagnostic agents that process medical imaging and patient dat a. The system must deliver consistent sub-100ms inference times for critical diagnoses while supporting deployment across multiple hospital sites with different NVIDIA GPU configurations (from RTX 6000 workstations to DGX systems). The agents need to maintain high accuracy while being portable across different hardware environments and capable of running efficiently on various GPU memory configurations. Which optimization strategy would deliver the BEST performance improvements while maintaining deployment flexibility across diverse NVIDIA hardware configurations?",
+    "a": [
+      "Deploy agents with NVIDIA CUDA-optimized Docker containers using a sequential inference architecture that processes each layer individually with GPU-to-CPU memory transfers between operations to avoid memory issues.",
+      "Deploy agents using NVIDIA NIM containers with CPU-optimized inference to avoid GPU memory constraints and ensure consistent performance across different hospital infrastructure configurations.",
+      "Deploy models using NVIDIA TensorRT optimization in their original FP32 precision format without any quantization or memory optimization, requiring 32GB+ GPU memory across all deployment sites.",
+      "Deploy agents using model optimizations with post-training quantization with Nvidia NIM deployment for portable performance across different GPU platforms and memory configurations."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Deploy agents using model optimizations with post-training quantization with Nvidia NIM deployment for portable performance across different GPU..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Deploy agents with NVIDIA CUDA-optimized Docker containers using a sequential inference architecture...; B: Deploy agents using NVIDIA NIM containers with CPU-optimized inference to avoid GPU...; C: Deploy models using NVIDIA TensorRT optimization in their original FP32 precision format..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are tasked with deploying a multi-modal agentic system that must respond to user queries with minimal latency while maintaining guardrails for safe and context-aware interactions. Which of the following configurations best leverages NVIDIA’s AI stack to meet these requirements?",
+    "a": [
+      "Integrate NeMo Guardrails, configure NIM microservices for optimized inference, use TensorRT- LLM for deployment, and profile the system using Triton Inference Server with multi-modal support.",
+      "Integrate NeMo Guardrails, use Omniverse to generate synthetic data, configure NIM microservices for optimized inference, use TensorRT-LLM for deployment, and profile the system using NeMo Agent Toolkit for multi-modal support.",
+      "Use NeMo Guardrails for safety, deploy the model with Triton Inference Server using default settings, and rely on hardware accelerators like GPU/TPU inference for cost efficiency.",
+      "Use NIM microservices for deployment, optionally use NeMo Guardrails unless one wants to minimize the inference overhead."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Integrate NeMo Guardrails configure NIM microservices for optimized inference use TensorRT-LLM for deployment and profile the system using..., which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on B: Integrate NeMo Guardrails use Omniverse to generate synthetic data configure NIM microservices...; C: Use NeMo Guardrails for safety deploy the model with Triton Inference Server ...;D: Use NIM microservices for deployment optionally use NeMo Guardrails unless one wants..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Integrate NeMo Guardrails, configure NIM microservices for optimized inference, use TensorRT-LLM for deployment, and profile the system using Triton Inference Server with multi-modal support. Which of the following strategies aligns with best practices for operationalizing and scaling such Agentic systems?",
+    "a": [
+      "Use Docker containers orchestrated by Kubernetes, implement MLOps pipelines for CI/CD, monitor agent health with Prometheus/Grafana.",
+      "Deploy agents on bare-metal servers to maximize performance and avoid container overhead, using manual scripts for orchestration and monitoring.",
+      "Deploy all agents on a single high-performance GPU node to reduce latency, and use cron jobs for periodic health checks and updates.",
+      "Run agents as independent serverless functions to minimize infrastructure management, relying primarily on cloud provider auto-scaling and logging tools."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Use Docker containers orchestrated by Kubernetes implement MLOps pipelines for CI/CD monitor agent health with Prometheus/Grafana, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on B: Deploy agents on bare-metal servers to maximize performance and avoid container overhead...; C: Deploy all agents on a single high-performance GPU node to reduce latency...; D: Run agents as independent serverless functions to minimize infrastructure management relying primarily..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating optimization opportunities between NeMo Guardrails, NIM microservices, and TensorRT-LLM in a production healthcare agent, which analysis approach best identifies optimization opportunities across the NVIDIA stack?",
+    "a": [
+      "Conduct stress testing of individual microservices and guardrails to measure peak throughput and determine theoretical performance limits of each module.",
+      "Use default configurations to establish a deployment baseline, focusing on stability before conducting deeper performance profiling.",
+      "Create end-to-end latency waterfalls that capture guardrail overhead, NIM queuing delays, and TensorRT optimization benefits while assessing overall pipeline efficiency.",
+      "Tune each component individually, focusing primarily on local performance metrics with secondary attention to integration patterns."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Create end-to-end latency waterfalls that capture guardrail overhead NIM queuing delays and TensorRT optimization benefits while assessing overall..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Conduct stress testing of individual microservices and guardrails to measure peak throughput...; B: Use default configurations to establish a deployment baseline focusing on stability before...; D: Tune each component individually focusing primarily on local performance metrics with secondary..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating GPU utilization inefficiencies in deploying Llama Nemotron models across A100 and H100 clusters, which approaches help identify optimal resource allocation strategies? (Choose two.)",
+    "a": [
+      "Allow Nemotron variants to profile actual workload characteristics and allocate resources based on observed demands.",
+      "Profile resource utilization for each Nemotron variant and match models to appropriate GPU tiers.",
+      "Allocate all agents to Hl00 GPUs, allowing resource profiles to automatically adjust for model size and computational requirements.",
+      "Assess concurrent execution capabilities by employing multi-instance GPU partitioning for varying workload types."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Profile resource utilization for each Nemotron variant and match models to appropriate GPU tiers and Assess concurrent execution capabilities by employing multi-instance GPU partitioning for varying workload types, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Allow Nemotron variants to profile actual workload characteristics and allocate resources based...; C: Allocate all agents to Hl00 GPUs allowing resource profiles to automatically adjust..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A financial services company is deploying a multi-agent customer service system consisting of three specialized agents: a reasoning LLM for complex queries, an embedding agent for document retrieval, and a re-ranking agent for result optimization. The system experiences significant traffic variations, with peak loads during business hours (10x normal traffic) and minimal usage overnight. The company needs a deployment solution that can handle these fluctuations cost-effectively while maintaining sub-second response times during peak periods. Which NVIDIA infrastructure approach would provide the MOST cost-effective and scalable deployment solution for this variable-load multi-agent system?",
+    "a": [
+      "Deploy agents directly on individual NVIDIA RTX workstations without containerization or orchestration, relying on load balancers with round-robin for traffic distribution.",
+      "Deploy each agent on dedicated NVIDIA DGX systems with manual scaling based on previous days traffic predictions and static resource allocation for peak loads.",
+      "Deploy NVIDIA NIM microservices on Kubernetes with auto-scaling capabilities, utilizing NVIDIA NIM Operator for lifecycle management and horizontal pod autoscaling based on custom metrics.",
+      "Deploy all agents on a single large GPU instance without containerization, scaling compute by upgrading to larger GPU instances when needed."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Deploy NVIDIA NIM microservices on Kubernetes with auto-scaling capabilities utilizing NVIDIA NIM Operator for lifecycle management and horizontal..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. Performance comes from matching workload shape to serving topology: small requests, large reasoning calls, embeddings, rerankers, and multimodal models should scale on separate resource signals. GPU utilization, queue depth, dynamic batching, model precision, and container lifecycle are therefore first-class design variables, not after-the-fact tuning knobs. The distractors are weaker because they lean on A: Deploy agents directly on individual NVIDIA RTX workstations without containerization or orchestration...; B: Deploy each agent on dedicated NVIDIA DGX systems with manual scaling based...; D: Deploy all agents on a single large GPU instance without containerization scaling..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your team notices a spike in failed tool calls from a deployed workflow agent after a recent API schema update. The agent still returns outputs, but many are irrelevant or incomplete. Which maintenance task should be prioritized to restore accurate behavior?",
+    "a": [
+      "Reset the agent’s long-term memory and reinitialize logs.",
+      "Update the tool function specifications and re-test action sequences.",
+      "Increase model temperature to encourage tool exploration.",
+      "Reduce tool retrieval vector similarity threshold to broaden context."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Update the tool function specifications and re-test action sequences, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Reset the agent s long-term memory and reinitialize logs; C: Increase model temperature to encourage tool exploration; D: Reduce tool retrieval vector similarity threshold to broaden context, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating an agent’s integration with external tools and APIs for data retrieval and action execution, which analysis approaches effectively identify reliability and performance issues? (Choose two.)",
+    "a": [
+      "Implement comprehensive API call tracing with latency measurement, success rates per endpoint, and correlation analysis between tool failures and task completion.",
+      "Use static API endpoints and parameters configured during development, allowing consistent and effective agent integration across predictable workflows.",
+      "Connect to external APIs with standard procedures and monitor request and response exchanges to isolate the analysis of integration reliability and effectiveness.",
+      "Design integration tests simulating API version changes, schema modifications, and backward compatibility scenarios to ensure reliable tool connections across updates."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Implement comprehensive API call tracing with latency measurement success rates per endpoint and correlation analysis between tool failures... and Design integration tests simulating API version changes schema modifications and backward compatibility scenarios to ensure reliable tool connections..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Use static API endpoints and parameters configured during development allowing consistent and...; C: Connect to external APIs with standard procedures and monitor request and response..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A recently deployed agent sometimes outputs empty responses under heavy system load. Which system-level signal is most useful for diagnosing this issue?",
+    "a": [
+      "Number of tool function arguments returned per query",
+      "Retrieval similarity thresholds in vector search",
+      "GPU memory utilization and server-side inference logs",
+      "Prompt injection detection rate over time"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to GPU memory utilization and server-side inference logs, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Number of tool function arguments returned per query; B: Retrieval similarity thresholds in vector search; D: Prompt injection detection rate over time, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI architect at a national healthcare provider is maintaining an agentic AI system. The system must monitor model and system performance in real time, raise alerts on failures or anomalies, manage version control and rollback of diagnostic models, and provide transparent insight into agent behavior during patient care workflows. Which operational approach best supports these requirements using the NVIDIA AI stack?",
+    "a": [
+      "Containerize each agent in NIM with basic health checks running on cron jobs, and manage version rollback by swapping prebuilt container images.",
+      "Optimize all models with TensorRT and use periodic manual log reviews and NVIDIA shell scripts for detecting service anomalies and managing rollback.",
+      "Deploy agent models on NVIDIA Triton Inference Server with Prometheus and Grafana for performance alerting, and manage model lifecycle via NGC and the Triton model repository.",
+      "Expose agents as stateless NVIDIA API endpoints and monitor activity through application logs, with model versions tracked in a Git-based script repository."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Deploy agent models on NVIDIA Triton Inference Server with Prometheus and Grafana for performance alerting and manage model..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Containerize each agent in NIM with basic health checks running on cron...; B: Optimize all models with TensorRT and use periodic manual log reviews and...; D: Expose agents as stateless NVIDIA API endpoints and monitor activity through application..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are building a customer-support chatbot that fetches user account data from an external billing API. During testing, the API sometimes returns timeouts or 500 errors. You want the agent to be resilient-retrying when appropriate but failing gracefully if the service is down. Which strategy best handles intermittent failures in API calls while still ensuring a good user experience?",
+    "a": [
+      "Retry requests with a consistent short delay after each failure and notify the user as each retry takes place.",
+      "Implement exponential-backoff retries with a circuit breaker, and return a clear message to the user if all retries fail.",
+      "Return a standard fallback message on failures to maintain conversation flow and reduce the risk of service interruptions for the user .",
+      "Schedule retries using a fixed delay for all failure types, maintaining predictable timing and user notifications after each attempt."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implement exponential-backoff retries with a circuit breaker and return a clear message to the user if all retries..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema- bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Retry requests with a consistent short delay after each failure and notify...; C: Return a standard fallback message on failures to maintain conversation flow and...; D: Schedule retries using a fixed delay for all failure types maintaining predictable..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When evaluating a customer service agent’s resilience to API failures and network issues, which analysis methods effectively identify weaknesses in error handling and retry mechanisms? (Choose two.)",
+    "a": [
+      "Analyze retry logic for exponential backoff patterns, retry limits, and circuit breaker integration to prevent cascading failures in distributed systems.",
+      "Implement retry mechanisms that standardize recovery attempts across scenarios, emphasizing consistency in handling errors.",
+      "Use fixed retry intervals to avoid the pitfalls of dynamic tuning, keeping retry timing consistent across different error conditions.",
+      "Test under normal network conditions to establish baseline behavior, comparing results against production performance during degraded service scenarios.",
+      "Conduct failure injection testing with varied error types (timeouts, rate limits, malformed responses) while monitoring recovery patterns and fallback behavior ."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "e": "The selected design maps to Analyze retry logic for exponential backoff patterns retry limits and circuit breaker integration to prevent cascading failures in... and Conduct failure injection testing with varied error types timeouts rate limits malformed responses while monitoring recovery patterns and..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An autonomous vehicle company operates a multi-agent AI system across its fleet to process real- time sensor data, make driving decisions, and communicate with cloud infrastructure. The company needs fleet-wide monitoring to track GPU utilization, inference times, and memory usage, correlate performance with driving conditions and system load, and predict safety issues before they occur . Which monitoring and observability approach would BEST meet these fleet-scale, safety-critical requirements?",
+    "a": [
+      "Deploy NVIDIA NIM microservices with Prometheus integration, NVIDIA Nsight Systems profiling, and Kubernetes-native monitoring to provide detailed metrics, profiling, and container orchestration observability across the entire stack.",
+      "Implement layered application monitoring with distributed tracing, synthetic transaction monitoring, and custom dashboards to capture complex dependencies, transaction flow, and service- level performance trends across the fleet.",
+      "Implement comprehensive APM solutions with real-time baselines, automated root cause analysis, and fleet management integration to coordinate operational insights and performance management across thousands of vehicles.",
+      "Deploy enterprise telemetry using OpenTelemetry standards with machine learning-based anomaly detection, custom performance visualization, and automated alerting to deliver predictive operational insights and support proactive maintenance actions."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Deploy NVIDIA NIM microservices with Prometheus integration NVIDIA Nsight Systems profiling and Kubernetes-native monitoring to provide detailed metrics..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Implement layered application monitoring with distributed tracing synthetic transaction monitoring and custom...; C: Implement comprehensive APM solutions with real-time baselines automated root cause analysis and...; D: Deploy enterprise telemetry using OpenTelemetry standards with machine learning-based anomaly detection custom..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are implementing Agentic AI within an Enterprise AI Factory. You are focused on the operation and scaling of the agentic systems including each of the Enterprise AI Factory components. Which observability strategy involves providing detailed insights into the system’s performance? (Choose two.)",
+    "a": [
+      "Detailed model and application tracing for identifying performance bottlenecks.",
+      "Centralized logging to track system events.",
+      "Continuous monitoring of key metrics using OpenTelemetry (OTEL).",
+      "Artifact repository used by the AI agents where all the system performance metrics are stored."
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The selected design maps to Detailed model and application tracing for identifying performance bottlenecks and Continuous monitoring of key metrics using OpenTelemetry OTEL, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Centralized logging to track system events; D: Artifact repository used by the AI agents where all the system performance..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your support agent frequently fails to complete tasks when third-party tools return unexpected formats. Which solution improves resilience against these failures?",
+    "a": [
+      "Add robust schema validation and exception handling for all tool outputs",
+      "Use deterministic temperature settings for all generations",
+      "Reduce the number of tools available to avoid bad integrations",
+      "Re-train the model to avoid the use of third-party tools entirely"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Add robust schema validation and exception handling for all tool outputs, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Use deterministic temperature settings for all generations; C: Reduce the number of tools available to avoid bad integrations; D: Re-train the model to avoid the use of third- party tools entirely, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two error handling strategies are MOST important for maintaining agent reliability in production environments? (Choose two.)",
+    "a": [
+      "Circuit breaker patterns for external service calls",
+      "Immediate failure propagation to users with verbose logging",
+      "Automatic retry with exponential backoff for transient failures",
+      "Immediate system shutdown for error handling"
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The selected design maps to Circuit breaker patterns for external service calls and Automatic retry with exponential backoff for transient failures, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Immediate failure propagation to users with verbose logging; D: Immediate system shutdown for error handling, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A customer service agent sometimes fails to complete multi-step workflows when APIs respond slowly or inconsistently. Which approach most effectively increases robustness when working with unreliable APIs?",
+    "a": [
+      "Restrict available tools to reduce decision complexity",
+      "Add retries with exponential backoff and set request timeouts",
+      "Cache recent API results to limit unnecessary repeated calls",
+      "Adjust generation parameters to produce more predictable responses"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Add retries with exponential backoff and set request timeouts, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Restrict available tools to reduce decision complexity; C: Cache recent API results to limit unnecessary repeated calls; D: Adjust generation parameters to produce more predictable responses, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are building an agent that performs financial analysis by retrieving and processing structured data from a client’s internal SQL database. The agent must handle occasional connection errors and retry the query up to a few times before failing gracefully. Which approach best meets these requirements?",
+    "a": [
+      "Use structured tool calls with built-in retry handling and timed delays inside the tool wrapper",
+      "Use few-shot prompting to guide the agent’s conversation flow and manually retry failed API responses",
+      "Use a reactive agent pattern that retries the query after a user confirms a retry attempt",
+      "Use memory to track the number of failed attempts and apply it in later retries"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Use structured tool calls with built-in retry handling and timed delays inside the tool wrapper, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For knowledge-grounded agents, the clean architecture is a RAG path with retrievers and vector indexes externalized from the LLM, then evaluated for retrieval quality and answer faithfulness. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Use few-shot prompting to guide the agent s conversation flow and manually...; C: Use a reactive agent pattern that retries the query after a user ...;D: Use memory to track the number of failed attempts and apply it..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A large enterprise is preparing to roll out its AI-powered customer support agents worldwide. To maintain high availability and reliability, the operations team must select the best approach for monitoring, updating, and managing all agent instances across different locations. Which solution most effectively ensures reliable operation and simplified management of large-scale agent deployments?",
+    "a": [
+      "Establishing centralized monitoring and automated deployment pipelines to oversee agent health, trigger updates, and manage rollbacks across all environments",
+      "Allocating a dedicated support team to monitor agent logs and perform manual restarts to ensure human interaction in the data flywheel",
+      "Scheduling updates and health checks on an annual basis to minimize service disruptions and ensure agent health, trigger updates, and manage rollbacks across all environments",
+      "Provide separate monitoring tools and manual updates at each regional deployment for greater local control of agent health, trigger updates, and manage rollbacks across all environments"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Establishing centralized monitoring and automated deployment pipelines to oversee agent health trigger updates and manage rollbacks across all..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For optimization, NeMo Agent Toolkit profiling and evaluation expose workflow timing, token flow, tool latency, and quality metrics that single-output grading cannot capture. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on B: Allocating a dedicated support team to monitor agent logs and perform manual...; C: Scheduling updates and health checks on an annual basis to minimize service...; D: Provide separate monitoring tools and manual updates at each regional deployment for ...,which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’ve deployed an agent that helps users troubleshoot technical issues with their devices. After several weeks in production, user feedback indicates a decline in response accuracy, especially for newer issues. Which monitoring method is most appropriate for identifying the root cause of declining agent performance?",
+    "a": [
+      "Review output token counts across sessions to detect unusual model behavior",
+      "Analyze logs of tool usage frequency and error rates during inference",
+      "Compare average prompt length over time to analyze common input patterns",
+      "Schedule a weekly re-deployment cycle to reset the model and improve freshness"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Analyze logs of tool usage frequency and error rates during inference, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Review output token counts across sessions to detect unusual model behavior; C: Compare average prompt length over time to analyze common input patterns; D: Schedule a weekly re-deployment cycle to reset the model and improve freshness, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "After deploying a financial assistant agent, users report occasional inconsistencies in how transactions are categorized. What is the best first step for diagnosing the issue?",
+    "a": [
+      "Review and modify prompt temperature to enhance precision",
+      "Review and retrain the model with more financial datasets",
+      "Implement agent memory reset after each session",
+      "Review tool call inputs and outputs in recent session logs"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Review tool call inputs and outputs in recent session logs, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool- using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: Review and modify prompt temperature to enhance precision; B: Review and retrain the model with more financial datasets; C: Implement agent memory reset after each session, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Which two validation approaches are MOST critical for ensuring agent reliability in production deployments? (Choose two.)",
+    "a": [
+      "User satisfaction surveys as the primary quality metric",
+      "Performance testing during development phases",
+      "Structured output validation with Pydantic schemas",
+      "Random sampling of agent interactions for manual review",
+      "Automated consistency checking across multiple agent runs"
+    ],
+    "c": [
+      2,
+      4
+    ],
+    "multi": true,
+    "e": "The selected design maps to Structured output validation with Pydantic schemas and Automated consistency checking across multiple agent runs, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. For tool-using agents, the durable pattern is schema-bound function invocation with timeouts, typed outputs, retry policy, and traceable execution rather than free-form endpoint guessing. The evaluation target is the full agent workflow: planning quality, tool selection, intermediate state, latency, retries, user feedback, and final task completion. Instrumentation must expose where degradation starts so remediation can focus on prompts, tool schemas, retrieval, model parameters, or infrastructure rather than random retuning. The distractors are weaker because they lean on A: User satisfaction surveys as the primary quality metric; B: Performance testing during development phases; D: Random sampling of agent interactions for manual review, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are implementing a RAG (Retrieval-Augmented Generation) solution. What is the primary purpose of implementing semantic guardrails within a RAG system?",
+    "a": [
+      "To establish rules and constraints based on the meaning of user queries and generated responses.",
+      "To eliminate all potential harmful entries from the vector database.",
+      "To automatically translate all LLM responses into multiple languages for improved user comprehension.",
+      "To filter out all queries containing specific keywords that have been flagged as problematic."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to To establish rules and constraints based on the meaning of user queries and generated responses, which is the highest-control path for this scenario rather than a prompt- only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on B: To eliminate all potential harmful entries from the vector database; C: To automatically translate all LLM responses into multiple languages for improved user ...;D: To filter out all queries containing specific keywords that have been flagged..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When implementing security measures for enterprise agentic systems using NVIDIA’S NeMo Guardrails, which approach provides the most comprehensive protection?",
+    "a": [
+      "Input sanitization at the user interface level",
+      "Multi-layered guardrails with content moderation, output filtering, and behavioral monitoring",
+      "Rule-based content filtering with predefined patterns",
+      "User authentication and authorization controls"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Multi-layered guardrails with content moderation output filtering and behavioral monitoring, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Input sanitization at the user interface level; C: Rule-based content filtering with predefined patterns; D: User authentication and authorization controls, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your team has built an agent using LangChain and needs to implement guardrails for deployment in a production environment. Which approach represents the MOST effective integration of NVIDIA NeMo Guardrails?",
+    "a": [
+      "Rebuild the agent using only NeMo Guardrails, thereby reconstructing the LangChain implementation with enhanced safety controls and production-ready guardrail integration.",
+      "Wrap the LangChain agent with NeMo Guardrails configuration while maintaining the existing workflow architecture and preserving current development investments.",
+      "Configure input filtering to address safety requirements, integrating guardrail mechanisms focused on data validation and moderation within the current framework.",
+      "Run the LangChain agent in parallel with NeMo Guardrails, allowing comparison of outputs between systems for comprehensive safety validation and performance optimization."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Wrap the LangChain agent with NeMo Guardrails configuration while maintaining the existing workflow architecture and preserving current development..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Rebuild the agent using only NeMo Guardrails thereby reconstructing the LangChain implementation...; C: Configure input filtering to address safety requirements integrating guardrail mechanisms focused on...; D: Run the LangChain agent in parallel with NeMo Guardrails allowing comparison of..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "This question addresses important concerns in the field of AI ethics and compliance, particularly as organizations develop more autonomous AI agents. Implementing effective guardrails against bias, ensuring data privacy, and adhering to regulations are essential components of responsible AI development. Which of the following statements accurately describes how RAGAS (Retrieval Augmented Generation Assessment) can be utilized for implementing safety checks and guardrails in agentic AI applications?",
+    "a": [
+      "RAGAS cannot evaluate all safety aspects independently but provides metrics like Topic Adherence and Agent Goal Accuracy that serve as guardrails.",
+      "RAGAS can only evaluate the quality of document retrieval but has no applications for safety guardrails in agentic systems.",
+      "RAGAS is exclusively designed for hallucination detection and cannot evaluate other safety aspects of agentic applications.",
+      "RAGAS can only be used in conjunction with other guardrail frameworks like NeMo and cannot function independently."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to RAGAS cannot evaluate all safety aspects independently but provides metrics like Topic Adherence and Agent Goal Accuracy that..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on B: RAGAS can only evaluate the quality of document retrieval but has no...; C: RAGAS is exclusively designed for hallucination detection and cannot evaluate other safety...; D: RAGAS can only be used in conjunction with other guardrail frameworks like..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "Your team has deployed a generative agent for internal HR use, including summarizing candidate resumes and suggesting interview questions. After deployment, you’ve noticed that the model occasionally associates certain names or genders with particular roles. Which mitigation strategy is the most effective and scalable for reducing this type of bias in agent outputs?",
+    "a": [
+      "Adjust system prompts to explicitly instruct the agent to avoid assumptions based on demographic features",
+      "Randomly replace names in prompts to reduce identity correlation",
+      "Add more training examples to the training dataset and re-train the model",
+      "Implement guardrails to prevent outputs referencing protected attributes"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Implement guardrails to prevent outputs referencing protected attributes, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Adjust system prompts to explicitly instruct the agent to avoid assumptions based...; B: Randomly replace names in prompts to reduce identity correlation; C: Add more training examples to the training dataset and re-train the model, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing safety violations in a financial advisory agent that uses NeMo Guardrails, which evaluation approach best identifies gaps in guardrail coverage?",
+    "a": [
+      "Apply keyword- and rule-based validation methods to confirm compliance with policy terms and common risk conditions.",
+      "Analyze violation patterns, test adversarial prompts, measure guardrail activation, and align policies with observed failures.",
+      "Conduct functional testing with representative user inputs to verify policy enforcement in typical usage scenarios.",
+      "Monitor overall guardrail activations and system logs to assess operational behavior across different interaction types."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Analyze violation patterns test adversarial prompts measure guardrail activation and align policies with observed failures, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Apply keyword and rule-based validation methods to confirm compliance with policy terms...; C: Conduct functional testing with representative user inputs to verify policy enforcement in...; D: Monitor overall guardrail activations and system logs to assess operational behavior across..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are developing a RAG solution and have decided to use a classifier branch as part of your semantic guardrail system to assess the risk of generated text. Which of the following is a key benefit of using a classifier branch compared to solely relying on prompt filtering?",
+    "a": [
+      "Since a classifier branch does not require training, it can identify potentially problematic content.",
+      "Classifier branches primarily focus on detecting factual inaccuracies, rather than stylistic or harmful language.",
+      "Classifier branches can automatically adapt to new forms of harmful language.",
+      "Classifier branches eliminate the need for human oversight, thereby automating the safety process."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Classifier branches can automatically adapt to new forms of harmful language, which is the highest-control path for this scenario rather than a prompt-only or single- service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Since a classifier branch does not require training it can identify potentially...; B: Classifier branches primarily focus on detecting factual inaccuracies rather than stylistic or ...;D: Classifier branches eliminate the need for human oversight thereby automating the safety..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You’re deploying a healthcare-focused agentic AI system that helps doctors make treatment recommendations based on patient records. The agent’s reasoning is not exposed to users, and its decisions sometimes differ from clinical guidelines. What safety and compliance mechanisms should be in place? (Choose two.)",
+    "a": [
+      "Allow overrides by human doctors to maintain accountability",
+      "Require model explainability or traceability for all outputs",
+      "Prioritize autonomous speed of decision over explainability",
+      "Exempt the model from compliance if it improves outcomes",
+      "Obfuscate decision logic to protect proprietary methods"
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "e": "The selected design maps to Allow overrides by human doctors to maintain accountability and Require model explainability or traceability for all outputs, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on C: Prioritize autonomous speed of decision over explainability; D: Exempt the model from compliance if it improves outcomes; E: Obfuscate decision logic to protect proprietary methods, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI Engineer is analyzing a production agentic AI system’s compliance with responsible AI standards. Which evaluation approaches effectively identify potential safety vulnerabilities and ethical risks in multi-agent workflows? (Choose two.)",
+    "a": [
+      "Emphasize latency metrics and throughput performance as key evaluation factors for safety vulnerabilities, providing a baseline for operational measures and resource allocation.",
+      "Implement comprehensive audit trails using NVIDIA NeMo Guardrails with semantic similarity checks, tracking agent decisions across conversation flows and evaluating policy violations through automated compliance scoring.",
+      "Use user feedback as a primary signal for risk identification, emphasizing post-deployment observations and qualitative experience reports alongside operational monitoring.",
+      "Deploy multi-layered evaluation combining bias detection metrics (demographic parity, equalized odds) with adversarial testing to probe agent responses for harmful outputs across diverse user populations"
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "The selected design maps to Implement comprehensive audit trails using NVIDIA NeMo Guardrails with semantic similarity checks tracking agent decisions across conversation flows... and Deploy multi-layered evaluation combining bias detection metrics demographic parity equalized odds with adversarial testing to probe agent responses..., which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Emphasize latency metrics and throughput performance as key evaluation factors for safety...; C: Use user feedback as a primary signal for risk identification emphasizing post-deployment..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are deploying an AI-driven applicant-screening agent that analyzes candidate resumes and social-media data to recommend top applicants. Due to anti-discrimination laws and corporate policy, the system must mitigate bias against protected groups, maintain an audit trail of decisions, and comply with GDPR (including data minimization and explicit consent). Which of the following strategies is most effective for ensuring your screening agent both mitigates bias in its recommendations and complies with data-privacy regulations?",
+    "a": [
+      "Perform a post-deployment GDPR and bias audit and process raw personal data as received.",
+      "Pseudonymize protected attributes, implement fairness-aware debiasing, maintain an audit trail, and enforce GDPR data-minimization and consent.",
+      "Encrypt all candidate data at rest and in transit, remove protected attributes from analysis, and conduct manual bias checks on recommendations.",
+      "Exclude gender and ethnicity fields during training, use a generic privacy policy for consent, and do not maintain audit logs or apply targeted debiasing."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Pseudonymize protected attributes implement fairness-aware debiasing maintain an audit trail and enforce GDPR data-minimization and consent, which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Perform a post-deployment GDPR and bias audit and process raw personal data...; C: Encrypt all candidate data at rest and in transit remove protected attributes...; D: Exclude gender and ethnicity fields during training use a generic privacy policy..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A health assistant agent has been running on production environment for several weeks. The compliance team wants to audit how personal health data has been processed. Which operational feature supports this requirement?",
+    "a": [
+      "Adding more prompt examples to clarify privacy rules",
+      "Masking all output with a profanity and PII detector",
+      "Increasing model temperature for diverse interpretations",
+      "Enabling full session logging with audit trail metadata"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Enabling full session logging with audit trail metadata, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Adding more prompt examples to clarify privacy rules; B: Masking all output with a profanity and PII detector; C: Increasing model temperature for diverse interpretations, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "You are designing an AI-powered drafting assistant for contract lawyers. The assistant suggests standard clauses and highlights potential risks based on past agreements. Senior attorneys must review, accept, modify, or reject each suggestion, see why a clause was recommended, and provide feedback to help improve the assistant. Which design feature is most critical for enabling effective human-in-the-loop oversight, transparency, and trust?",
+    "a": [
+      "Display suggested clauses with links to additional details about provenance and risk highlighting in a side panel, allowing users to access more context as needed.",
+      "Insert suggested clauses into the draft and highlight changes for review at the end, inviting users to provide detailed feedback on clauses they wish to flag for improvement.",
+      "Present batch “accept all” or “reject all” controls for suggested clauses, with explanations and feedback collected in a summary report after draft review.",
+      "Show inline “why” explanations for each suggestion, highlight precedent and risk factors, and include accept/modify/reject controls with immediate feedback capture for model refinement."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Show inline why explanations for each suggestion highlight precedent and risk factors and include accept/modify/reject controls with immediate..., which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Display suggested clauses with links to additional details about provenance and risk...; B: Insert suggested clauses into the draft and highlight changes for review at...; C: Present batch accept all or reject all controls for suggested clauses with..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A development team is creating an AI assistant that interacts with employees to help manage schedules and tasks. The team wants to ensure users can easily provide feedback, understand the agent’s decisions, and intervene when necessary to maintain control and trust. Which practice best supports effective human oversight and interaction with the AI agent?",
+    "a": [
+      "Continuously collecting and integrating user feedback throughout the agent’s lifecycle to drive ongoing improvements",
+      "Incorporating user review stages before finalizing agent decisions to maintain accountability",
+      "Enabling flexible user interactions beyond predefined commands to accommodate diverse needs",
+      "Designing intuitive user interfaces with integrated feedback loops and transparent explanations of agent decisions"
+    ],
+    "c": [
+      3
+    ],
+    "e": "The selected design maps to Designing intuitive user interfaces with integrated feedback loops and transparent explanations of agent decisions, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Continuously collecting and integrating user feedback throughout the agent s lifecycle to...; B: Incorporating user review stages before finalizing agent decisions to maintain accountability; C: Enabling flexible user interactions beyond predefined commands to accommodate diverse needs, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A logistics company is implementing an agentic AI system for supply chain optimization that manages inventory levels, predicts demand, and automatically reorders supplies across multiple warehouses. Supply chain managers need to monitor AI decisions, understand the reasoning behind inventory recommendations, and intervene when business conditions change rapidly. The system must present complex data analytics in an intuitive way that enables quick decision-making while providing detailed insights when needed. Managers have varying levels of technical expertise and need interfaces that support both high-level oversight and detailed analysis. Which user interface design approach would BEST support effective human oversight of this complex multi-agent supply chain system?",
+    "a": [
+      "Develop a comprehensive dashboard with AI decision summaries, drill-down access to underlying data sets, and segmented performance metrics to enable targeted analysis of supply chain operations.",
+      "Create separate specialized interfaces tailored to specific user roles, allowing managers to view AI- driven recommendations with drill-down options for role-specific details, but without a unified interface for cross-role collaboration.",
+      "Create a layered interface featuring intuitive summaries, drill-down capabilities for detailed analysis, contextual explanations of AI decisions, and clear intervention controls with impact visualization and decision support tools.",
+      "Create a streamlined interface presenting only high-level AI decisions and simplified recommendations, with drill-down views limited to basic historical trends for quick reference."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Create a layered interface featuring intuitive summaries drill-down capabilities for detailed analysis contextual explanations of AI decisions and..., which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Develop a comprehensive dashboard with AI decision summaries drill-down access to underlying...; B: Create separate specialized interfaces tailored to specific user roles allowing managers to...; D: Create a streamlined interface presenting only high-level AI decisions and simplified recommendations..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU- aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "An AI Engineer has deployed a multi-agent system to manage supply chain logistics. Stakeholders request greater insight into how the agents decide on actions across tasks. Which approach would best improve decision transparency without modifying the underlying model architecture?",
+    "a": [
+      "Gather structured user evaluations after each completed subtask",
+      "Generate visual summaries of attention patterns for every decision",
+      "Record a step-by-step reasoning log throughout each agent workflow",
+      "Retain and share the full sequence of task instructions with stakeholders"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The selected design maps to Record a step-by-step reasoning log throughout each agent workflow, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The deployment logic aligns with NVIDIA NIM for containerized inference, TensorRT-LLM for optimized engines, and Triton for batching, scheduling, and Prometheus-visible inference metrics. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Gather structured user evaluations after each completed subtask; B: Generate visual summaries of attention patterns for every decision; D: Retain and share the full sequence of task instructions with stakeholders, which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "When analyzing a customer service agentic system’s performance degradation over time, which evaluation approach most effectively identifies opportunities for human-in-the-loop intervention to improve agent decision-making transparency and user trust?",
+    "a": [
+      "Monitor only final task completion rates without examining intermediate decision points, user interaction patterns, or opportunities for beneficial human intervention during agent conversations",
+      "Implement multi-stage evaluation tracking decision confidence scores, user correction patterns, intervention effectiveness, and explainability-satisfaction correlations",
+      "Rely on periodic manual reviews of random conversation samples without systematic tracking of intervention effectiveness, decision transparency, or user trust indicators",
+      "Collect anonymous usage statistics without capturing specific decision rationales, user feedback on agent explanations, or transparency improvement opportunities for trust building"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The selected design maps to Implement multi-stage evaluation tracking decision confidence scores user correction patterns intervention effectiveness and explainability-satisfaction correlations, which is the highest-control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on A: Monitor only final task completion rates without examining intermediate decision points user ...;C: Rely on periodic manual reviews of random conversation samples without systematic tracking...; D: Collect anonymous usage statistics without capturing specific decision rationales user feedback on..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems."
+  },
+  {
+    "q": "A medical diagnostics company is deploying an agentic AI system to assist radiologists in analyzing medical imaging. The system must provide AI-generated preliminary diagnoses and allow radiologists to review, modify, and approve all recommendations before patient treatment decisions. Human expertise should remain central, with detailed records of human interventions and decision rationales maintained. Which approach would best balance human oversight with AI support in a safety-critical setting?",
+    "a": [
+      "Design an interactive system that presents AI analysis with confidence scores, allows radiologists to review evidence, modify recommendations, and requires explicit approval with documented reasoning for all decisions.",
+      "Design a fully automated system that presents final diagnoses to radiologists for simple approval or rejection, minimizing human interaction to improve efficiency and reduce decision fatigue.",
+      "Design a passive monitoring system where AI makes decisions while humans observe without ability to intervene, focusing on post-decision evaluation and quality assurance.",
+      "Design a simple notification system that alerts radiologists only when AI confidence falls below predetermined thresholds, otherwise allowing autonomous operation without human review or documentation."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The selected design maps to Design an interactive system that presents AI analysis with confidence scores allows radiologists to review evidence modify recommendations..., which is the highest- control path for this scenario rather than a prompt-only or single-service shortcut. The NVIDIA stack component that anchors this design is NeMo Guardrails, because rails can be placed before retrieval, during dialog, around tool execution, and after generation. The system must constrain behavior at runtime, preserve reviewability, and make human accountability explicit when outputs affect regulated, safety-critical, or rights-sensitive decisions. Guardrails, audit trails, provenance, and intervention controls are stronger than relying on vague ethical prompts or undisclosed autonomous decisions. The distractors are weaker because they lean on B: Design a fully automated system that presents final diagnoses to radiologists for ...;C: Design a passive monitoring system where AI makes decisions while humans observe...; D: Design a simple notification system that alerts radiologists only when AI confidence..., which compromises traceability, resilience, scalability, or policy enforcement in production. The answer therefore fits NVIDIA’s production-agent pattern: modular workflow design, measurable runtime behavior, GPU-aware serving where applicable, and controlled integration with enterprise systems. Thank you for your visit. To try more exams, please visit below link"
+  }
+];
+const SETS = [];
+
+const quiz = document.getElementById('quiz');
+const scoreEl = document.getElementById('score');
+let activeSet = 'all';  // 'all' or a set name like 'set1'
+
+function letter(i) { return String.fromCharCode(65 + i); }
+
+function renderQuestion(q, qi) {
+  const isMulti = !!q.multi;
+  const type = isMulti ? 'checkbox' : 'radio';
+  const opts = q.a.map((text, oi) => `
+    <li>
+      <label data-qi="${qi}" data-oi="${oi}">
+        <input type="${type}" name="q${qi}" value="${oi}">
+        <strong>${letter(oi)}.</strong> ${escapeHtml(text)}
+      </label>
+    </li>`).join('');
+  const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
+  const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
+  const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  const expHtml = q.e
+    ? `<div class="explanation" id="exp${qi}" hidden><span class="exp-label">Explanation</span>${escapeHtml(q.e)}</div>`
+    : '';
+  const expBtn = q.e ? `<button data-explain="${qi}">Explanation</button>` : '';
+  return `
+    <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
+      <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
+      <ul class="opts">${opts}</ul>
+      <div class="actions">
+        <button data-check="${qi}">Check</button>
+        <button data-reset="${qi}">Reset</button>
+        ${expBtn}
+      </div>
+      ${expHtml}
+    </div>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  })[c]);
+}
+
+function checkQuestion(qi) {
+  const q = QUESTIONS[qi];
+  const correct = new Set(q.c);
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    const oi = +label.dataset.oi;
+    const input = label.querySelector('input');
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    if (input.checked) {
+      if (correct.has(oi)) label.classList.add('correct');
+      else label.classList.add('wrong');
+    } else if (correct.has(oi)) {
+      label.classList.add('reveal-correct');
+    }
+  });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = false;
+  updateScore();
+}
+
+function resetQuestion(qi) {
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    label.querySelector('input').checked = false;
+  });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = true;
+  updateScore();
+}
+
+function inActiveSet(q) {
+  return activeSet === 'all' || q.set === activeSet;
+}
+
+function updateScore() {
+  let answered = 0, correct = 0, total = 0;
+  QUESTIONS.forEach((q, qi) => {
+    if (!inActiveSet(q)) return;
+    total++;
+    const inputs = document.querySelectorAll(`#q${qi} input`);
+    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    if (picked.length === 0) return;
+    answered++;
+    const expected = new Set(q.c);
+    const isExactMatch =
+      picked.length === expected.size &&
+      picked.every(p => expected.has(p));
+    if (isExactMatch) correct++;
+  });
+  const label = activeSet === 'all' ? 'overall' : activeSet;
+  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+}
+
+function applyFilter() {
+  QUESTIONS.forEach((q, qi) => {
+    const el = document.getElementById(`q${qi}`);
+    if (!el) return;
+    el.classList.toggle('hidden', !inActiveSet(q));
+  });
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.set === activeSet);
+  });
+  updateScore();
+}
+
+// ── Cache: persist answers + checked state across reloads ────────────────────
+const CACHE_KEY = 'quiz-cache-ncp-aai-practice-test';
+
+function saveCache() {
+  const answers = {};   // qi -> [oi, ...]
+  const checked = {};   // qi -> true
+  QUESTIONS.forEach((q, qi) => {
+    const picked = [...document.querySelectorAll(`#q${qi} input:checked`)]
+      .map(i => +i.value);
+    if (picked.length) answers[qi] = picked;
+    // A question is "checked" if any label has a result class.
+    const el = document.getElementById(`q${qi}`);
+    if (el && el.querySelector('.correct, .wrong, .reveal-correct')) checked[qi] = true;
+  });
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ answers, checked })); } catch(_) {}
+}
+
+function loadCache() {
+  let cache;
+  try { cache = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch(_) {}
+  if (!cache) return;
+  const { answers = {}, checked = {} } = cache;
+  // Restore selections first.
+  Object.entries(answers).forEach(([qi, ois]) => {
+    ois.forEach(oi => {
+      const input = document.querySelector(`#q${qi} input[value="${oi}"]`);
+      if (input) input.checked = true;
+    });
+  });
+  // Restore checked visual state.
+  Object.keys(checked).forEach(qi => checkQuestion(+qi));
+}
+
+quiz.innerHTML = QUESTIONS.map(renderQuestion).join('');
+
+// Restore cache after DOM is built.
+loadCache();
+
+quiz.addEventListener('click', e => {
+  const t = e.target;
+  if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
+  else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+  else if (t.matches('[data-explain]')) {
+    const ex = document.getElementById(`exp${t.dataset.explain}`);
+    if (ex) ex.hidden = !ex.hidden;
+  }
+});
+quiz.addEventListener('change', () => { updateScore(); saveCache(); });
+
+document.getElementById('checkAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) checkQuestion(qi); });
+  saveCache();
+});
+document.getElementById('resetAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  saveCache();
+});
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    activeSet = tab.dataset.set;
+    applyFilter();
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  });
+});
+
+if (SETS.length > 1) applyFilter();
+else updateScore();
+
+// Dark-mode toggle. Persists across reloads in localStorage but falls back
+// to prefers-color-scheme when no preference is stored.
+const THEME_KEY = 'quiz-theme';
+function applyTheme(theme) {
+  const html = document.documentElement;
+  if (theme === 'dark' || theme === 'light') {
+    html.setAttribute('data-theme', theme);
+  } else {
+    html.removeAttribute('data-theme');
+  }
+  const isDark = theme === 'dark'
+    || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.getElementById('themeIcon').textContent = isDark ? '☀️' : '🌙';
+  document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+}
+applyTheme(localStorage.getItem(THEME_KEY));
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const isCurrentlyDark = current === 'dark'
+    || (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const next = isCurrentlyDark ? 'light' : 'dark';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+});
+</script>
+</body>
+</html>

--- a/public/ncp-aai/index.html
+++ b/public/ncp-aai/index.html
@@ -142,7 +142,25 @@
     border-bottom: 1px solid var(--border);
     font-weight: bold;
     z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    flex-wrap: wrap;
   }
+  #scoreText .ok { color: var(--reveal); }
+  #scoreText .ko { color: var(--wrong-border); }
+  #reviewWrong {
+    font-size: .85rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  #reviewWrong.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  #reviewWrong:disabled { opacity: .5; cursor: default; }
   .multi-tag {
     font-size: .75rem;
     background: var(--multi-bg);
@@ -227,7 +245,10 @@
 </div>
 <p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
 
-<div id="score">Score: 0 / 0 answered</div>
+<div id="score">
+  <span id="scoreText">Score: 0 / 0 answered</span>
+  <button id="reviewWrong" type="button" disabled>Review wrong (0)</button>
+</div>
 <div id="quiz"></div>
 <div class="actions" style="margin: 2rem 0;">
   <button id="checkAll" class="primary">Check all</button>
@@ -1856,8 +1877,9 @@ const QUESTIONS = [
 const SETS = [];
 
 const quiz = document.getElementById('quiz');
-const scoreEl = document.getElementById('score');
+const scoreEl = document.getElementById('scoreText');
 let activeSet = 'all';  // 'all' or a set name like 'set1'
+let reviewWrong = false;  // when true, show only answered-incorrectly questions
 
 function letter(i) { return String.fromCharCode(65 + i); }
 
@@ -1930,30 +1952,52 @@ function inActiveSet(q) {
   return activeSet === 'all' || q.set === activeSet;
 }
 
+function pickedFor(qi) {
+  return [...document.querySelectorAll(`#q${qi} input`)]
+    .filter(i => i.checked).map(i => +i.value);
+}
+
+function isExact(qi, picked) {
+  const expected = new Set(QUESTIONS[qi].c);
+  return picked.length === expected.size && picked.every(p => expected.has(p));
+}
+
+// A question counts as "wrong" once it has a selection that is not an exact match.
+function isWrongAnswered(qi) {
+  const picked = pickedFor(qi);
+  return picked.length > 0 && !isExact(qi, picked);
+}
+
 function updateScore() {
   let answered = 0, correct = 0, total = 0;
   QUESTIONS.forEach((q, qi) => {
     if (!inActiveSet(q)) return;
     total++;
-    const inputs = document.querySelectorAll(`#q${qi} input`);
-    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    const picked = pickedFor(qi);
     if (picked.length === 0) return;
     answered++;
-    const expected = new Set(q.c);
-    const isExactMatch =
-      picked.length === expected.size &&
-      picked.every(p => expected.has(p));
-    if (isExactMatch) correct++;
+    if (isExact(qi, picked)) correct++;
   });
+  const wrong = answered - correct;
   const label = activeSet === 'all' ? 'overall' : activeSet;
-  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+  scoreEl.innerHTML =
+    `<span class="ok">${correct} correct</span> · ` +
+    `<span class="ko">${wrong} wrong</span> · ` +
+    `${answered}/${total} answered (${label})`;
+  const reviewBtn = document.getElementById('reviewWrong');
+  if (reviewBtn) {
+    reviewBtn.textContent = reviewWrong ? `Show all (${wrong} wrong)` : `Review wrong (${wrong})`;
+    reviewBtn.classList.toggle('active', reviewWrong);
+    reviewBtn.disabled = wrong === 0 && !reviewWrong;
+  }
 }
 
 function applyFilter() {
   QUESTIONS.forEach((q, qi) => {
     const el = document.getElementById(`q${qi}`);
     if (!el) return;
-    el.classList.toggle('hidden', !inActiveSet(q));
+    const visible = inActiveSet(q) && (!reviewWrong || isWrongAnswered(qi));
+    el.classList.toggle('hidden', !visible);
   });
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.set === activeSet);
@@ -2016,7 +2060,20 @@ document.getElementById('checkAll').addEventListener('click', () => {
 });
 document.getElementById('resetAll').addEventListener('click', () => {
   QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  reviewWrong = false;
+  applyFilter();
   saveCache();
+});
+
+document.getElementById('reviewWrong').addEventListener('click', () => {
+  reviewWrong = !reviewWrong;
+  if (reviewWrong) {
+    // Reveal correct answers on the wrong questions so they can be reviewed.
+    QUESTIONS.forEach((q, qi) => { if (inActiveSet(q) && isWrongAnswered(qi)) checkQuestion(qi); });
+    saveCache();
+  }
+  applyFilter();
+  window.scrollTo({ top: 0, behavior: 'instant' });
 });
 
 document.querySelectorAll('.tab').forEach(tab => {

--- a/public/ncp-aio/index.html
+++ b/public/ncp-aio/index.html
@@ -1,0 +1,4408 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NCP-AIO Practice Tests</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --border: #ddd;
+    --hover: rgba(0, 0, 0, 0.04);
+    --card: #fafafa;
+    --accent: #2563eb;
+    --correct-bg: #16a34a;
+    --correct-fg: #ffffff;
+    --correct-border: #15803d;
+    --wrong-bg: #dc2626;
+    --wrong-fg: #ffffff;
+    --wrong-border: #b91c1c;
+    --reveal: #16a34a;
+    --multi-bg: #2563eb;
+  }
+  html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --fg: #e7e9ee;
+    --muted: #9aa3b2;
+    --border: #2a2f3a;
+    --hover: rgba(255, 255, 255, 0.05);
+    --card: #161a21;
+    --accent: #60a5fa;
+    --correct-bg: #166534;
+    --correct-fg: #ecfdf5;
+    --correct-border: #22c55e;
+    --wrong-bg: #7f1d1d;
+    --wrong-fg: #fee2e2;
+    --wrong-border: #ef4444;
+    --reveal: #22c55e;
+    --multi-bg: #3b82f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme]) {
+      color-scheme: dark;
+      --bg: #0f1115;
+      --fg: #e7e9ee;
+      --muted: #9aa3b2;
+      --border: #2a2f3a;
+      --hover: rgba(255, 255, 255, 0.05);
+      --card: #161a21;
+      --accent: #60a5fa;
+      --correct-bg: #166534;
+      --correct-fg: #ecfdf5;
+      --correct-border: #22c55e;
+      --wrong-bg: #7f1d1d;
+      --wrong-fg: #fee2e2;
+      --wrong-border: #ef4444;
+      --reveal: #22c55e;
+      --multi-bg: #3b82f6;
+    }
+  }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    max-width: 880px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .subtitle { color: var(--muted); margin: 0 0 1rem; }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .q {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    background: var(--card);
+  }
+  .q h2 { font-size: 1rem; margin: 0 0 .75rem; }
+  .opts { list-style: none; padding: 0; margin: 0; }
+  .opts li { margin: .35rem 0; }
+  .opts label {
+    display: block;
+    padding: .5rem .75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    color: var(--fg);
+  }
+  .opts label:hover { background: var(--hover); }
+  .opts input { margin-right: .5rem; }
+  .opts label.correct {
+    background: var(--correct-bg);
+    color: var(--correct-fg);
+    border-color: var(--correct-border);
+  }
+  .opts label.wrong {
+    background: var(--wrong-bg);
+    color: var(--wrong-fg);
+    border-color: var(--wrong-border);
+  }
+  .opts label.reveal-correct { outline: 2px dashed var(--reveal); }
+  .actions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+    margin-top: .75rem;
+  }
+  button {
+    padding: .4rem .8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--fg);
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover { background: var(--hover); }
+  button.primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  button.primary:hover { filter: brightness(1.1); }
+  .note { font-size: .85rem; color: var(--muted); }
+  #score {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: .5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-weight: bold;
+    z-index: 10;
+  }
+  .multi-tag {
+    font-size: .75rem;
+    background: var(--multi-bg);
+    color: white;
+    padding: .1rem .4rem;
+    border-radius: 3px;
+    margin-left: .5rem;
+    vertical-align: middle;
+  }
+  .set-tag {
+    font-size: .7rem;
+    color: var(--muted);
+    margin-left: .5rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+  }
+  .tabs {
+    display: flex;
+    gap: .25rem;
+    flex-wrap: wrap;
+    margin: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: .5rem;
+  }
+  .tab {
+    padding: .35rem .7rem;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: .9rem;
+  }
+  .tab:hover { background: var(--hover); color: var(--fg); }
+  .tab.active {
+    background: var(--card);
+    border-color: var(--border);
+    border-bottom-color: var(--card);
+    color: var(--fg);
+    font-weight: 600;
+  }
+  .q.hidden { display: none; }
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <div>
+    <h1>NCP-AIO Practice Tests</h1>
+    <p class="subtitle">NVIDIA AI Operations Certified Professional (NCP-AIO) - 5 Mock Exams, 300 questions</p>
+  </div>
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">
+    <span id="themeIcon">🌙</span>
+    <span id="themeLabel">Dark</span>
+  </button>
+</div>
+<p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
+<div class="tabs">
+<button class="tab active" data-set="all">All</button>
+<button class="tab" data-set="Set 1">Exam 1</button>
+<button class="tab" data-set="Set 2">Exam 2</button>
+<button class="tab" data-set="Set 3">Exam 3</button>
+<button class="tab" data-set="Set 4">Exam 4</button>
+<button class="tab" data-set="Set 5">Exam 5</button>
+</div>
+<div id="score">Score: 0 / 0 answered</div>
+<div id="quiz"></div>
+<div class="actions" style="margin: 2rem 0;">
+  <button id="checkAll" class="primary">Check all</button>
+  <button id="resetAll">Reset</button>
+</div>
+
+<script>
+const QUESTIONS = [
+  {
+    "q": "You are tasked with designing a scalable data center architecture to support AI workloads that are expected to grow significantly over the next five years. The design must balance cost, performance, and future adaptability. Which of the following design choices best supports this objective?",
+    "a": [
+      "Build a monolithic architecture with all GPUs located in a single cluster to simplify workload management.",
+      "Use legacy hardware to minimize upfront costs and plan for an overhaul when demand increases.",
+      "Invest in modular GPU clusters connected via an RDMA-capable network for scalability and low-latency communication.",
+      "Focus solely on scaling CPU resources, as they can handle most AI workloads with enough cores."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with installing and configuring Baseboard Management Controller (BMC) software on an NVIDIA DGX system to enable remote hardware monitoring and management. After the installation, you must configure the network interface for BMC. Which of the following is the correct approach to ensure proper network configuration?",
+    "a": [
+      "Access the BMC web interface through the default IP address and configure the network settings.",
+      "Use the NVIDIA System Management Interface (nvidia-smi) to configure the BMC network interface directly.",
+      "Manually edit the /etc/bmc_config file on the host system to set the network parameters.",
+      "Use the system's BIOS interface to configure the BMC network settings."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A Slurm administrator notices that certain jobs are stuck in the PENDING state for GPU resources, despite available GPU nodes in the cluster. Upon investigation, the administrator finds that these jobs request resources not configured in the cluster. Which action should the administrator take to resolve this issue?",
+    "a": [
+      "Rebalance the GPU node allocation using the srun command to optimize the workload.",
+      "Instruct users to submit jobs without specifying resource constraints.",
+      "Use the scontrol show jobs command to manually force the jobs into a running state.",
+      "Update the GRES (Generic Resource) configuration in slurm.conf to match the requested resource type and restart Slurm."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with optimizing the training performance of a large neural network on an NVIDIA GPU cluster. Which of the following practices best utilizes the NVIDIA GPU architecture and software stack to maximize training throughput?",
+    "a": [
+      "Disable cuDNN acceleration to ensure deterministic results during training.",
+      "Increase the batch size to maximize GPU utilization, keeping an eye on available memory.",
+      "Use Tensor Cores for mixed-precision training with FP32 inputs and FP64 outputs.",
+      "Prioritize CPU processing for preprocessing steps to reduce GPU workload."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with designing a data center to support large-scale AI workloads, including training and inference tasks. The AI models require substantial computational resources and high-speed data transfer. Which of the following considerations is most critical for optimizing the architecture to handle these workloads efficiently?",
+    "a": [
+      "Configuring a flat network topology to reduce complexity and costs.",
+      "Utilizing GPUs with NVLink connectivity for improved inter-GPU communication.",
+      "Deploying traditional CPU-based servers to maximize general-purpose processing capacity.",
+      "Implementing a hybrid storage solution with SSDs for caching and HDDs for long-term storage."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing a data pipeline for an AI workload that processes petabytes of data stored across multiple storage systems. The pipeline must ensure low-latency data access for training models while minimizing bottlenecks. Which of the following techniques is most effective for optimizing the storage and data pipeline performance?",
+    "a": [
+      "Implementing data caching with NVMe storage at intermediate pipeline stages.",
+      "Using a single-threaded data loader to ensure sequential data processing.",
+      "Relying solely on cloud-based object storage for real-time AI workloads.",
+      "Using traditional HDDs to store frequently accessed training data."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A data center administrator is experiencing issues where their multi-GPU node is not recognizing all GPUs connected through NVIDIA NVSwitch. Upon checking, the Fabric Manager service is not running. Which two steps should the administrator take to resolve this issue? (Choose two)",
+    "a": [
+      "Check the system logs for errors using journalctl -u nvidia-fabricmanager.",
+      "Verify that the NVIDIA Fabric Manager package is installed on the system.",
+      "Upgrade the system's GPU driver to the latest version that supports NVLink/NVSwitch.",
+      "Reconfigure the BIOS to disable SR-IOV (Single Root I/O Virtualization).",
+      "Use the nvidia-smi -restart-fm command to restart the Fabric Manager service."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "Which tool within the NVIDIA AI ecosystem is best suited for enabling the rapid deployment and orchestration of AI workflows in a hybrid cloud environment?",
+    "a": [
+      "NVIDIA TensorRT",
+      "NVIDIA Fleet Command",
+      "NVIDIA Triton Inference Server",
+      "NVIDIA NGC"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing a Kubernetes cluster running a machine learning workload that experiences periodic spikes in resource demand. To ensure the cluster handles these spikes effectively while maintaining cost efficiency, you need to implement an autoscaling solution. Which actions should you take? (Choose two)",
+    "a": [
+      "Use the Vertical Pod Autoscaler (VPA) to adjust the resource requests and limits of running pods dynamically.",
+      "Deploy a custom controller to monitor resource usage and manually adjust the number of pods.",
+      "Configure the Kubernetes scheduler to prioritize GPU nodes over CPU nodes.",
+      "Install and configure the Cluster Autoscaler to dynamically add or remove nodes in response to pod scheduling needs.",
+      "Enable the Horizontal Pod Autoscaler (HPA) to scale pods based on CPU and memory usage."
+    ],
+    "c": [
+      3,
+      4
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with deploying cloud VMI (Virtual Machine Image) containers in an AI operations environment to support a scalable AI model training workload. Which of the following steps is the most appropriate to ensure the deployment is optimized for performance and resource utilization?",
+    "a": [
+      "Use pre-configured VMIs optimized for AI workloads, ensure the containers are using GPU-based instances, and configure resource limits within the container orchestration platform.",
+      "Deploy containers without specifying hardware constraints, relying on the default CPU-based instances for training.",
+      "Use older versions of container orchestration software to ensure compatibility with the VMI deployment.",
+      "Use a custom-built VMI image without validation to ensure flexibility and faster deployments."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are optimizing the fabric manager service on an NVIDIA NVLink/NVSwitch system to improve performance. After making changes to the configuration file, the service fails to restart, and the logs show the error: Invalid configuration value for \"topology_validation\". Which of the following is the most appropriate resolution?",
+    "a": [
+      "Clear the service cache and attempt to restart the fabric manager service.",
+      "Update the NVIDIA NVSwitch firmware to the latest version.",
+      "Reinstall the NVIDIA drivers to reset the configuration file to its default state.",
+      "Correct the value of the topology_validation parameter in the configuration file."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your organization is building a new data center optimized for AI workloads using NVIDIA GPUs. Which of the following architectural designs would best support high performance and scalability for distributed training tasks?",
+    "a": [
+      "Rely on cloud-based GPU instances for intermittent AI tasks, without provisioning any on-premises infrastructure.",
+      "Deploy NVIDIA GPUs in each server and interconnect them using traditional Ethernet switches.",
+      "Use a mix of consumer-grade GPUs and CPU-only servers to save on costs.",
+      "Implement an InfiniBand network with NVIDIA GPUs connected via NVLink across nodes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing an NVIDIA Base Command Manager (BCM) cluster, and users report that they are unable to submit jobs due to insufficient quota, despite the cluster having idle resources. Upon investigation, you discover that a default quota policy is misaligned with the current workload demands. Which of the following actions should you take to resolve the issue?",
+    "a": [
+      "Disable quota enforcement for all users in the BCM settings.",
+      "Adjust the quota policy for the affected users or groups to match their workload requirements.",
+      "Increase the default quota for all users to the maximum available resources.",
+      "Reboot the cluster nodes to refresh quota allocation."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with deploying a Virtual Machine Image (VMI) in a containerized environment on a cloud platform. The requirement is to optimize the deployment process for scalability and ensure proper resource allocation. Which of the following steps is essential to deploy a cloud-based VMI container properly while adhering to best practices?",
+    "a": [
+      "Allocate all available CPU and memory resources to the container to maximize performance.",
+      "Skip container image version tagging for faster deployment.",
+      "Use a lightweight container runtime optimized for VMI hosting, such as Kata Containers.",
+      "Use an orchestration tool like Kubernetes to automate container deployment and scaling."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A company is deploying an AI-based recommendation system that performs real-time inference on incoming user requests. Despite having high-performance GPUs for inference, the latency occasionally spikes, causing delays in serving recommendations. Which action is most likely to optimize resource allocation and reduce latency spikes?",
+    "a": [
+      "Use CPUs instead of GPUs for inference tasks",
+      "Increase the batch size for inference requests",
+      "Implement dynamic resource scaling with a load balancer",
+      "Decrease the timeout threshold for API responses"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A system administrator observes high latency during GPU-to-GPU communication on an NVIDIA NVLink/NVSwitch-enabled system. Upon investigation, they notice frequent drops in Fabric Manager service performance. Which of the following actions would most effectively troubleshoot and optimize the service?",
+    "a": [
+      "Verify and update the NVSwitch firmware to ensure compatibility with the driver version.",
+      "Reduce the Fabric Manager service logging level to \"Error\" to improve performance.",
+      "Disable the Fabric Manager service and manually configure NVSwitch communication.",
+      "Ensure the Fabric Manager service is using the most recent configuration file optimized for NVLink topology."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A data science team is transitioning to the NVIDIA AI Workbench for managing their AI development workflow. The team requires a platform that integrates with popular machine learning frameworks, offers seamless access to pre-trained models, and supports distributed training. Which of the following features of NVIDIA AI Workbench makes it the most suitable for their requirements?",
+    "a": [
+      "Provides direct access to Kaggle competitions and datasets",
+      "Exclusively supports NVIDIA DGX systems without compatibility for cloud platforms",
+      "Lacks integration with pre-trained models and requires manual configuration",
+      "Built-in support for TensorFlow, PyTorch, and ONNX models"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You manage the deployment of an AI-powered recommendation system that serves millions of users globally. The system must deliver recommendations in real-time with minimal latency. Which KPI is most critical for ensuring the system meets its performance objectives?",
+    "a": [
+      "Response Latency",
+      "Training Time",
+      "Model Accuracy",
+      "CPU Utilization"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing a Kubernetes cluster running multiple AI workloads. A particular workload requires GPUs for training large models, but the pods are failing to schedule despite having sufficient GPU resources available on one of the nodes. What is the most likely cause of the scheduling issue?",
+    "a": [
+      "The node does not have a taint allowing GPU workloads.",
+      "The pod does not include a GPU resource request.",
+      "The scheduler is not configured to handle extended resources.",
+      "The GPU driver is not installed on the node."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing an NVIDIA DGX system where the fabric manager service for NVIDIA NVLink/NVSwitch systems fails to start. Upon checking the logs, you notice an error indicating the service cannot establish communication with the NVSwitches. What is the most likely cause of this issue, and how can it be resolved?",
+    "a": [
+      "The fabric manager service configuration file is missing or corrupted.",
+      "The system's power supply is insufficient to support all GPUs and NVSwitches.",
+      "System BIOS settings are misconfigured, causing NVLink bridges to be disabled.",
+      "The NVIDIA GPU drivers are outdated or incompatible with the fabric manager version."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are setting up a Kubernetes cluster to deploy AI workloads that rely on GPU acceleration. After installing the NVIDIA GPU hardware, which of the following steps is correct to ensure the GPUs are available to Kubernetes pods?",
+    "a": [
+      "Install the NVIDIA driver, NVIDIA Container Toolkit, and NVIDIA device plugin for Kubernetes on each node.",
+      "Configure the Kubernetes scheduler to prioritize nodes with GPUs using the gpu-priority annotation.",
+      "Install the NVIDIA Container Toolkit on each node and configure the gpu namespace.",
+      "Use the kubectl deploy gpu command to install GPU drivers and plugins on all cluster nodes."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with designing an AI infrastructure for a financial institution that requires real-time fraud detection. The workload involves training models on historical data while continuously inferring from incoming transaction streams. Which infrastructure design strategy best supports these requirements?",
+    "a": [
+      "Deploy a single high-performance GPU server to handle both training and inference workloads.",
+      "Use an edge computing solution with low-power CPUs for both training and inference to minimize latency.",
+      "Use a distributed GPU cluster for training and a separate CPU-based cluster for inference.",
+      "Design a hybrid infrastructure using cloud GPUs for training and on-premise CPUs for inference."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are responsible for setting up audit logging in a NVIDIA-powered AI infrastructure to meet regulatory compliance requirements. Which of the following is the best practice for implementing audit logging in this environment?",
+    "a": [
+      "Use tamper-proof logging mechanisms to record all actions, including administrative changes and data access.",
+      "Enable logging only for critical AI workloads to minimize storage costs.",
+      "Retain logs indefinitely without any archiving policy to demonstrate compliance during audits.",
+      "Store all audit logs locally on the same machine that runs the AI workloads to ensure accessibility."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your team is tasked with deploying a deep learning model for real-time inference at scale. The application requires low-latency predictions while handling thousands of requests per second. Which of the following strategies is the most appropriate for ensuring scalable and efficient model serving?",
+    "a": [
+      "Deploy the model on a single GPU server with batch processing enabled to maximize throughput.",
+      "Use NVIDIA Triton Inference Server to manage model serving with dynamic batching and GPU acceleration.",
+      "Serialize the model into a local file on each server and use Python scripts for direct inference calls.",
+      "Distribute the model across multiple nodes without a load balancer to avoid additional latency."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An administrator is deploying Kubernetes on NVIDIA hosts using the Bright Cluster Manager (BCM) for an AI-focused data center. Which of the following actions is essential to ensure Kubernetes is correctly installed and optimized for GPU workloads?",
+    "a": [
+      "Ensure the NVIDIA GPU operator is deployed after Kubernetes installation.",
+      "Configure all nodes to use CPU-only scheduling to avoid GPU overcommitment.",
+      "Install the standard Kubernetes package without additional configurations for GPUs.",
+      "Use the default Kubernetes scheduler without additional plugins for GPU resources."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A fleet of autonomous trucks operates in diverse environments, including urban, highway, and rural areas. To ensure the reliability of the AI infrastructure, what is the best method to maintain redundancy and avoid single points of failure in real-time decision-making?",
+    "a": [
+      "Use a single, high-performance GPU in each vehicle for all inference tasks.",
+      "Distribute inference tasks across nearby vehicles using Vehicle-to-Vehicle (V2V) communication.",
+      "Implement a multi-GPU setup within each vehicle and enable failover mechanisms.",
+      "Perform all inference tasks in the cloud, ensuring centralized monitoring and backup."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "After deploying the NVIDIA Base Command Manager (BCM) on a set of GPU nodes, the agents fail to communicate with the central BCM manager. You check the system logs and find the following:Error: TLS handshake failed.Warning: Invalid API key provided.No connectivity issues between the agents and the central manager.Which of the following actions will resolve the issue?",
+    "a": [
+      "Restart the central BCM manager to reset connections with the agents",
+      "Disable SSL/TLS to bypass the handshake error.",
+      "Regenerate the tenant-specific API key and update the agent configuration.",
+      "Verify and install the correct version of the BCM agent compatible with the GPU driver"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are deploying an AI inference pipeline using NVIDIA GPUs in a production environment. Which of the following configurations best utilizes the NVIDIA software stack for low-latency inference?",
+    "a": [
+      "Deploy the model using PyTorch's native inference mode without additional optimization tools.",
+      "Use CUDA to manually write custom kernels for inference to ensure maximum performance.",
+      "Run inference on the CPU while reserving the GPU for other workloads.",
+      "Use TensorRT to optimize the model and run inference with FP16 precision."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are administering a Slurm-based NVIDIA AI cluster used for running high-performance AI workloads. During a routine check, you notice that some compute nodes are underutilized, while others are overburdened. This imbalance is causing delays in workload execution. You need to implement a solution to distribute workloads more evenly across the cluster. Which of the following steps is the best way to address workload imbalance across Slurm compute nodes?",
+    "a": [
+      "Configure SelectType=select/cons_res and use CR_CPU_Memory to schedule jobs based on both CPU and memory requirements.",
+      "Increase the NodeWeight of heavily used nodes to prioritize them for job allocation.",
+      "Enable AutoDetect in the Slurm configuration to automatically balance workloads.",
+      "Set SchedulingAlgorithm=round-robin to ensure jobs are distributed sequentially across nodes."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An AI application for predictive maintenance relies on historical data logs for model training and real-time telemetry for inference. The data lifecycle management plan must include regulatory compliance and frequent model retraining. Which approach best aligns with these requirements?",
+    "a": [
+      "Archive all historical data in cold storage without metadata indexing.",
+      "Perform daily deletions of telemetry data after inference.",
+      "Store real-time and historical data in the same database to simplify management.",
+      "Use a centralized data lake with tagging and access controls for regulatory compliance."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A company is setting up an NVIDIA Bright Cluster Manager (BCM) cluster to manage their GPU-powered AI workloads. The administrator needs to ensure that the installation adheres to best practices and that the environment is configured optimally for AI operations. Which of the following is a key requirement for the successful installation and configuration of BCM?",
+    "a": [
+      "Ensure the management node and compute nodes use different operating system distributions.",
+      "Use a supported Linux distribution on both management and compute nodes.",
+      "Disable Secure Boot on all nodes to avoid conflicts with BCM installation.",
+      "Configure the DHCP server to assign static IPs to the management and compute nodes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An administrator attempts to configure MIG on an NVIDIA A100 GPU but encounters issues where certain workloads are unable to access the GPU. Upon investigation, the administrator finds that workloads requiring CUDA 11.4 fail to run on one of the MIG instances. What is the most likely cause of this issue?",
+    "a": [
+      "The administrator has not enabled MIG mode on the GPU.",
+      "MIG instances require workloads to use the same CUDA version as the host system.",
+      "The MIG instance is configured with insufficient memory for the workload.",
+      "The MIG instance is not assigned to a specific NUMA node on the host."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A team is managing multiple AI workloads and needs to monitor GPU utilization, application performance, and system bottlenecks during runtime. Which NVIDIA tool is most appropriate for this use case?",
+    "a": [
+      "NVIDIA Triton Inference Server",
+      "NVIDIA TensorRT",
+      "NVIDIA Jetson SDK",
+      "NVIDIA Nsight Systems"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An AI workload involves training large models on terabytes of data stored in a shared file system. The organization aims to minimize data access latency and maximize throughput during training. Which storage solution is best aligned with this requirement?",
+    "a": [
+      "Traditional storage architecture with CPU-based data transfer to GPUs.",
+      "NVIDIA GPUDirect Storage integrated with a high-performance NVMe-based file system.",
+      "Direct GPU-to-GPU communication over RDMA without shared storage.",
+      "In-memory caching of the entire dataset across multiple nodes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are using system management tools to troubleshoot an AI training workload that is stuck in a \"queued\" state on your cluster. Resource utilization on the cluster shows sufficient available CPU and GPU resources, and no other workloads are consuming excessive memory. However, the job remains queued. What is the most likely cause of the issue, and what should you do to resolve it?",
+    "a": [
+      "The workload's resource requests exceed the system's per-user quota; reduce the resource requests.",
+      "The workload's dependencies are not installed on the worker nodes; install the missing packages.",
+      "The system's scheduler is misconfigured, so you should restart the scheduler service.",
+      "The workload is scheduled on a node in maintenance mode; reassign the workload to another node."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are designing the storage infrastructure for an AI data center that processes video data for computer vision workloads. The workload requires a sustained write throughput for ingesting large video datasets and high read throughput for model training. Which of the following considerations is most important when designing the storage solution?",
+    "a": [
+      "Prioritizing high IOPS over throughput for video data processing.",
+      "Selecting a storage system optimized for sequential reads and writes.",
+      "Configuring storage with RAID 0 to maximize redundancy and data protection.",
+      "Ensuring the storage system supports tape drives for high write throughput."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are using Magnum IO NCCL (NVIDIA Collective Communications Library) for distributed deep learning training across multiple GPUs. The training process is experiencing significant slowdowns during inter-GPU communication. You notice that some GPUs report higher communication latency in the NCCL logs. Upon closer inspection, the PCIe and NVLink usage metrics are within expected ranges, but the IB fabric shows increased retransmissions. What is the most effective solution to improve communication performance?",
+    "a": [
+      "Enable NCCL topology hints in the Magnum IO configuration.",
+      "Adjust the InfiniBand MTU size to match the network's optimal configuration.",
+      "Reduce the batch size to decrease communication load.",
+      "Increase the PCIe bandwidth allocation for each GPU."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your organization is building a training pipeline for a deep learning model using NVIDIA NGC containers and Kubernetes. The pipeline requires efficient orchestration of GPU resources, scalable job execution, and the ability to resume failed jobs without manual intervention. As the lead AI engineer, you need to design a solution to automate this workflow. Which approach best automates the training pipeline with NVIDIA tools while addressing the requirements?",
+    "a": [
+      "Use NVIDIA DeepOps to deploy Kubernetes with GPU support and integrate it with NVIDIA NGC containers.",
+      "Manually script the training process using bash scripts to handle GPU allocation and job retries.",
+      "Use Kubernetes with NVIDIA Triton Inference Server for training job orchestration.",
+      "Deploy NVIDIA Clara Parabricks for managing model training workflows."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "A company is developing autonomous drones for large-scale agricultural monitoring. As the AI infrastructure architect, you must design a scalable system to handle the drone's real-time image analysis and decision-making requirements. Which approach best ensures scalability, low latency, and reliable real-time processing for this use case?",
+    "a": [
+      "Implement edge computing on each drone for image analysis, with periodic updates to the central cloud for training.",
+      "Deploy all image analysis tasks to a centralized cloud infrastructure using batch processing.",
+      "Offload all processing to third-party services for cost savings and simplified management.",
+      "Use GPU clusters in the cloud exclusively for both training and inference, leveraging high network throughput."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing the data lifecycle for an AI application that processes real-time sensor data from IoT devices. To optimize storage costs while ensuring data availability for training and inference, which data lifecycle management strategy should you implement?",
+    "a": [
+      "Delete data older than a week to minimize storage costs.",
+      "Store all data in a high-cost, high-performance storage tier indefinitely.",
+      "Store raw data indefinitely and process it on demand for training.",
+      "Use a tiered storage strategy with cold storage for older, less frequently accessed data."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your organization operates an AI system that processes customer data from the EU for predictive analytics. As part of compliance requirements with GDPR, you need to ensure that data processing adheres to principles of transparency and data minimization. Which approach best aligns with GDPR compliance when operating AI workloads on NVIDIA GPUs?",
+    "a": [
+      "Enable real-time logging of all GPU computations for auditing purposes.",
+      "Store all customer data indefinitely to support future analytics needs.",
+      "Configure the AI system to process only pseudonymized data for analytics.",
+      "Ensure all GPU computations occur in regions outside the EU to avoid GDPR constraints."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your AI operations team is responsible for managing a distributed system where datasets are frequently updated and accessed by multiple nodes. Which of the following methods best ensures efficient data management and minimizes overhead?",
+    "a": [
+      "Avoid caching mechanisms to ensure the most up-to-date data is always accessed directly from storage.",
+      "Deploy object storage solutions like NVIDIA GPUDirect Storage with caching layers for frequently accessed data.",
+      "Replicate the entire dataset on all compute nodes to minimize read latency.",
+      "Use a centralized metadata server to manage dataset versioning and updates across nodes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing a Kubernetes cluster with multiple AI workloads running in separate namespaces. A high-priority machine learning (ML) workload is experiencing performance degradation due to resource contention with other workloads. The cluster has sufficient overall resources, but the ML workload is not getting the required CPU and memory. Which of the following approaches will most effectively resolve the issue?",
+    "a": [
+      "Use Kubernetes taints and tolerations to reserve nodes exclusively for the ML workload.",
+      "Increase the node count in the Kubernetes cluster to provide additional resources.",
+      "Configure ResourceQuotas in the namespace of the ML workload to ensure minimum resource allocation.",
+      "Enable a cluster-wide LimitRange policy to cap the resource usage of all workloads equally."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are monitoring the performance of NVIDIA Base Command Manager (BCM) in your AI data center and observe significant delays in job scheduling and execution. The logs reveal the following: High CPU utilization on the central BCM manager Frequent disk I/O warnings on the central server Normal network traffic between agents and the central manager Which of the following actions is the best approach to resolve this issue?",
+    "a": [
+      "Optimize disk I/O by migrating to NVMe-based storage for the central manager.",
+      "Add more GPUs to the compute nodes.",
+      "Increase the timeout values in the agent configuration files.",
+      "Upgrade the network switches to increase bandwidth."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your organization operates a data center running GPU-based systems for AI training. Energy costs are a significant concern, and you aim to optimize power usage without sacrificing performance. Which of the following strategies is most effective for managing GPU power consumption during training?",
+    "a": [
+      "Use a software-based energy-saving mode that reduces the number of cores available on the GPU.",
+      "Reduce the GPU clock speeds permanently to minimize energy usage across all workloads.",
+      "Use NVIDIA's nvidia-smi tool to dynamically adjust the power limit based on the workload requirements.",
+      "Set GPUs to their maximum power limit to ensure peak performance at all times."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are the administrator of a Slurm cluster used for high-performance computing workloads. The cluster consists of nodes with varying configurations, and you need to update the slurm.conf file to allocate nodes into specific partitions based on their memory and CPU configurations. Which of the following steps should you take to ensure the changes are applied correctly?",
+    "a": [
+      "Update the slurm.conf file, then copy it manually to each compute node and restart slurmd on each node.",
+      "Modify the slurm.conf file and run scontrol reconfigure on the primary Slurm controller.",
+      "Modify the slurm.conf file, then restart the Slurm daemons (slurmctld and slurmd) on all nodes.",
+      "Modify the slurm.conf file and wait for the Slurm daemons to automatically propagate the changes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are provisioning a new cluster using NVIDIA Base Command Manager (BCM). Your goal is to ensure that the cluster is configured for optimal performance for distributed training of a large deep learning model. Which of the following actions must be taken during the provisioning process?",
+    "a": [
+      "Assign a shared storage system that can only be accessed by a single node at a time.",
+      "Enable auto-scaling to ensure the number of nodes adjusts dynamically during training.",
+      "Select the appropriate GPU instance type based on the model size and training requirements.",
+      "Configure the cluster to disable Infiniband to reduce network overhead."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are an AI Operations engineer troubleshooting a fabric manager service on an NVIDIA NVLink/NVSwitch system. You notice that the fabric manager service is not running, and your goal is to determine the root cause. Which of the following actions would most likely identify and resolve the issue?",
+    "a": [
+      "Restart the fabric manager service without investigating logs or configuration files.",
+      "Reinstall the operating system to resolve potential file corruption.",
+      "Check the compatibility of the installed NVIDIA driver version with the fabric manager service version.",
+      "Verify the /etc/nv-fabricmanager/config.json file for syntax errors and ensure it is correctly configured for the current hardware topology."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are managing a deep learning workload using Docker containers. A specific container running TensorFlow occasionally fails with an OOMKilled status. Upon inspecting the container logs, you notice high memory consumption during the workload execution. What is the most appropriate solution to address this issue?",
+    "a": [
+      "Restart the container automatically when it fails using the --restart policy.",
+      "Disable the memory limits on the Docker container to allow it to use the host's memory freely.",
+      "Modify the TensorFlow code to run in a CPU-only mode instead of GPU mode.",
+      "Increase the available memory to the Docker container by adjusting the --memory flag."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "Your organization has recently onboarded a new GPU cluster to Fleet Command, and you must ensure that workloads are deployed only to devices with a minimum of 16 GB of GPU memory. Which of the following configurations will ensure compliance with this requirement?",
+    "a": [
+      "Tag devices manually with \"High-Memory\" and apply tag-based deployment policies.",
+      "Specify the GPU memory requirement in the resource quota section of the workload configuration.",
+      "Configure a deployment policy with GPU memory requirements in the workload definition.",
+      "Set a device filter policy based on GPU type (e.g., NVIDIA A100)."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with scaling an AI workload running on a Kubernetes cluster. The workload requires GPU support for AI inference and has varying demand based on user traffic. Which configuration ensures optimal resource utilization and workload scaling?",
+    "a": [
+      "Use a Deployment with GPU resource requests, combined with a Horizontal Pod Autoscaler (HPA) based on CPU usage metrics.",
+      "Use a Deployment with resource requests and limits for CPU and memory, leaving GPU configurations unset.",
+      "Use a DaemonSet to ensure that each node in the cluster has a pod utilizing GPUs.",
+      "Use a Deployment with GPU resource requests and limits, combined with a custom metric-based autoscaler."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with preprocessing a large dataset containing millions of rows and multiple categorical and numerical features for training a machine learning model. Which of the following actions is the most optimal approach using NVIDIA RAPIDS to handle the dataset effectively and prepare it for training?",
+    "a": [
+      "Use cuDF to load the data into GPU memory and apply GPU-accelerated transformations such as filtering, encoding, and scaling.",
+      "Use pandas for initial data preprocessing steps, then transfer the data to cuDF for GPU-accelerated transformations.",
+      "Use cuDF to perform all preprocessing steps on the CPU to avoid GPU memory bottlenecks.",
+      "Use cuML for data preprocessing as it provides optimized methods for both numerical and categorical data transformations."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are an administrator managing an NVIDIA AI cluster that uses Slurm for workload scheduling. The research team is experiencing delays in job execution due to inefficient scheduling policies. Your task is to optimize the scheduling configuration to improve resource allocation while minimizing job wait times. Which of the following configurations in Slurm is the most effective approach to prioritize job scheduling and ensure fair resource allocation in a multi-user environment?",
+    "a": [
+      "Disable backfill scheduling and rely solely on the default FIFO (first in, first out) scheduling policy.",
+      "Use PreemptionMode=kill to terminate low-priority jobs immediately when high-priority jobs are submitted.",
+      "Set PriorityType=basic and allocate resources on a first-come, first-served basis.",
+      "Enable the backfill scheduler and configure job priorities using the PriorityWeightFairShare parameter."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "An AI team plans to provision a new cluster for large-scale model training. They need to ensure that the cluster is optimized for performance and reliability while keeping costs under control. Which of the following actions should they take? (Choose two)",
+    "a": [
+      "Use mixed-instance types within a single cluster to optimize cost.",
+      "Deploy cluster nodes across multiple availability zones for high availability.",
+      "Select GPU instances with the highest memory regardless of application requirements.",
+      "Disable auto-scaling to ensure consistent resource availability.",
+      "Configure network settings to use dedicated bandwidth for inter-node communication."
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "A company is deploying an AI-powered weather prediction model in a cloud environment and aims to minimize energy usage while maintaining high performance. Which strategy should they implement to achieve their goal?",
+    "a": [
+      "Enable aggressive overclocking on GPUs to reduce execution time.",
+      "Configure all GPU instances to run at maximum clock speed continuously.",
+      "Utilize auto-scaling to adjust GPU resources based on workload demand.",
+      "Use single-precision (FP32) calculations to maintain accuracy and efficiency."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with scaling an AI data center to accommodate growing datasets and higher computational demands. Which of the following storage architectures is the best choice to ensure scalability, high performance, and fault tolerance?",
+    "a": [
+      "Configuring direct-attached storage (DAS) on each compute node.",
+      "Implementing a distributed parallel file system like Lustre or GPFS.",
+      "Using a single large NAS device for all storage needs.",
+      "Using JBOD (Just a Bunch of Disks) for flexible data storage."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are administering an NVIDIA Fleet Command deployment for a multi-department organization. The finance department requires access to specific dashboards for monitoring GPU utilization and cost analytics, while the AI research team needs access to deploy and manage models across the organization. As the administrator, how should you configure user access to meet these requirements while maintaining security and least privilege principles? (Choose two)",
+    "a": [
+      "Create two user roles: \"Finance Viewer\" and \"Research Administrator,\" assigning appropriate permissions to each role.",
+      "Set up role-based access control (RBAC) to enforce permissions at the project level and assign users to the appropriate roles.",
+      "Configure access policies at the GPU cluster level, giving the finance department read-only access and the research team full access.",
+      "Assign the \"Administrator\" role to all users to simplify management.",
+      "Create a single shared account for the finance and research teams to streamline access."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with deploying an AI training workload on a Kubernetes cluster. The workload involves GPU-intensive tasks, and the cluster contains both CPU and GPU nodes. How should you configure Kubernetes to ensure the AI workload runs efficiently on GPU nodes?",
+    "a": [
+      "Schedule the workload using default Kubernetes scheduling policies without modifications.",
+      "Configure a Kubernetes Service to expose GPU nodes directly to the AI application.",
+      "Use node affinity to specify GPU nodes for the workload.",
+      "Label the GPU nodes and use taints and tolerations to isolate them for AI workloads."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You observe that certain compute nodes in an NVIDIA-powered AI cluster are not receiving jobs, and their state is marked as \"down\" in the Base Command Manager (BCM). What is the most effective way to diagnose and resolve the issue using system management tools?",
+    "a": [
+      "Use ping to test connectivity between the BCM controller and the affected nodes.",
+      "Use nvidia-smi on the controller node to check for GPU availability.",
+      "Use BCM's cluster-wide scheduling logs to force the nodes back to an \"active\" state.",
+      "Use a GPU profiling tool like nvprof to identify performance bottlenecks."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 1"
+  },
+  {
+    "q": "You are deploying Kubernetes on NVIDIA hosts using BCM. The cluster must be configured to handle AI workloads efficiently while ensuring compatibility with GPU-accelerated containers. Which two configurations should you prioritize during installation and deployment? (Choose two)",
+    "a": [
+      "Enable GPU sharing by modifying Kubernetes kube-scheduler.",
+      "Enable MIG (Multi-Instance GPU) mode on supported GPUs.",
+      "Set up NVIDIA DeepOps to configure GPU-accelerated Kubernetes clusters.",
+      "Assign a fixed number of GPUs per node to specific workloads.",
+      "Install the NVIDIA Container Toolkit on each node."
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 1"
+  },
+  {
+    "q": "You are tasked with deploying NVIDIA DOCA services on a DPU (Data Processing Unit) with an Arm-based architecture. The deployment must ensure optimized performance, security, and compatibility with the underlying hardware. Which of the following steps is essential for a successful deployment?",
+    "a": [
+      "Install the DOCA SDK without configuring network namespaces for data isolation.",
+      "Install DOCA services directly on the host machine to bypass compatibility checks with the DPU Arm architecture.",
+      "Disable secure boot on the DPU to simplify the installation process.",
+      "Verify that the DPU firmware is updated to the latest version compatible with the DOCA SDK."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "An organization is upgrading its data center to support advanced AI workloads, including real-time inference and large-scale model training. Network performance is identified as a potential bottleneck. Which of the following configurations should be prioritized to optimize network performance for AI workloads?",
+    "a": [
+      "Implementing RDMA over Converged Ethernet (RoCE) for low-latency data transfer.",
+      "Using a single network interface card (NIC) per server to minimize configuration complexity.",
+      "Configuring all devices to use legacy network switches to avoid compatibility issues.",
+      "Deploying a 1 Gbps Ethernet network to save costs while maintaining adequate performance."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A team deploying a high-performance AI inference pipeline observes significant delays in loading models and processing input data. They plan to implement NVIDIA GPUDirect Storage to optimize performance. Which aspect of their current setup must they prioritize for compatibility with GPUDirect?",
+    "a": [
+      "Migrate to a cloud-based storage system for better scalability.",
+      "Ensure the storage devices support SATA connections.",
+      "Replace all GPUs with CPUs that have higher core counts.",
+      "Verify that the file system and storage devices are NVMe-based and support RDMA."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "An administrator notices degraded performance on a multi-GPU system connected via NVIDIA NVSwitch. The Fabric Manager service is running but is not optimizing GPU-to-GPU communication. Which two actions should the administrator take to optimize performance? (Choose two)",
+    "a": [
+      "Restart the Fabric Manager service to reinitialize the NVSwitch configuration.",
+      "Ensure that the GPUs are configured in a full-mesh topology in the Fabric Manager settings.",
+      "Run the nvidia-smi topo command to verify GPU topology and bandwidth.",
+      "Add the Fabric Manager service to the system's boot process using chkconfig.",
+      "Modify the system's NUMA settings to bind all GPUs to a single CPU."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "What is the primary purpose of the NVIDIA AI Enterprise Suite within the NVIDIA AI ecosystem?",
+    "a": [
+      "To provide tools for building and optimizing AI inference models",
+      "To facilitate large-scale AI development on Kubernetes-based infrastructures",
+      "To provide a toolkit for creating AI-based digital twins",
+      "To offer a marketplace for pretrained AI models and containers"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A company is running AI inference workloads on GPU-based nodes in a hybrid cloud environment. The workload demand varies significantly during the day, causing underutilization during low-demand periods and over-provisioning during high-demand periods. Which strategy should the company implement to optimize GPU usage while maintaining service levels?",
+    "a": [
+      "Deploy a round-robin scheduling policy to distribute workloads equally across all nodes.",
+      "Use dynamic resource scaling with predictive autoscaling based on historical workload trends.",
+      "Enable CPU-based failover mechanisms for all AI workloads.",
+      "Deploy static resource allocation with a fixed number of GPU nodes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are responsible for troubleshooting a Broadcom BCM Ethernet switch experiencing intermittent performance issues in an AI operations environment. The switch is connected to multiple high-speed InfiniBand adapters used for large-scale model training. Upon inspection, you notice packet drops and high latency in data transmission. Which of the following steps is the most appropriate first step to identify the root cause of the issue?",
+    "a": [
+      "Replace all cables connecting the switch to the adapters with new, high-quality cables.",
+      "Verify the switch firmware version and compare it with the vendor's recommended version.",
+      "Inspect the port counters for errors such as CRC or FEC errors.",
+      "Perform a factory reset of the switch to eliminate configuration errors."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "During the deployment of NVIDIA Bright Cluster Manager (BCM), an administrator encounters issues with node discovery. Which of the following steps is most likely to resolve the issue?",
+    "a": [
+      "Verify that the PXE boot configuration is correctly set up for the compute nodes.",
+      "Check that the compute nodes are connected to the management node via SSH.",
+      "Enable NVIDIA GPU drivers on the compute nodes before discovery begins.",
+      "Restart the BCM service on the management node to reinitialize the discovery process."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with installing Base Command Manager (BCM) on a newly provisioned GPU cluster. The installation must ensure proper configuration for optimal performance and future scalability. Which of the following steps are required during installation? (Choose two)",
+    "a": [
+      "Disable SSL encryption to simplify internal communications between cluster nodes.",
+      "Configure the cluster nodes with a shared filesystem accessible to BCM.",
+      "Configure the bcm.conf file to define the GPU types and their memory capacity.",
+      "Install the required BCM dependencies, such as Docker and Kubernetes.",
+      "Skip the installation of monitoring tools to avoid performance overhead."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "While troubleshooting an NVIDIA NVSwitch system, you observe degraded NVLink bandwidth between GPUs. Upon running diagnostic commands, you notice intermittent errors reported by the fabric manager service. Which troubleshooting step is most likely to resolve the issue?",
+    "a": [
+      "Update the fabric manager and NVSwitch firmware to the latest versions.",
+      "Verify and reseat the NVLink cables and connectors.",
+      "Increase the timeout settings in the fabric manager configuration file.",
+      "Replace the GPUs that are reporting NVLink errors."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A company plans to deploy an AI infrastructure to support a recommendation engine for e-commerce. The platform needs to scale dynamically during seasonal peaks and minimize idle resource costs. What infrastructure management strategy should be implemented?",
+    "a": [
+      "Use dedicated on-premise CPUs and GPUs for peak and non-peak periods.",
+      "Deploy static virtual machines in the cloud with a fixed number of GPU resources.",
+      "Use on-premise GPU servers with auto-scaling capabilities.",
+      "Implement Kubernetes with GPU scheduling in a hybrid cloud environment."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are managing an AI training workload on a GPU cluster, but the GPU utilization is consistently below 40%, leading to extended training times. Which of the following actions is most likely to resolve the issue?",
+    "a": [
+      "Switch to a CPU-based implementation for preprocessing.",
+      "Reduce the learning rate to ensure more precise model convergence.",
+      "Disable mixed precision training to simplify computations.",
+      "Increase the number of worker threads in the data loading process."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "After successfully installing Base Command Manager (BCM), you are tasked with configuring it to manage workloads effectively. Which of the following configurations should you implement to ensure a functional and secure deployment? (Choose two)",
+    "a": [
+      "Define user roles and permissions within BCM to restrict access to critical resources.",
+      "Disable logging to reduce storage requirements.",
+      "Use default storage paths for job logs and temporary files.",
+      "Configure the job submission API with token-based authentication.",
+      "Set up BCM to allow root-level access for all users for operational simplicity."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are troubleshooting a performance degradation issue in an HPC cluster using NVIDIA Magnum IO. You suspect that the NVSHMEM library is not performing optimally due to incorrect configuration. What is the most effective first step to troubleshoot the issue?",
+    "a": [
+      "Restart the job scheduler to reset all cluster jobs and configurations.",
+      "Verify the environment variables related to NVSHMEM, such as NVSHMEM_SYMMETRIC_SIZE, to ensure they are properly configured for the workload.",
+      "Disable RDMA (Remote Direct Memory Access) to isolate the issue to CPU-only communication paths.",
+      "Reinstall the NVSHMEM library on all nodes in the cluster."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are configuring a Multi-Instance GPU (MIG) for a high-performance computing (HPC) cluster. Your goal is to allocate resources for a mix of workloads: one requiring high memory and compute capabilities, and several smaller jobs needing less memory but consistent throughput. Which steps should you take to optimize the MIG configuration for this scenario? (Choose two)",
+    "a": [
+      "Create identical MIG instances to simplify the configuration and distribute workloads evenly.",
+      "Divide the GPU into MIG instances of varying sizes based on workload requirements.",
+      "Reserve at least one GPU instance exclusively for debugging and maintenance tasks.",
+      "Allocate all GPU resources to the largest MIG instance to maximize performance for the high-memory workload.",
+      "Monitor MIG usage patterns and adjust the configuration dynamically based on workload changes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "During cluster provisioning in NVIDIA Base Command Manager (BCM), you notice that training jobs are not achieving expected performance. Upon investigation, you identify that the cluster nodes are not fully utilizing the available GPUs. Which of the following steps is most likely to resolve this issue?",
+    "a": [
+      "Configure each node to reserve a portion of GPU memory for system-level tasks.",
+      "Disable NVLink to minimize the overhead of GPU-to-GPU communication.",
+      "Verify that the job scheduling policy in BCM supports multi-GPU training workloads.",
+      "Assign multiple training jobs to a single GPU to improve utilization."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your team is working on training a deep learning model across multiple nodes in a distributed environment. You are using NVIDIA's AI Workflow Orchestration tools, such as NVIDIA NGC and Kubernetes, to manage the distributed training jobs. During the training, you want to ensure fault tolerance, optimize GPU utilization, and enable automated recovery in case of node failure. Which of the following configurations is most effective for managing distributed training jobs with NVIDIA solutions?",
+    "a": [
+      "Disabling checkpointing to minimize I/O overhead during distributed training.",
+      "Using Kubernetes with NVIDIA GPU Operator to deploy and manage GPU nodes.",
+      "Using NVIDIA NGC's pretrained models without any orchestration to reduce workload complexity.",
+      "Manually allocating GPUs to training jobs without orchestration to avoid scheduler overhead."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You need to deploy an AI inference application in a Kubernetes cluster that uses GPUs for accelerated processing. Which of the following YAML configurations ensures that the pod can access the GPU resources?",
+    "a": [
+      "resources: requests: gpu: \"1\" limits: gpu: \"1\"",
+      "resources: requests: nvidia.gpu: \"1\" limits: nvidia.gpu: \"1\"",
+      "resources: requests: memory: \"4Gi\" cpu: \"2\" limits: memory: \"8Gi\" cpu: \"4\"",
+      "resources: requests: nvidia.com/gpu: \"1\" limits: nvidia.com/gpu: \"1\""
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A Run.ai administrator wants to monitor GPU utilization and ensure that workloads are distributed efficiently across a hybrid cloud environment. Which feature or tool in Run.ai should the administrator use to achieve this goal?",
+    "a": [
+      "Use the Run.ai CLI to manually monitor GPU utilization metrics.",
+      "Enable the Scheduler Reports feature in the Run.ai dashboard to track workload distribution and GPU usage.",
+      "Configure Kubernetes Metrics Server to collect GPU usage data and integrate it with Run.ai.",
+      "Use the Namespace Resource Limiter in Kubernetes to restrict GPU utilization by workloads."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with designing the storage infrastructure for an AI data center that primarily runs deep learning workloads. The center processes large datasets, requires low-latency access, and needs to accommodate both training and inference workloads. Which two storage configurations would best meet the requirements? (Choose two)",
+    "a": [
+      "NVMe-based SSD arrays with high IOPS",
+      "Distributed file system designed for AI workloads",
+      "Tape drives for archival and real-time data retrieval",
+      "Object storage with built-in tiering capabilities",
+      "HDDs with RAID-5 configuration"
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are optimizing the Baseboard Management Controller (BMC) on an NVIDIA system for secure remote management. After configuring new authentication settings, users report that they cannot log in to the BMC web interface. The logs show repeated Invalid credentials errors. What is the most likely issue?",
+    "a": [
+      "The new authentication settings are not supported by the current BMC firmware version.",
+      "A misconfigured LDAP server is causing login attempts to fail.",
+      "The password complexity requirements for the BMC were not met during the configuration update.",
+      "Network connectivity issues are preventing users from reaching the BMC web interface."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with designing a scalable and fault-tolerant AI infrastructure to handle real-time data processing for a financial prediction system. Which of the following is the most critical design consideration to ensure both scalability and fault tolerance in this AI architecture?",
+    "a": [
+      "Rely on a single region in a cloud platform to minimize network latency during training and inference.",
+      "Use a monolithic application design for simplicity in deploying AI models and associated services.",
+      "Deploy the AI model on a single high-performance GPU server with RAID-5 storage to ensure data redundancy.",
+      "Use a distributed computing framework like Kubernetes to manage containerized AI workloads across multiple nodes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are deploying a TensorFlow-based AI workload on a Kubernetes cluster using a container image from NVIDIA GPU Cloud (NGC). The container image must utilize the GPU for training tasks. However, during the deployment, the container does not detect the GPU and defaults to CPU usage. What is the most likely cause, and how can it be resolved?",
+    "a": [
+      "The container image is not compatible with the Kubernetes cluster version. Upgrade Kubernetes to the latest version.",
+      "The deployment YAML file lacks the nodeSelector for GPU-enabled nodes. Add a nodeSelector to the YAML file.",
+      "The NVIDIA GPU operator is not installed on the cluster. Install the NVIDIA GPU operator to enable GPU utilization.",
+      "The Kubernetes node does not have sufficient CPU and memory resources for the container. Increase node resources."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with deploying a cloud VMI container to a Kubernetes-based environment for an AI workload requiring GPU acceleration. The container image has been built successfully, and the GPU nodes in the cluster are correctly labeled. However, the deployment fails, and the container logs show an error indicating that the container runtime does not support GPUs. Which action should you take to resolve the issue?",
+    "a": [
+      "Upgrade the Kubernetes version to ensure compatibility with the container runtime.",
+      "Rebuild the container image with a different base image optimized for CPU workloads.",
+      "Allocate additional memory to the container for compatibility with GPU workloads.",
+      "Ensure the NVIDIA Container Toolkit is installed on the GPU nodes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are administering a server equipped with NVIDIA A100 GPUs and need to configure Multi-Instance GPU (MIG) profiles to optimize GPU utilization for concurrent AI workloads. Which of the following actions is the most critical to ensure efficient resource allocation and workload performance?",
+    "a": [
+      "Allocate all MIG instances with the same profile size to ensure uniform resource distribution.",
+      "Enable MIG on only one GPU to reduce administrative complexity.",
+      "Configure MIG profiles based on the memory and compute requirements of each workload.",
+      "Assign more MIG instances than the physical GPU resources to maximize utilization."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "In a shared AI infrastructure, multiple teams run training and inference jobs on the same set of GPU resources. The operations team notices frequent job failures and resource contention issues. Which approach should the team adopt to ensure efficient workload management and fair resource allocation?",
+    "a": [
+      "Enable overcommitment of GPU resources to maximize utilization.",
+      "Deploy a priority-based scheduler with job preemption capabilities.",
+      "Allow teams to request as many GPUs as needed, assuming resources will be available.",
+      "Implement a first-come, first-served (FCFS) scheduling policy for all jobs."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your organization is planning to deploy an AI application that requires low-latency inference for real-time decisions while training models with large datasets that are primarily stored in the cloud. Which infrastructure design best meets these requirements?",
+    "a": [
+      "Deploy inference workloads on-premises and training workloads in the cloud.",
+      "Adopt a hybrid model where data is replicated between on-premises and cloud environments.",
+      "Deploy inference workloads on edge devices while training occurs in the cloud.",
+      "Deploy all components on a public cloud using GPU instances."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your organization operates edge devices that require frequent deployment of AI models. The models are trained in the cloud and need to be securely deployed to multiple edge locations with minimal latency. You also require centralized monitoring and rollback capabilities in case of deployment issues. Which NVIDIA tool and process should you use to automate the deployment of models to edge devices while meeting the organization's requirements?",
+    "a": [
+      "Use NVIDIA Fleet Command to deploy models to edge devices and monitor their performance.",
+      "Leverage NVIDIA cuBLAS to transfer models to edge devices.",
+      "Use Kubernetes with NVIDIA Triton Inference Server and manage deployments manually.",
+      "Develop a custom Python-based deployment tool integrated with NVIDIA RAPIDS for monitoring."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are running a containerized AI workload on a host system using Docker. The workload processes large datasets and is experiencing high latency during disk I/O operations. Upon investigation, you find the container uses a volume mapped to an HDD on the host. What is the most appropriate solution to optimize storage performance for this workload?",
+    "a": [
+      "Compress the data files before processing to reduce the size of I/O operations.",
+      "Increase the size of the container's writable layer using the --storage-opt flag.",
+      "Replace the HDD with an SSD on the host system and map the volume to the SSD.",
+      "Set the container to use a read-only file system to minimize write operations."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "While deploying NVIDIA VMI containers in a cloud environment, you need to ensure that the containerized workload can fully utilize the GPU resources of the host machine. Which configuration step is required to achieve this?",
+    "a": [
+      "Add the --gpus all flag when starting the container.",
+      "Run the container without any additional flags.",
+      "Allocate CPU cores to mimic GPU-like performance.",
+      "Install GPU drivers inside the container."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are responsible for setting up monitoring and alerting in NVIDIA Fleet Command to ensure prompt responses to GPU utilization spikes and model performance degradation. What steps should you take to configure effective monitoring and alerting? (Choose two)",
+    "a": [
+      "Use Fleet Command's built-in alerting system, but only monitor GPU temperature to reduce complexity.",
+      "Set up project-specific alerts with customized thresholds based on workload requirements.",
+      "Integrate Fleet Command with a third-party monitoring tool like Prometheus or Grafana for advanced monitoring.",
+      "Disable alerts temporarily for teams that do not require active monitoring to reduce false positives.",
+      "Enable GPU utilization alerts and set a global threshold for all deployments."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "While troubleshooting an issue with NVIDIA Baseboard Management Controller (BMC), you observe that the system's BMC interface becomes unresponsive after enabling IPMI over LAN. Which of the following is the most likely root cause of this issue?",
+    "a": [
+      "The BMC interface is disabled in the system BIOS.",
+      "The network switch connected to the BMC is misconfigured to block IPMI traffic.",
+      "The IPMI over LAN feature conflicts with an existing DHCP server configuration.",
+      "The BMC firmware is outdated and incompatible with IPMI over LAN."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "As a Slurm administrator, you are tasked with monitoring the health of compute nodes in your cluster. Recently, jobs have been failing due to nodes becoming unresponsive. You want to configure a health check script to automatically mark nodes as DOWN when they fail the health check. What is the correct way to achieve this?",
+    "a": [
+      "Add the health check script path to the HealthCheckProgram parameter in slurm.conf and set an appropriate interval using HealthCheckInterval.",
+      "Modify the slurmctld service to automatically disable nodes that become unresponsive without needing a health check script.",
+      "Write a custom script to monitor node health and use scontrol update to manually mark nodes as DOWN when issues are detected.",
+      "Enable the NodeFail flag in slurm.conf and restart all slurmd daemons to ensure health checks are enforced."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "During the deployment of cloud VMI containers for a production AI model inference system, you encounter high latency in response times. Which of the following strategies is the most effective way to address this issue?",
+    "a": [
+      "Configure multiple replicas of the container and implement load balancing to distribute the inference requests evenly.",
+      "Disable resource constraints within the orchestration platform to allow unrestricted resource usage.",
+      "Use a single, high-performance GPU container instance and scale vertically as needed.",
+      "Increase the size of the VMI storage disk to enhance read/write speeds."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A team is troubleshooting their Kubernetes cluster after integrating NVIDIA GPU Operator. The team notices that their AI/ML pods fail to utilize the GPUs. Which of the following actions should the team take to resolve the issue?",
+    "a": [
+      "Verify that the GPU nodes are labeled with nvidia.com/gpu.present.",
+      "Manually compile and install the NVIDIA GPU driver on all cluster nodes.",
+      "Replace the NVIDIA GPU Operator with a custom script to allocate GPU resources.",
+      "Ensure that the NVIDIA Device Plugin DaemonSet is running and correctly configured."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are managing an AI cluster where training times for machine learning models have significantly increased. After reviewing the system, you need to identify the most likely source of the bottleneck. Which of the following factors is most critical to check first to diagnose the issue?",
+    "a": [
+      "The availability of additional hard disk storage on the compute nodes.",
+      "The GPU utilization and PCIe bandwidth between GPUs and CPUs.",
+      "The temperature of the data center where the cluster is housed.",
+      "The power supply wattage of each compute node."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A company is deploying a Kubernetes cluster to run AI/ML workloads using NVIDIA GPUs. To manage the GPU resources effectively, they plan to use NVIDIA GPU Operator. Which of the following best describes the primary role of the NVIDIA GPU Operator in this scenario?",
+    "a": [
+      "The GPU Operator replaces Kubernetes' native scheduler for handling GPU workloads.",
+      "The GPU Operator provisions GPUs in the Kubernetes cluster by creating GPU hardware from virtual resources.",
+      "The GPU Operator schedules AI/ML workloads on GPU nodes without requiring Kubernetes node labels.",
+      "The GPU Operator manages the lifecycle of GPU drivers, runtime libraries, and monitoring tools in Kubernetes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with deploying NVIDIA Virtual Machine Images (VMI) containers in the cloud to support AI workloads using TensorFlow. The workload requires GPU acceleration and compatibility with TensorFlow 2.9. Which container image should you select to ensure compatibility and performance?",
+    "a": [
+      "tensorflow/tensorflow:latest",
+      "nvidia/ai:universal",
+      "nvidia/tensorflow:2.9-cuda11.6",
+      "nvidia/cuda:latest"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A system administrator is tasked with configuring a Run.ai environment to optimize the allocation of GPU resources across multiple departments in an organization. Each department must have a dedicated quota of GPU resources, but unused GPUs should be shared dynamically between departments when needed. Which configuration approach best meets this requirement?",
+    "a": [
+      "Create separate virtual clusters for each department, ensuring no overlap in resource allocation.",
+      "Configure static quotas for each department in Run.ai and assign GPUs exclusively to those quotas.",
+      "Implement dynamic quotas with overcommitment enabled and set department-specific limits in the Run.ai interface.",
+      "Use Kubernetes node affinity to statically bind workloads to GPUs associated with specific departments."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A Kubernetes cluster hosts multiple machine learning workloads, some of which require GPUs. You notice that non-GPU workloads are being scheduled on GPU-enabled nodes, leading to resource contention. To resolve this, you decide to enforce proper resource allocation. Which steps should you take to address this issue? (Choose two)",
+    "a": [
+      "Configure the Kubernetes scheduler to assign workloads to nodes based on their resource utilization.",
+      "Apply a node selector in the pod specification to ensure workloads are assigned to appropriate nodes.",
+      "Label GPU nodes and use affinity rules to schedule workloads requiring GPUs.",
+      "Use taints on GPU nodes to restrict scheduling of non-GPU workloads.",
+      "Deploy a custom scheduler that exclusively handles GPU workload placement."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "You are tasked with deploying an NVIDIA GPU-accelerated Kubernetes cluster for AI training workloads. After installing Kubernetes on all nodes, you want to enable GPU support. What is the correct sequence of steps to install the NVIDIA GPU Operator and ensure proper functionality?",
+    "a": [
+      "Install the NVIDIA GPU Operator, enable node labeling for GPUs, and deploy GPU workloads.",
+      "Install the NVIDIA GPU Operator, deploy GPU workloads, and verify node readiness.",
+      "Install the NVIDIA GPU Operator, configure the NVIDIA Container Toolkit, and deploy GPU workloads.",
+      "Install the NVIDIA GPU driver manually, install the NVIDIA GPU Operator, and then deploy GPU workloads."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You need to deploy a containerized VMI for a machine learning application on a cloud platform. The VMI needs access to GPU resources for efficient computation. Which of the following actions should you prioritize to ensure a successful deployment?",
+    "a": [
+      "Ignore GPU-specific configurations to simplify the deployment process.",
+      "Use the default cloud instance type without verifying hardware compatibility with GPU workloads.",
+      "Enable the container runtime's built-in GPU acceleration feature and configure resource limits in the deployment specification.",
+      "Manually install GPU drivers inside the container runtime during deployment."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A user reports that an AI inference workload is running slower than expected on the cluster. Using system management tools, you observe the following:GPU utilization is at 30% across all worker nodes.Memory utilization is high on several nodes.Disk I/O rates are elevated, especially for nodes hosting the workload.Network latency between nodes is within normal limits.What is the most likely cause of the performance bottleneck, and what should you do to address it?",
+    "a": [
+      "The GPUs are underutilized due to driver issues; reinstall the GPU drivers.",
+      "Network congestion is throttling communication between nodes; increase network bandwidth.",
+      "The workload is improperly configured for multi-GPU execution; reconfigure the workload for distributed GPU processing.",
+      "The workload's input data is not properly partitioned, causing high disk I/O; optimize data partitioning."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your data center runs several NVIDIA DGX systems for AI training, which generate significant heat during operation. Which cooling approach is most suitable for maintaining optimal GPU performance and energy efficiency?",
+    "a": [
+      "Use liquid cooling systems specifically designed for NVIDIA DGX servers.",
+      "Rely on natural ventilation to reduce operational costs.",
+      "Implement raised flooring with underfloor airflow to manage heat dissipation.",
+      "Install traditional air conditioning units throughout the data center."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A data scientist is preprocessing a dataset using NVIDIA RAPIDS and encounters missing values in both numerical and categorical columns. Which of the following strategies best utilizes RAPIDS to handle the missing data efficiently?",
+    "a": [
+      "Export the dataset to a CSV file, use Python's pandas to handle missing values, and reload the updated dataset into cuDF.",
+      "Use cuDF.dropna() to remove rows with missing values, followed by reloading the data into GPU memory to update the dataset.",
+      "Convert the dataset to a NumPy array and manually handle missing values before loading it back into cuDF.",
+      "Use cuDF.fillna() to replace missing values with a specified constant or statistic like the mean, median, or mode directly on the GPU."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are an administrator configuring a NVIDIA A100 GPU with Multi-Instance GPU (MIG) enabled to optimize the usage of GPU resources for diverse AI workloads. Your goal is to allocate GPU resources to three workloads with the following requirements:1. Workload A requires low-latency inferencing and minimal GPU memory.2. Workload B involves training a small model and requires moderate GPU memory.3. Workload C involves data preprocessing and requires minimal GPU compute but a large amount of GPU memory.Which configuration best meets these requirements?",
+    "a": [
+      "Disable MIG and allocate the entire GPU to a single workload at a time.",
+      "Use a single MIG instance with 7g.40gb and run all workloads concurrently.",
+      "Configure three instances of equal size, each with 1/3 of the GPU memory and compute power.",
+      "Create three MIG instances: one with 1g.5gb for Workload A, one with 2g.10gb for Workload B, and one with 4g.20gb for Workload C."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A container running a machine learning inference service is unable to communicate with other containers within the same Docker network. The following configurations are in place:1. The container is connected to a custom Docker bridge network.2. Other containers on the same network can communicate with each other.3. A firewall rule allows all traffic on the Docker network interface.What steps would you take to troubleshoot this issue? (Choose two)",
+    "a": [
+      "Verify that the container's IP address is unique within the Docker bridge network.",
+      "Restart the Docker service to reinitialize all network connections.",
+      "Bind the container's port explicitly to the host network.",
+      "Ensure that the iptables rules on the host machine allow traffic on the Docker bridge subnet.",
+      "Use the docker exec command to check if the container's DNS resolution is functional."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 2"
+  },
+  {
+    "q": "An AI operations engineer is troubleshooting a performance bottleneck in a deep learning training workload running on a multi-node GPU cluster. The training job uses large batches of data, and the GPUs are observed to have low utilization. Which of the following is the most likely cause of the low GPU utilization?",
+    "a": [
+      "Network congestion causing delays in data transfer between nodes.",
+      "The batch size is too large for efficient GPU processing.",
+      "Insufficient GPU memory to hold the model weights and training data.",
+      "The CPU is overloaded due to an excessive number of processes."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "During an optimization audit for an NVIDIA NVLink/NVSwitch system, the fabric manager service shows degraded performance, and the logs contain repeated \"Failed to initialize NVSwitch topology\" errors. Which action would best resolve this issue?",
+    "a": [
+      "Re-seat all NVSwitch modules to ensure proper hardware connections.",
+      "Update the firmware for all NVSwitch components to the latest version compatible with your system.",
+      "Disable the fabric manager service to allow the system to function without NVLink optimization.",
+      "Manually overwrite the nv-fabricmanager service binary with a fresh copy from the installation media."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "An AI team is facing performance issues with a data pipeline that preprocesses large datasets for deep learning. Profiling reveals frequent I/O stalls during data loading. Which strategy would most effectively reduce I/O bottlenecks?",
+    "a": [
+      "Disabling asynchronous data loading to simplify pipeline operations.",
+      "Compressing input data files to minimize storage usage.",
+      "Increasing the batch size to reduce data loader overhead.",
+      "Switching to a distributed file system with high-throughput capabilities."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your team is deploying an AI training platform in an on-premises data center using NVIDIA GPUs. You need to ensure that multiple teams can share GPU resources securely and fairly while isolating workloads. The solution should minimize administrative overhead and allow for flexible resource allocation. Which approach best supports these requirements?",
+    "a": [
+      "Install separate physical servers for each team to ensure isolation",
+      "Use Kubernetes with taints and tolerations only, without device plugins",
+      "Use Docker containers with CUDA and share all GPUs via the --gpus all flag",
+      "Use NVIDIA MIG (Multi-Instance GPU) to partition GPUs for different teams"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "During the installation of Baseboard Management Controller (BMC) software on an NVIDIA DGX server, you want to ensure secure access to the BMC interface. Which of the following is the best practice to configure secure access after installation?",
+    "a": [
+      "Use a static IP address for BMC but leave the default credentials unchanged.",
+      "Enable HTTPS and upload a custom SSL certificate through the BMC interface.",
+      "Use the NVIDIA System Management Interface (nvidia-smi) to encrypt BMC communication.",
+      "Disable user authentication to streamline access for administrators."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "Your team is tasked with implementing sustainability-focused power management policies for GPU-based systems running 24/7 AI inference workloads. Which of the following approaches aligns best with both energy efficiency and maintaining high availability?",
+    "a": [
+      "Disable all non-critical system monitoring features to reduce energy consumption.",
+      "Use legacy power management tools that provide static power capping for the entire system.",
+      "Run the GPUs in a low-power mode at all times to minimize energy usage.",
+      "Leverage NVIDIA Data Center GPU Manager (DCGM) to monitor and enforce energy-efficient power limits dynamically."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A data center running AI workloads on NVIDIA GPUs is experiencing high energy consumption. The operations team has been tasked with optimizing energy efficiency without compromising the performance of critical AI models. They are considering various monitoring and tuning strategies. Which of the following strategies is the most effective for monitoring and improving energy efficiency in an AI workload environment?",
+    "a": [
+      "Enable GPU Dynamic Voltage and Frequency Scaling (DVFS).",
+      "Disable all GPU performance modes to reduce energy usage.",
+      "Reduce the batch size of training workloads to minimize GPU usage.",
+      "Monitor GPU utilization using NVIDIA-smi and scale cluster nodes dynamically."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are administering an NVIDIA Base Command Manager (BCM) environment with multiple AI researchers. A new project requires one of the users, Emily, to have exclusive access to two NVIDIA A100 GPUs for a three-week experiment. Other users should not be able to utilize these GPUs during this time. Which action should you take to meet this requirement?",
+    "a": [
+      "Place the GPUs in a dedicated resource pool and assign the pool to Emily.",
+      "Increase Emily's priority in the scheduler to ensure GPU availability.",
+      "Assign Emily a user quota of two GPUs and enable resource preemption.",
+      "Assign Emily a higher resource priority group in BCM."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are running a Docker container with a machine learning application that writes intermediate training data to a mounted volume. During training, you notice a significant slowdown in data read/write operations. What is the most effective way to optimize the storage performance for this workload?",
+    "a": [
+      "Enable the --storage-opt size flag to increase the container's storage layer size.",
+      "Use bind mounts instead of volumes for storing intermediate data.",
+      "Run the container with the --read-only flag to prevent unnecessary writes.",
+      "Use a tmpfs mount for the container's intermediate data storage."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are provisioning a new cluster with NVIDIA Base Command Manager (BCM). During cluster setup, you notice that certain compute nodes are not reporting their GPU availability to BCM, leading to scheduling failures for GPU-intensive jobs. Which of the following actions is the most effective for resolving the issue?",
+    "a": [
+      "Restart the BCM service to reinitialize the cluster nodes.",
+      "Verify and update the CUDA version on the affected nodes to ensure compatibility with BCM.",
+      "Reprovision the affected nodes with a default template to reset their configuration.",
+      "Increase the timeout value for node discovery in the BCM configuration."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are monitoring a GPU-accelerated AI workload on a server using NVIDIA System Management Interface (nvidia-smi). The AI model is running slower than expected, and you suspect a GPU bottleneck. Which metric should you focus on to determine if the GPU is underutilized?",
+    "a": [
+      "PCIe Bandwidth Utilization (%)",
+      "Memory Usage (%)",
+      "Power Draw (Watts)",
+      "GPU Utilization (%)"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "You are deploying an AI inference application in a Kubernetes cluster with GPU nodes. The application requires a GPU to run efficiently. However, some pods are being scheduled on non-GPU nodes, causing performance degradation. The cluster has sufficient GPU nodes available. Which of the following configurations will ensure that the AI inference pods are always scheduled on GPU nodes?",
+    "a": [
+      "Use a readiness probe to ensure pods are only scheduled when GPU resources are available.",
+      "Use a nodeSelector in the pod specification to target nodes with the GPU label.",
+      "Enable Kubernetes dynamic provisioning to allocate GPU resources automatically.",
+      "Deploy all GPU nodes in a separate namespace and assign the AI inference pods to that namespace."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A company needs to leverage NVIDIA AI Workbench for an AI project that spans multiple environments, including on-premises servers, private clouds, and public cloud providers. They want to ensure seamless transitions between environments while maintaining optimal performance. Which NVIDIA AI Workbench feature addresses this need?",
+    "a": [
+      "Native integration with only a single public cloud provider",
+      "Limited to on-premises DGX systems without multi-cloud support",
+      "Kubernetes integration for orchestration across hybrid environments",
+      "Automatically deploys workflows directly to edge devices without cloud compatibility"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 2"
+  },
+  {
+    "q": "A company is deploying a real-time AI inference application using NVIDIA GPUs. The application involves processing high-throughput video streams and requires low-latency predictions. The engineer must configure the NVIDIA software stack to ensure optimal performance while maintaining resource efficiency. Which of the following strategies should the engineer prioritize to meet these requirements?",
+    "a": [
+      "Run the application in a single-threaded environment to avoid synchronization issues.",
+      "Disable cuDNN to reduce overhead during inference.",
+      "Configure CUDA streams to enable overlapping of kernel execution and memory transfers.",
+      "Utilize NVIDIA Nsight Systems for live debugging during production inference."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An organization is planning to implement an AI-driven real-time recommendation system using the NVIDIA AI platform ecosystem. They require:1. Support for streaming data processing.2. Optimization for recommendation model inferencing.3. Integration with popular data pipeline frameworks like Apache Kafka.Which NVIDIA solution best fits their requirements?",
+    "a": [
+      "NVIDIA Clara Parabricks with NVIDIA TensorRT",
+      "NVIDIA Merlin with NVIDIA Triton Inference Server",
+      "NVIDIA cuDNN library with NVIDIA Tesla T4 GPUs",
+      "NVIDIA CUDA Toolkit with NVIDIA A100 Tensor Core GPUs"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An AI inference workload running in production occasionally experiences latency spikes. Which of the following is the most likely cause, and how can it be addressed?",
+    "a": [
+      "Insufficient GPU memory causing out-of-memory (OOM) errors.",
+      "CPU-GPU data transfer overhead due to frequent small batch processing.",
+      "Improper cooling in the data center leading to thermal throttling.",
+      "Using mixed precision inference instead of full precision."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are troubleshooting a performance bottleneck in an NVIDIA DGX system running AI workloads. The storage performance has significantly degraded, and you notice high I/O wait times in system logs. Which of the following is the most likely root cause of this issue?",
+    "a": [
+      "The storage system is using SSDs instead of HDDs.",
+      "Incorrect BIOS settings are limiting the storage controller's bandwidth.",
+      "The storage system's file system is not optimized for parallel workloads.",
+      "The NVIDIA GPU driver is outdated."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing a distributed AI training system and notice that the GPUs are underutilized, leading to slower training times. Which of the following diagnostic steps is most likely to help identify the root cause of the bottleneck?",
+    "a": [
+      "Add more GPUs to the system to compensate for underutilization.",
+      "Increase the learning rate of the model to make training faster.",
+      "Adding more GPUs does not resolve underutilization caused by bottlenecks elsewhere in the system, such as I/O or network latency.",
+      "Use NVIDIA Nsight Systems to analyze data movement between the host and GPUs."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are an AI operations engineer troubleshooting a Broadcom (BCM) chipset-based InfiniBand network. A specific node is experiencing intermittent connectivity issues with fluctuating link quality and speed. Using diagnostic tools, you observe that the link speed occasionally drops from HDR (200Gbps) to FDR (56Gbps). Upon further investigation, the port counters report CRC errors and excessive packet retransmissions. What is the most likely root cause of the issue, and how should you resolve it?",
+    "a": [
+      "Incorrect cable type used for HDR speeds.",
+      "Excessive multicast traffic causing congestion.",
+      "Misconfigured flow control settings on the switch port.",
+      "Faulty transceiver module on the affected node."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with deploying an AI container from the NVIDIA NGC (NVIDIA GPU Cloud) catalog onto a Kubernetes cluster. The container needs to run an AI workload that leverages GPUs, and you want to ensure that the deployment is optimized for GPU usage. Which of the following steps is the most appropriate for this task?",
+    "a": [
+      "Build a custom container by adding GPU drivers and CUDA libraries to the image from NGC before deployment.",
+      "Deploy the container as is, assuming the GPU driver and CUDA toolkit are pre-installed on all nodes.",
+      "Deploy the container without specifying any GPU-related parameters, as Kubernetes automatically detects GPUs.",
+      "Use the NVIDIA GPU Operator to manage GPU resources and enable GPU workloads in the Kubernetes cluster before deploying the container."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are an AI Operations Administrator managing an NVIDIA AI deployment in a multi-tenant environment. To ensure that only authorized users can access specific resources, you need to configure access control policies that meet the following requirements:1. Restrict access to GPU resources based on project groups.2. Ensure compliance with the principle of least privilege.3. Enable role-based access control (RBAC) for managing permissions.Which of the following actions best meets the above requirements?",
+    "a": [
+      "Assign all users admin privileges to ensure flexibility in accessing GPU resources.",
+      "Assign GPU resources directly to individual users without grouping them by project.",
+      "Create custom roles and assign them to users based on project-specific needs.",
+      "Disable RBAC and manage access via individual user permissions."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A team is building an AI-driven recommendation system requiring fast model inference and large-scale data processing. They plan to use NVIDIA Triton Inference Server for serving machine learning models and RAPIDS for GPU-accelerated data analytics. The team discusses the advantages of integrating these tools. Which of the following benefits correctly describes the combined use of Triton Inference Server and RAPIDS for this project?",
+    "a": [
+      "Provides automatic hyperparameter tuning for machine learning models.",
+      "Supports direct deployment of TensorFlow models without conversion.",
+      "Ensures compatibility with only NVIDIA TensorRT-optimized models.",
+      "Enables GPU-accelerated data preprocessing and high-throughput model inference."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying an NGC container for training a natural language processing (NLP) model. The deployment needs to optimize GPU utilization on a single-node environment with multiple GPUs. Which configuration is required to ensure the container uses all available GPUs on the node?",
+    "a": [
+      "Configure the container to use the --gpu-count=1 option to maximize individual GPU performance.",
+      "Specify the --gpus all flag when running the container with docker run.",
+      "Set the NVIDIA_VISIBLE_DEVICES environment variable to none within the container.",
+      "Disable GPU isolation in the Kubernetes cluster for unrestricted GPU access."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization is deploying NVIDIA BlueField Data Processing Units (DPUs) in a GPU cluster used for AI model training. The goal is to enhance security without introducing significant overhead or affecting performance. Which approach best secures the GPU cluster using NVIDIA BlueField DPUs while ensuring minimal impact on AI workload performance?",
+    "a": [
+      "Run all BlueField DPU processes on the host CPU to simplify security policy management.",
+      "Configure the BlueField DPUs to handle east-west traffic encryption and access control.",
+      "Enable BlueField's zero-trust framework and enforce secure boot for all GPU nodes.",
+      "Route all AI model training data traffic through a centralized firewall outside the GPU cluster."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your NVIDIA-powered AI cluster is used for both training and inference workloads. Training jobs are GPU-intensive and long-running, while inference jobs are lightweight but latency-sensitive. What strategy should you implement to ensure both types of workloads are efficiently managed without compromising performance?",
+    "a": [
+      "Allocate a fixed number of GPUs exclusively for inference workloads.",
+      "Assign all jobs to a single queue and rely on BCM's default scheduling algorithm to optimize resource allocation.",
+      "Create separate queues for training and inference workloads with distinct resource limits.",
+      "Prioritize inference jobs over training jobs by increasing their job priority."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with designing a storage system for an AI data center that runs deep learning workloads requiring large datasets. The system must support high-throughput training, minimize latency, and ensure scalability for future growth. Which of the following storage configurations best meets these requirements?",
+    "a": [
+      "Network-attached storage (NAS) with spinning disks in RAID 1 configuration.",
+      "A distributed parallel file system with NVMe SSDs and high-speed interconnects.",
+      "Single-tier storage using SSDs for all workloads, regardless of data access frequency.",
+      "Direct-attached storage (DAS) with HDDs on each compute node."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are responsible for designing a storage solution for a new AI data center that will process large-scale machine learning (ML) workloads. The workloads involve training models on high-resolution video datasets, requiring high-speed data access, scalability, and data integrity. Which storage architecture would be the most suitable for these requirements?",
+    "a": [
+      "Direct Attached Storage (DAS) with a single-node architecture",
+      "Network Attached Storage (NAS) with HDDs",
+      "Distributed File System (DFS) optimized for parallel processing",
+      "Object Storage with SSDs and high IOPS capabilities"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with configuring a data center to support high-density AI workloads, including clusters with multiple GPUs. Which of the following approaches to power and cooling are correct? (Choose two)",
+    "a": [
+      "Deploy air-cooled racks with traditional cooling systems to minimize costs.",
+      "Design the cooling system to maintain a consistent temperature of 30°C across all racks.",
+      "Design power distribution to provide redundant paths to all critical components.",
+      "Use liquid cooling for high-density GPU racks to manage heat more effectively.",
+      "Plan for a single power source to simplify power management in the data center."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization uses Run:AI to manage GPU resources for machine learning workloads. A user reports that their job remains in the \"Pending\" state even though some GPUs are idle. After investigating, you discover the idle GPUs belong to another project with a configured quota. What should you do to enable the job to use those idle GPUs?",
+    "a": [
+      "Enable Elastic Quotas for both projects in the Run:AI User Interface.",
+      "Disable quotas entirely in the Run:AI configuration to ensure all GPUs are shared.",
+      "Increase the quota of the user's project in the runai-config.yaml file.",
+      "Use the kubectl scale command to increase the replicas of the user's job."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An NVIDIA A30 GPU has been configured with MIG to run multiple AI inference tasks. However, one of the instances is experiencing degraded performance. Upon investigation, you find that other workloads are unaffected. Which of the following steps is most likely to resolve the issue?",
+    "a": [
+      "Adjust the MIG instance profile size for the affected workload.",
+      "Disable MIG on the GPU to allow unrestricted resource sharing.",
+      "Increase the number of MIG instances on the affected GPU.",
+      "Assign the workload to a different instance without changing its profile size."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with deploying a Kubernetes cluster on NVIDIA hosts using Bright Cluster Manager (BCM) for AI workloads. Which of the following steps is essential to ensure the successful initialization of the Kubernetes cluster and its readiness for GPU workloads?",
+    "a": [
+      "Directly install NVIDIA GPU drivers on all nodes after initializing the Kubernetes cluster.",
+      "Enable the Bright Cluster Manager (BCM) Kubernetes module and configure node templates for GPU nodes.",
+      "Skip the GPU node configuration step, as Kubernetes automatically detects GPUs with BCM.",
+      "Deploy the NVIDIA GPU Operator as the first step before Kubernetes initialization."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You have configured MIG on an NVIDIA A100 GPU to support an AI workload requiring both training and inference on separate GPU instances. After deploying the workload, you observe performance degradation during inference. What is the most likely cause and resolution?",
+    "a": [
+      "The inference workload is attempting to access resources outside its allocated MIG instance; enable resource sharing between instances.",
+      "The MIG instance allocated for inference has insufficient GPU memory; resize the instance with a larger profile.",
+      "MIG instances are not designed for real-time inference; migrate the workload to a separate GPU.",
+      "MIG is incompatible with concurrent training and inference workloads; disable MIG mode."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "During a diagnostic test for an HPC workload utilizing NVIDIA Magnum IO, you observe that communication between GPUs in separate nodes is experiencing high latency. What is the most probable root cause, and how should you address it?",
+    "a": [
+      "Ensure that GPUDirect RDMA is enabled and functioning correctly between the nodes.",
+      "Disable NVLink communication to force data transfer through the PCIe bus for testing purposes.",
+      "Replace all Ethernet cables to rule out connectivity issues.",
+      "Increase the number of threads allocated to the CPU to manage communication paths more efficiently."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An organization plans to train deep learning models that require extensive GPU resources and involve frequent updates to their large dataset. Budget constraints demand minimal upfront investment. Which option is the most suitable for their infrastructure?",
+    "a": [
+      "Leverage a public cloud platform offering GPU instances on-demand.",
+      "Deploy all resources on a private on-premises data center with dedicated GPU clusters.",
+      "Use edge devices with accelerated computing capabilities for training.",
+      "Adopt a hybrid setup with data stored on-premises and training performed in the cloud."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An organization plans to deploy an AI inference application on a Kubernetes cluster with NVIDIA GPUs. The operations team must ensure the application utilizes GPUs efficiently. What is the first step in configuring the cluster for GPU-based workloads?",
+    "a": [
+      "Install the NVIDIA Container Toolkit on all nodes with GPUs.",
+      "Update the Kubernetes scheduler to prioritize GPU-based nodes.",
+      "Install the CUDA Toolkit on all nodes in the cluster.",
+      "Deploy the NVIDIA Device Plugin for Kubernetes on GPU nodes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing a multi-node AI training cluster running on NVIDIA GPUs. You need to monitor GPU utilization to ensure that the resources are being optimally used and identify potential bottlenecks such as memory underutilization or compute saturation. The solution must integrate with existing monitoring tools and provide real-time insights. Which approach best enables monitoring GPU utilization for this AI workload?",
+    "a": [
+      "Deploy NVIDIA cuDNN to monitor GPU utilization directly.",
+      "Use NVIDIA DCGM (Data Center GPU Manager) to collect GPU utilization metrics and integrate them with Prometheus and Grafana for visualization.",
+      "Use NVIDIA TensorRT to monitor GPU utilization during training.",
+      "Leverage Kubernetes Metrics Server to capture detailed GPU-specific metrics."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A financial services company is using TensorRT to optimize a deep learning model for fraud detection. Which feature of TensorRT can be most effectively utilized to reduce inference time while maintaining model accuracy?",
+    "a": [
+      "Replacing TensorRT with CUDA directly for better GPU optimization.",
+      "Implementing TensorRT's built-in overclocking tools to accelerate inference.",
+      "Precision calibration for INT8 inference with minimal accuracy loss.",
+      "Manual kernel optimization to handle fraud detection-specific computations."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying a PyTorch container from NGC for a multi-GPU training task on a Kubernetes cluster. The application requires access to all available GPUs on a single node. During deployment, the training job uses only one GPU despite the node having multiple GPUs available. Which configuration step is necessary to ensure the container uses all GPUs?",
+    "a": [
+      "Configure the --gpus all flag in the container's command-line arguments within the deployment YAML.",
+      "Set the limits and requests for GPUs to the total number of GPUs on the node in the pod specification.",
+      "Use the nvidia-docker runtime in the pod specification to explicitly allow access to multiple GPUs.",
+      "Add the NVIDIA_DRIVER_CAPABILITIES=all environment variable to the container."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with setting up a Kubernetes cluster on NVIDIA hosts using Bright Cluster Manager (BCM). After configuring the cluster head node, which of the following steps is correct to ensure the worker nodes are ready for Kubernetes workloads?",
+    "a": [
+      "Deploy the Kubernetes dashboard and initialize kubectl on all worker nodes.",
+      "Install the NVIDIA GPU drivers and CUDA toolkit on the head node only, as the head node manages GPU access for the cluster.",
+      "Use the BCM command cm-kubernetes to deploy Kubernetes on worker nodes, ensuring the appropriate roles and labels are assigned.",
+      "Skip GPU driver installation on worker nodes as BCM automatically provisions the required drivers during deployment."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A deep learning training workload running on your cluster with NVIDIA GPUs and InfiniBand networking is experiencing degraded performance. The network congestion seems to occur during the AllReduce operation used by distributed training frameworks like NCCL. Which troubleshooting step is most effective in resolving the observed network congestion?",
+    "a": [
+      "Use Quality of Service (QoS) settings to prioritize AllReduce traffic over other cluster communications.",
+      "Upgrade the network firmware to the latest version to resolve congestion.",
+      "Reduce the message size for AllReduce operations to minimize network utilization.",
+      "Enable jumbo frames in the Ethernet network to improve throughput."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are a data center administrator troubleshooting performance issues in an HPC cluster using NVIDIA Magnum IO GPUDirect RDMA over InfiniBand. The application performance has degraded significantly, and you suspect a problem with the InfiniBand link. You use the ibstat and ibdiagnet tools to diagnose the issue. The ibstat output shows that the link width is at 2x instead of 4x, and ibdiagnet reports excessive symbol errors on one of the ports. What is the most likely root cause of the issue, and how should you resolve it?",
+    "a": [
+      "Outdated firmware on the InfiniBand adapter.",
+      "A misconfigured subnet manager priority.",
+      "A faulty cable connecting the InfiniBand ports.",
+      "Incorrect queue pair (QP) configuration in the application."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying a container from NGC on a system where multiple users share the same GPU resources. To ensure fair usage and prevent one container from monopolizing GPU resources, which of the following is the best practice during deployment?",
+    "a": [
+      "Use the --gpus flag with specific device IDs to allocate GPUs to the container.",
+      "Set the --memory flag in the docker run command to limit GPU memory usage.",
+      "Deploy the container without restrictions and use nvidia-smi to monitor GPU usage manually.",
+      "Modify the container runtime to limit GPU access for each user."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An organization is designing a new data center to support high-performance AI workloads. The data center will house GPUs optimized for training large-scale deep learning models. Which of the following design considerations is most critical for ensuring reliable and efficient operation of AI workloads in this context?",
+    "a": [
+      "Utilize air-cooled servers with standard 1U rack spacing.",
+      "Focus on designing modular server racks to simplify future hardware upgrades.",
+      "Increase the redundancy of network switches to handle traffic spikes in AI model training.",
+      "Deploy direct liquid cooling systems to manage the heat generated by high-density GPUs."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are designing a data center for AI workloads with a focus on high-performance computing (HPC). Which of the following statements about the network design is correct? (Choose two)",
+    "a": [
+      "Rely on traditional TCP/IP Ethernet for all communication within the data center.",
+      "Use a flat network topology to minimize latency for AI model training.",
+      "Use a ring topology to ensure equal bandwidth distribution for all nodes.",
+      "Implement InfiniBand for interconnects to support high-throughput and low-latency communication.",
+      "Separate AI training workloads from storage traffic using dedicated network links."
+    ],
+    "c": [
+      3,
+      4
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "You are troubleshooting a model deployment on an NVIDIA GPU server. The model exhibits irregular performance with fluctuating inference times. Using nvidia-smi, you notice no significant GPU utilization drops. Which tool or feature should you use next to diagnose potential memory issues on the GPU?",
+    "a": [
+      "Run TensorRT profiler",
+      "nvidia-smi dmon",
+      "Monitor GPU temperature using nvidia-smi",
+      "Enable ECC Memory Check using nvidia-smi"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A team submits multiple GPU-intensive training jobs to an NVIDIA cluster managed by Base Command Manager (BCM). Despite sufficient GPUs being available, some jobs remain in the queue for extended periods. Upon investigation, you find that the jobs have strict resource requirements. How can you optimize the scheduling process to improve resource utilization and reduce queuing time?",
+    "a": [
+      "Enable job preemption in BCM to allow high-priority jobs to replace low-priority jobs.",
+      "Modify job submission parameters to use a wider range of compatible GPUs.",
+      "Adjust the resource allocation policies to allow overcommitment of GPUs.",
+      "Use workload partitioning to allocate specific GPUs to high-priority jobs only."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A Broadcom BCM Ethernet switch in your AI operations cluster is experiencing poor throughput when handling mixed workloads, including distributed training and inference. You suspect suboptimal switch configurations are causing the issue. Which of the following adjustments is most likely to optimize the switch's performance for AI workloads?",
+    "a": [
+      "Reduce MTU size to 900 bytes to improve handling of small packets.",
+      "Disable jumbo frames to prevent packet fragmentation.",
+      "Increase the buffer size for all ports to the maximum supported by the switch.",
+      "Configure DSCP-based Quality of Service (QoS) to prioritize AI traffic."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing an NVIDIA DGX cluster running Magnum IO for optimized multi-GPU and multi-node communication. During a training job, you notice suboptimal performance and frequent communication stalls between nodes. Logs indicate errors in NCCL (NVIDIA Collective Communication Library) communication. What is the most likely cause, and how can it be resolved?",
+    "a": [
+      "Outdated version of NCCL that is incompatible with Magnum IO.",
+      "Network congestion on the InfiniBand fabric used by Magnum IO.",
+      "Incorrect network interface configuration in the Magnum IO configuration file.",
+      "Insufficient GPU memory allocation for NCCL operations."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with deploying NVIDIA DOCA services on a Data Processing Unit (DPU) with an ARM-based architecture in a high-performance computing (HPC) environment. What is the correct sequence of steps to ensure a successful installation and deployment?",
+    "a": [
+      "Use a containerized image of the DOCA services directly on the host CPU without requiring DPU-specific configurations.",
+      "Install the DOCA SDK on the DPU, configure the necessary ARM libraries, validate the hardware dependencies, and then deploy the DOCA services.",
+      "Install the DOCA SDK on the host server, configure the necessary drivers on the host server, and directly deploy services on the host server instead of the DPU.",
+      "Deploy the DOCA services on a virtual machine running on the host server, without interacting directly with the DPU hardware."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A team is optimizing an inference pipeline for a deep learning model running on a single GPU. Despite sufficient GPU memory and compute resources, the inference latency is higher than expected. Which of the following optimizations is most likely to reduce inference latency?",
+    "a": [
+      "Increasing the learning rate of the model during inference.",
+      "Increasing the batch size to process more requests simultaneously.",
+      "Deploying the model on a different GPU with higher memory.",
+      "Reducing the precision of the model weights to FP16."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "While deploying an AI workload on an NVIDIA DGX cluster, you encounter an error stating that the GPU resources are not detected on the worker nodes. After inspecting the setup, you suspect a misconfiguration during deployment. Which of the following steps is most likely to resolve this issue?",
+    "a": [
+      "Ensure that the correct GPU driver version is installed and compatible with the kernel.",
+      "Enable the kubelet's GPU feature gate.",
+      "Reinstall Kubernetes on the cluster nodes.",
+      "Increase the CPU and memory allocation for the Kubernetes scheduler."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with configuring MIG on a NVIDIA A100 GPU to run multiple high-performance computing (HPC) workloads. Each workload requires high compute power but uses only moderate GPU memory. Additionally, the system should support dynamic allocation for new tasks during runtime without disrupting ongoing workloads. Which of the following configurations is the most suitable?",
+    "a": [
+      "Create a single MIG instance with 7g.40gb to ensure maximum compute power for a single workload.",
+      "Configure four MIG instances with 2g.10gb and reserve one slot for dynamic task allocation.",
+      "Configure seven MIG instances with 1g.5gb each to maximize concurrency.",
+      "Disable MIG and use the full GPU for a single HPC workload to maximize performance."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing a Run:ai environment for an AI research team that requires dynamic allocation of GPU resources for training and inference tasks. Which of the following configurations best enables efficient GPU resource sharing while ensuring priority for critical inference workloads?",
+    "a": [
+      "Assign all available GPUs to a single shared resource pool with no prioritization.",
+      "Disable quotas and allow all workloads to compete for GPU resources without restrictions.",
+      "Create two separate resource pools: one for training and one for inference, with inference workloads assigned higher priority.",
+      "Enable automatic overprovisioning for training jobs to use all GPUs whenever idle."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your AI cluster is underperforming in terms of resource utilization, with some GPUs running at 20% utilization during workload execution. What is the most effective optimization strategy to improve GPU utilization?",
+    "a": [
+      "Increase the learning rate of the AI model to reduce training time.",
+      "Ensure the batch size is optimized to fully utilize GPU memory.",
+      "Configure the cluster to use CPU-only nodes for data preprocessing.",
+      "Deploy additional compute nodes to balance the workload."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are an AI operations engineer tasked with maintaining a high-performance cluster that uses NVIDIA InfiniBand for inter-node communication. Recently, you noticed a drop in performance during distributed training jobs, leading to increased training times. You suspect a network bottleneck and must identify its cause. Which approach is most effective for identifying a network bottleneck in an InfiniBand-based high-performance cluster?",
+    "a": [
+      "Use NVIDIA Nsight Systems to analyze application-level bottlenecks instead of network issues.",
+      "Analyze the counters provided by the InfiniBand Subnet Manager for excessive packet retransmissions.",
+      "Use iperf to measure point-to-point bandwidth between all cluster nodes.",
+      "Enable deep packet inspection (DPI) across all network flows to identify data transfer anomalies."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A team is deploying a deep learning model for real-time inference in an AI-driven healthcare system. They need to optimize the model for low latency and high throughput on NVIDIA GPUs. Which of the following steps should they take to use NVIDIA TensorRT for inference acceleration?",
+    "a": [
+      "Retrain the model using TensorRT-specific optimization algorithms.",
+      "Use TensorRT to directly execute the model in its original framework format.",
+      "Convert the trained model into the ONNX format and optimize it using TensorRT.",
+      "Rewrite the entire model architecture in TensorRT's proprietary programming language."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization has recently committed to achieving net-zero carbon emissions in its data center operations. As part of this initiative, you are tasked with integrating energy monitoring and performance tuning strategies for NVIDIA GPUs used in AI training workloads. Which approach best aligns with energy efficiency and sustainability goals while maintaining AI training performance?",
+    "a": [
+      "Configure the GPUs to operate in idle mode when not running AI workloads.",
+      "Deploy a single GPU model for all workloads to simplify energy monitoring.",
+      "Run all training jobs at maximum GPU power limits to reduce training time.",
+      "Use workload-aware power capping features to optimize GPU energy usage."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization has deployed a machine learning model to serve predictions for a mission-critical application. The deployment must maintain high availability and fault tolerance, even during peak loads. Which of the following approaches best achieves this objective?",
+    "a": [
+      "Use a single high-performance GPU server and enable model checkpointing for fault recovery.",
+      "Maintain a single replica of the model on each compute node to minimize resource usage.",
+      "Deploy the model using a multi-node setup with NVIDIA Triton Inference Server and Kubernetes for orchestration.",
+      "Use a cloud-based deployment without autoscaling to minimize operational complexity."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are deploying an AI training workload using a container from the NVIDIA GPU Cloud (NGC) on a multi-GPU server. After pulling the container image, you need to ensure that it has access to the GPUs and CUDA libraries on the host machine. Which of the following is the correct method to deploy the container?",
+    "a": [
+      "Run the container with the docker run command and add the --gpus all flag.",
+      "Modify the container's Dockerfile to include GPU support before deployment.",
+      "Use the docker run command without any additional flags to let the container automatically detect GPUs.",
+      "Use nvidia-smi to pre-allocate GPU resources before running the container."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing a multi-GPU AI workload distributed across a DGX cluster. To improve GPU utilization and performance across compute nodes, you decide to enable Multi-Process Service (MPS). What is the primary benefit of enabling MPS in this context?",
+    "a": [
+      "It replaces the need for a workload scheduler in distributed training",
+      "It enables multiple GPU kernels to run concurrently from the same process",
+      "It ensures exclusive access to a GPU by one process at a time",
+      "It allows GPU memory to be shared across multiple nodes in the cluster"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An AI operations engineer is tasked with optimizing the training of a deep learning model on NVIDIA GPUs. The model has a high level of computational complexity and is memory-intensive. The engineer must leverage the NVIDIA GPU architecture and software stack to maximize throughput while minimizing latency. Which of the following approaches would be the most effective for this scenario?",
+    "a": [
+      "Enable Tensor Cores and use mixed-precision training with AMP (Automatic Mixed Precision).",
+      "Partition the GPU into multiple virtual instances to train different parts of the model simultaneously.",
+      "Use the CPU for matrix multiplications and the GPU for activation functions.",
+      "Use FP64 precision for training to maximize numerical stability."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are provisioning a new NVIDIA cluster in Base Command Manager (BCM) for training deep learning models. The workloads require high throughput for data-intensive operations on a dataset stored in an external object storage system. Which storage configuration is most suitable to meet these requirements?",
+    "a": [
+      "Integrate a high-speed parallel file system with NVMe drives.",
+      "Configure direct-attached storage (DAS) with SSDs on each compute node.",
+      "Use network-attached storage (NAS) with 1 Gbps connectivity.",
+      "Leverage cloud-based storage with a standard internet connection."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An AI operations engineer is tasked with deploying a containerized deep learning application using NVIDIA NGC (NVIDIA GPU Cloud) containers. The target environment is a Kubernetes cluster with GPU-enabled nodes. Which of the following steps is crucial for ensuring the successful deployment of an NGC container?",
+    "a": [
+      "Pull the NGC container image directly from the NVIDIA GPU Cloud to each worker node manually.",
+      "Use a pre-built Helm chart for deploying non-GPU workloads as a template for GPU container deployment.",
+      "Ensure that the NVIDIA Container Toolkit is installed on all GPU-enabled nodes.",
+      "Use docker-compose to orchestrate the deployment of the NGC container across the Kubernetes cluster."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "As the administrator of a cluster using Run:AI, you need to configure resource quotas for different departments to ensure fair usage of the GPU resources. Each department should have a maximum limit on GPU usage, and any unused GPUs should be available for other departments. Which of the following steps should you follow to achieve this?",
+    "a": [
+      "Configure resource quotas in the Run:AI User Interface (UI) under the \"Projects\" tab and set limits for each project.",
+      "Use Kubernetes Pod Priority Classes to ensure that specific departments get GPU resources first.",
+      "Define quotas in the Run:AI Command-Line Interface (CLI) using the runai create project command with the --quota flag.",
+      "Use the kubectl apply command to define resource quotas directly in the Kubernetes namespace."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A company wants to deploy a scalable and efficient AI infrastructure using the NVIDIA AI platform ecosystem. Their primary goals are:1. Supporting large-scale training workloads.2. Minimizing latency during inference.3. Ensuring seamless integration with Kubernetes for containerized AI workflows.Which solution should they choose to meet these requirements?",
+    "a": [
+      "NVIDIA Jetson Nano with NVIDIA TensorRT",
+      "NVIDIA GRID Virtual GPU for virtual desktop environments",
+      "NVIDIA A40 GPUs with RAPIDS AI",
+      "NVIDIA DGX SuperPOD combined with NVIDIA Triton Inference Server"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are managing a containerized AI training pipeline that processes data stored on a shared NFS-mounted volume. Training times have increased significantly, and I/O bottlenecks are identified as the main issue. What is the best solution to improve storage performance in this scenario?",
+    "a": [
+      "Configure Docker to use the overlay2 storage driver for the container's writable layer.",
+      "Enable NFS compression to reduce the size of data transferred over the network.",
+      "Increase the Docker container's CPU and memory allocation to speed up processing.",
+      "Migrate the dataset from the NFS-mounted volume to a local SSD on the host."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization operates a multi-GPU AI environment powered by NVIDIA. You are tasked with implementing a centralized logging system to meet compliance requirements. Which configuration approach best aligns with regulatory best practices?",
+    "a": [
+      "Set log transmission to occur once a day in bulk to minimize network traffic and storage costs.",
+      "Configure each node to log events independently without transmitting them to a central system to reduce latency.",
+      "Use a centralized logging system that collects logs from all nodes in real-time and encrypts them during transit and at rest.",
+      "Enable logging only for high-performance GPU nodes while excluding logging for CPU-only nodes to save storage."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are tasked with designing an AI-based video analytics pipeline for real-time object detection and tracking. The solution must integrate with NVIDIA DeepStream SDK to efficiently handle the incoming video stream, perform AI inference, and manage data output. Which component in DeepStream SDK is responsible for efficiently decoding video streams into frames that can be processed by the AI models?",
+    "a": [
+      "nvdec",
+      "nvstreammux",
+      "nvvideoconvert",
+      "nvinfer"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are configuring NVIDIA Multi-Instance GPU (MIG) on an NVIDIA A100 GPU for a high-performance computing (HPC) workload. The workload requires running multiple small-scale simulations concurrently while maintaining GPU resource isolation. Which of the following steps is essential to achieve this configuration?",
+    "a": [
+      "Enable MIG mode on the GPU and create multiple instances with the appropriate profiles for the workload.",
+      "Disable MIG mode to use the full GPU for all concurrent simulations.",
+      "Allocate all available GPU memory to a single instance to maximize performance.",
+      "Configure the GPU to operate in exclusive mode and allow only a single instance to use the GPU at a time."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "During the installation of Kubernetes on NVIDIA hosts using Bright Cluster Manager (BCM), the administrator encounters issues where the nodes fail to join the Kubernetes cluster. Which of the following steps is most likely to resolve the issue?",
+    "a": [
+      "Increase the node's swap space to accommodate Kubernetes control plane operations.",
+      "Reinstall BCM with the default configuration and retry the Kubernetes deployment.",
+      "Verify that the kubelet service is running on all nodes and is correctly configured.",
+      "Configure a separate VLAN for GPU traffic to ensure proper network isolation."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "You are an administrator managing a cluster with Run:AI integrated into NVIDIA AI infrastructure. Researchers are reporting delays in job execution despite available resources. Upon investigation, you find that resource fragmentation and priority mismanagement are causing inefficient scheduling. You must configure Run:AI to ensure efficient resource allocation and prioritize jobs based on organizational needs. Which of the following steps is the best approach to improve resource utilization and job prioritization in a Run:AI-managed cluster?",
+    "a": [
+      "Configure Fair Share Scheduling with static priority values for all jobs.",
+      "Use the Guaranteed Queue for all submitted jobs to ensure immediate execution.",
+      "Enable Elastic Resource Allocation to dynamically adjust resource limits for running jobs.",
+      "Increase the number of GPUs allocated per job to ensure high throughput."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "An AI data center must support a wide range of workloads, including real-time inference and periodic training of models. The center must optimize its storage solution to balance cost, performance, and scalability. Which two strategies should the center implement? (Choose two)",
+    "a": [
+      "Adopt hybrid storage solutions with SSDs for hot data and HDDs for cold data",
+      "Deploy a unified storage solution using a single-tier architecture",
+      "Utilize storage-class memory (SCM) for caching frequently accessed data",
+      "Implement erasure coding to reduce storage overhead",
+      "Rely exclusively on block storage for all workloads"
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "set": "Set 3"
+  },
+  {
+    "q": "Your organization is implementing NVIDIA AI Enterprise Suite for its AI workloads, aiming to leverage its capabilities to streamline machine learning pipelines, enhance infrastructure optimization, and ensure enterprise-level support. During a team discussion, your colleague asks which specific feature of NVIDIA AI Enterprise Suite ensures streamlined deployment and management of AI workflows. Which of the following features of NVIDIA AI Enterprise Suite ensures streamlined deployment and management of AI workflows?",
+    "a": [
+      "Support for Real-Time Video Analytics",
+      "Advanced GPU Overclocking",
+      "NVIDIA CUDA Toolkit Exclusivity",
+      "Optimized Kubernetes Integration"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 3"
+  },
+  {
+    "q": "A data science team reports that their Slurm jobs are queued for extended periods, even though the cluster has idle nodes. Upon investigation, you discover the jobs request specific GPUs that are available. Which of the following actions should you take to resolve the issue and ensure efficient resource utilization?",
+    "a": [
+      "Adjust the SelectType parameter in slurm.conf to prioritize CPU scheduling over GPU scheduling.",
+      "Check and update the GRES configuration in the slurm.conf file to correctly define GPU resources.",
+      "Enable backfill scheduling by modifying the SchedulerType in slurm.conf.",
+      "Use the scontrol command to manually reassign jobs to different nodes."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A team is preparing an AI training environment on an NVIDIA GPU server running Linux. They need to install the latest drivers and ensure compatibility with TensorFlow 2.x. Which step is critical during the driver installation process to avoid compatibility issues?",
+    "a": [
+      "Check the version of TensorFlow and install drivers from the TensorFlow compatibility matrix.",
+      "Update the Linux kernel to the latest version before installing drivers.",
+      "Always install the latest available NVIDIA drivers from the NVIDIA website.",
+      "Install the driver in a virtual environment to isolate dependencies."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An AI workload on your cluster is experiencing I/O bottlenecks while reading large datasets stored on a high-performance parallel file system. The cluster uses NVIDIA Magnum IO GPUDirect Storage for accelerated data transfer. Upon investigation, you find that the file read throughput is significantly lower than expected, and GPU utilization is minimal. What is the most likely root cause, and how can you fix the issue?",
+    "a": [
+      "A faulty GPU PCIe connection is causing reduced bandwidth.",
+      "The GPU drivers are incompatible with GPUDirect Storage.",
+      "The NVMe drives in the storage system are underperforming due to thermal throttling.",
+      "Insufficient buffer size configuration in the GPUDirect Storage driver."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with deploying a new cluster of GPU nodes to support AI workloads. During installation, you need to ensure that the GPU drivers and CUDA toolkit are compatible with both the operating system and the deep learning frameworks used. Which of the following steps is the best approach to ensure compatibility?",
+    "a": [
+      "Skip installing the CUDA toolkit, as it is not necessary for deep learning workloads.",
+      "Install the latest GPU drivers and CUDA toolkit from NVIDIA's website.",
+      "Use the GPU driver and CUDA versions recommended by the target deep learning framework.",
+      "Install the default GPU drivers and CUDA toolkit available in the operating system's package manager."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are managing an NVIDIA AI cluster where you need to deploy multiple AI containers from NGC to perform various tasks. To ensure compatibility and smooth deployment, which of the following best practices should you follow?",
+    "a": [
+      "Verify the container compatibility with the host GPU driver version.",
+      "Pull and deploy the container on every compute node separately.",
+      "Disable the container runtime security settings for better performance.",
+      "Always use the latest version of the container regardless of the workload."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A startup is planning to deploy a generative AI model for text generation. The model requires high parallelism for matrix computations and efficient memory handling to process large datasets. The team is considering hardware options. Which of the following configurations is most suitable for this workload?",
+    "a": [
+      "A server with NVIDIA T4 GPUs and standard Ethernet networking",
+      "High-performance CPUs with multiple cores but no GPU acceleration",
+      "NVIDIA A100 Tensor Core GPUs paired with NVLink technology",
+      "NVIDIA DGX systems with integrated NVIDIA BlueField DPUs for data management"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A company is designing its data center architecture to optimize performance for distributed AI model training workloads. The architecture must handle large amounts of data transfer between GPUs across multiple nodes. Which networking approach would best support this requirement?",
+    "a": [
+      "Implement software-defined networking (SDN) to manage data flow between nodes dynamically.",
+      "Use a high-bandwidth, low-latency fabric such as InfiniBand.",
+      "Prioritize adding multiple NICs (Network Interface Cards) to each server without upgrading the network backbone.",
+      "Deploy 1 Gbps Ethernet connections between nodes for low latency."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are managing an NVIDIA-powered AI cluster, and a GPU-intensive training job fails repeatedly with the error message, \"Insufficient GPU memory available.\" Which system management tool and troubleshooting step should you use to diagnose the issue?",
+    "a": [
+      "Use a CPU profiling tool like htop to analyze CPU load during the job execution.",
+      "Use BCM's job logs to reallocate more GPUs to the job automatically.",
+      "Use nvidia-smi to monitor GPU utilization and identify memory-hogging processes.",
+      "Use a network monitoring tool like iftop to check for bottlenecks in data transfer."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A company is training a large-scale language model on NVIDIA GPUs and notices a significant slowdown in training speed as the dataset size increases. Which approach should they take to diagnose and resolve the bottleneck?",
+    "a": [
+      "Monitor GPU utilization and check for low utilization during training.",
+      "Increase the batch size to utilize more GPU memory, irrespective of GPU capacity.",
+      "Replace the current data loader with a generic data loader implementation.",
+      "Optimize the neural network layers using TensorRT during training."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with configuring Run:ai for a team working on multiple concurrent AI experiments. Each experiment requires access to a specific number of GPUs, but GPU resources should also be dynamically shared to maximize utilization. Which two configurations should you implement? (Choose two)",
+    "a": [
+      "Configure Run:ai's Job Scheduling Policies to enforce fair resource sharing.",
+      "Set up Run:ai's fractional GPU feature to allow sharing GPUs across jobs.",
+      "Use Run:ai's GPU Pooling to aggregate resources for shared access.",
+      "Define GPU quotas in Kubernetes ConfigMaps to limit GPU usage per experiment.",
+      "Enable Kubernetes Horizontal Pod Autoscaler to manage GPU scaling for each experiment."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "An organization is deploying an AI inference solution for a recommendation system using NVIDIA Triton Inference Server. The system needs to support multiple frameworks, dynamic batching, and custom pre-processing while optimizing hardware utilization. The team is evaluating Triton's features to ensure these requirements are met. Which feature of NVIDIA Triton Inference Server best addresses these requirements?",
+    "a": [
+      "Automatic model conversion to a unified NVIDIA proprietary format.",
+      "Support for multi-model deployment with isolated hardware allocation.",
+      "Integrated real-time debugging tools for each deployed model.",
+      "Dynamic batching to optimize GPU utilization."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your team is responsible for securing a multi-tenant AI infrastructure where multiple teams run training jobs on shared GPU clusters. NVIDIA BlueField DPUs are deployed to ensure data isolation and protect workloads. Which configuration most effectively enforces tenant isolation and protects GPU workloads using NVIDIA BlueField DPUs?",
+    "a": [
+      "Disable BlueField's Secure Boot feature to simplify tenant onboarding processes.",
+      "Consolidate all tenants into a single virtual network to simplify management and monitoring.",
+      "Assign separate BlueField DPUs to each tenant to manage encryption keys and access policies independently.",
+      "Use BlueField DPUs to configure VLANs and isolate network traffic for each tenant."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "After deploying Kubernetes on NVIDIA hosts using BCM, you need to ensure that the GPUs are available for containerized workloads. Which of the following configurations is correct to expose GPUs to Kubernetes pods?",
+    "a": [
+      "Install NVIDIA Docker and CUDA on the control plane node and restart the Kubernetes scheduler.",
+      "Enable GPU support by adding the nvidia.enable-gpu=true annotation to all Kubernetes pods.",
+      "Add the --enable-gpu flag to the kubelet configuration on the head node.",
+      "Deploy the NVIDIA device plugin DaemonSet in the cluster to expose GPUs to Kubernetes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During a routine health check of your InfiniBand fabric, you identify significant packet loss between two compute nodes connected through a Broadcom switch. Using ibdiagnet, you confirm that the switch is dropping packets. The packet drop counters reveal a higher-than-normal number of Discarded Packets and Port XmitWait counters for the affected ports. What is the most effective next step to resolve the issue?",
+    "a": [
+      "Upgrade the switch's firmware to the latest Broadcom-certified version.",
+      "Rebalance the workload to reduce traffic on the congested ports.",
+      "Increase the MTU size to reduce the number of packets transmitted.",
+      "Enable adaptive routing and congestion control mechanisms on the switch."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with setting up user roles and permissions for Fleet Command in a multi-tenant environment. The organization requires the following:1. Admin users should have the ability to manage resources across all projects and tenants.2. Developers should only access resources within specific projects.3. Security auditors need read-only access to all logs and system events.Which of the following steps best achieves these goals while adhering to best practices for role-based access control (RBAC) in Fleet Command?",
+    "a": [
+      "Create a single custom role with all required permissions and assign it to all users to simplify role management.",
+      "Assign all users the default \"Admin\" role to ensure universal access and avoid configuration issues.",
+      "Create custom roles with specific permissions for each requirement and assign these roles to appropriate user groups.",
+      "Assign project-specific roles to developers but share admin credentials with security auditors to reduce role creation overhead."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are deploying NVIDIA Virtual Machine Image (VMI) containers in the cloud for an AI workload requiring GPU acceleration. The containers fail to initialize, and upon investigation, you discover that the cloud instance is not recognizing the GPU resources. What step is most critical to ensure proper GPU resource availability?",
+    "a": [
+      "Ensure the instance is created using a GPU-enabled machine type.",
+      "Install the NVIDIA Container Toolkit inside the container.",
+      "Deploy the containers using a standard machine type with GPU drivers installed.",
+      "Configure Kubernetes node taints to prioritize GPU scheduling."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A machine learning team needs to deploy a TensorFlow-based container from the NVIDIA NGC catalog on their Kubernetes cluster to utilize GPU acceleration for their training workloads. Which two steps are essential to ensure the deployment runs successfully with GPU support? (Choose two)",
+    "a": [
+      "Configure the Kubernetes device plugin for NVIDIA GPUs on each cluster node.",
+      "Use kubectl apply to deploy the TensorFlow container YAML manifest without any modifications.",
+      "Label the Kubernetes nodes with nvidia.com/gpu=true to schedule GPU-based pods.",
+      "Install the NVIDIA Container Toolkit on each node in the Kubernetes cluster.",
+      "Use the --cpu-only flag when deploying the TensorFlow container to enable CPU fallback if GPUs are unavailable."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with configuring a high-availability architecture for an AI workload running on a cluster of NVIDIA GPUs. The workload requires real-time inference with minimal downtime, even in the event of a hardware failure. Which of the following configurations best ensures high availability?",
+    "a": [
+      "Deploy a GPU-based inference workload with asynchronous checkpointing enabled on a single node.",
+      "Deploy the workload on a single GPU node with a backup replica on the same node.",
+      "Distribute the workload across multiple GPU nodes in an active-active configuration with a load balancer.",
+      "Use NVIDIA MIG (Multi-Instance GPU) to partition a single GPU into multiple instances for redundancy."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your team is setting up a cluster for distributed training of deep learning models and wants to use NVIDIA Spectrum switches to enhance networking performance. Which of the following best describes a feature of NVIDIA Spectrum switches that is critical for AI operations?",
+    "a": [
+      "Spectrum switches optimize packet flow using static routing tables for all data paths.",
+      "Spectrum switches support only traditional Ethernet and do not integrate with InfiniBand networks.",
+      "Spectrum switches prioritize low-cost network solutions over performance, making them unsuitable for AI workloads.",
+      "Spectrum switches provide adaptive routing and congestion management, minimizing network bottlenecks in large-scale AI clusters."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your AI inference application occasionally experiences performance degradation, and you suspect that GPU memory is a bottleneck. You need to continuously monitor memory utilization to identify trends and diagnose the issue. The monitoring solution must provide historical data and alerting capabilities. Which solution best supports diagnosing GPU memory bottlenecks in this scenario?",
+    "a": [
+      "Run periodic benchmarks using NVIDIA TensorRT to identify memory bottlenecks.",
+      "Use NVIDIA DCGM in combination with a time-series database like InfluxDB for storing and analyzing GPU memory metrics.",
+      "Leverage NVIDIA CUDA Toolkit to monitor memory utilization in real time.",
+      "Install NVIDIA Nsight Systems to continuously track GPU memory usage."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your deployed AI inference pipeline is experiencing higher-than-expected latency during real-time predictions. Which of the following actions is most likely to help identify the issue?",
+    "a": [
+      "Enable logging of request latencies and analyze NVIDIA Triton Inference Server metrics.",
+      "Disable dynamic batching in NVIDIA Triton Inference Server to improve request throughput.",
+      "Profile the model's architecture to identify and remove layers with high computational cost.",
+      "Use NVIDIA TensorRT to compress the model and reduce memory usage."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are an AI Operations Administrator responsible for managing an NVIDIA AI cluster. The organization has reported irregularities in the resource allocation and utilization across multiple nodes in the cluster. To address this, you must ensure proper resource governance using NVIDIA's AI Enterprise tools and best practices. Which of the following is the best approach to implement resource governance in an NVIDIA AI cluster to ensure efficient utilization and avoid resource contention?",
+    "a": [
+      "Use NVIDIA vGPU profiles to allocate resources and limit utilization for specific workloads.",
+      "Utilize NVIDIA GPU Operator to integrate GPU monitoring and enable resource allocation policies.",
+      "Disable GPU exclusivity, allowing multiple processes to share the same GPU for flexibility.",
+      "Increase the priority of all jobs to prevent delays in resource allocation."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A research team is using NVIDIA Base Command to manage a DGX SuperPOD for large-scale AI training. They are experiencing bottlenecks when uploading datasets to the system, slowing down job execution. Which feature of NVIDIA Base Command can help address this issue?",
+    "a": [
+      "Integrated data management with NVIDIA Base Command Storage",
+      "Dependency management for Python libraries",
+      "GPU-exclusive caching to accelerate data uploads",
+      "Manual data replication to each DGX system in the cluster"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are administering a Fleet Command deployment for a global enterprise. The organization has multiple edge clusters in different regions, each with unique workloads and latency requirements. The IT team has decided to implement Fleet Command to centrally manage these clusters. Which of the following steps is most critical to ensure effective multi-cluster management in Fleet Command?",
+    "a": [
+      "Disable automatic updates to maintain control over version changes.",
+      "Install the same Kubernetes version across all clusters to maintain compatibility.",
+      "Register all edge clusters with unique identifiers in the Fleet Command console.",
+      "Ensure that each cluster is configured with identical hardware specifications for uniformity."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An AI operations team is setting up a storage solution for a data center handling both training and inference workloads. The team must ensure low latency for inference, high throughput for training, and durability for long-term data storage. What is the most effective combination of storage media and architecture?",
+    "a": [
+      "HDD-based object storage for training and inference workloads",
+      "Block storage with HDDs for active data and SSDs for cache",
+      "Hybrid architecture: SSDs for active data, object storage for archival",
+      "SSD-based NAS for inference, HDD-based tape storage for training"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During the deployment of a machine learning inference service, a Docker container fails to start. Upon inspecting the logs, you see the error message:\"OCI runtime create failed: container_linux.go:380: starting container process caused: exec: '/bin/bash': no such file or directory.\"What is the most likely cause of this issue, and how should it be resolved?",
+    "a": [
+      "The Dockerfile used to build the image is missing the RUN instruction to install dependencies.",
+      "The host machine's Docker Engine version is outdated and incompatible with the container runtime; upgrade the Docker Engine.",
+      "The base image used to build the Docker container does not include the /bin/bash shell; use an alternative base image with bash support or change the entry point to a compatible shell.",
+      "The container requires elevated permissions; restart Docker as a privileged user."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A company operates a Slurm cluster with a mix of GPU and CPU nodes. During a recent maintenance window, several GPU nodes were drained to apply security patches. After the updates, you must bring the drained GPU nodes back to an operational state while ensuring no pending jobs are scheduled on them until the updates are verified. What are the appropriate actions you should take to achieve this? (Choose two)",
+    "a": [
+      "Use the scontrol update command to set the node state to RESUME.",
+      "Use the scontrol update command to set the node state to MAINT.",
+      "Use the scontrol update command to set the node state to IDLE.",
+      "Restart the Slurm controller daemon to automatically refresh node states.",
+      "Submit a test job to manually verify the updated GPU nodes before setting their state to IDLE."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with configuring a Slurm cluster for a research group. Each user should be restricted to a maximum of 100 CPU cores and 1 TB of memory per job. Additionally, jobs submitted by members of the research group should have a lower priority compared to system-critical jobs. Which of the following steps would you take to achieve this configuration?",
+    "a": [
+      "Define a QoS (Quality of Service) for the research group with MaxCPUsPerJob=100 and MaxMemPerJob=1TB and assign it to their accounts.",
+      "Add a rule to the SchedulerParameters in slurm.conf to prioritize critical system jobs over all others.",
+      "Create a dedicated partition for the research group with MaxCPUsPerNode=100 and MaxMemPerNode=1TB to enforce resource restrictions.",
+      "Set the priority of the research group users to a lower value in slurm.conf using the Priority parameter."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are designing a training pipeline for a deep learning model using PyTorch on an NVIDIA GPU-enabled cluster. During training, you notice GPU utilization is inconsistent, with frequent idle periods. Initial investigation reveals the data loading process is a bottleneck. Which approach is most effective for addressing the data loading bottleneck and ensuring consistent GPU utilization during training?",
+    "a": [
+      "Use PyTorch's DataLoader with multi-threaded workers and prefetching enabled.",
+      "Use a synchronous data loading strategy to simplify the pipeline.",
+      "Reduce the number of threads used by the DataLoader to avoid contention.",
+      "Increase the batch size to maximize GPU memory utilization."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "After installing Kubernetes on NVIDIA hosts using Bright Cluster Manager (BCM), you notice that GPU workloads fail to execute. Upon investigation, you find that the GPU nodes are not recognized by the Kubernetes scheduler. Which of the following actions is most likely to resolve the issue?",
+    "a": [
+      "Reinitialize the Kubernetes cluster using kubeadm and reapply the BCM configurations.",
+      "Reinstall the NVIDIA GPU Operator on all nodes and manually restart the kubelet service.",
+      "Manually label the GPU nodes with nvidia.com/gpu to make them recognizable to the scheduler.",
+      "Reconfigure BCM to use NVIDIA-specific node templates and redeploy the Kubernetes cluster."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An AI operations team is experiencing slow performance during training jobs that require frequent reads and writes to a shared NVMe-based storage system. After initial troubleshooting, you notice high read latencies and inconsistent IOPS performance. Which of the following is the most appropriate first step to identify the root cause of the issue?",
+    "a": [
+      "Monitor storage-level metrics such as queue depth and disk utilization.",
+      "Replace the network adapters with higher bandwidth NICs.",
+      "Reconfigure the file system to use a smaller block size for better read performance.",
+      "Upgrade the NVMe drives to a higher capacity."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During the deployment of NVIDIA DOCA services on an ARM-based DPU, you encounter issues where the services fail to initialize properly. Which of the following troubleshooting steps is the most effective?",
+    "a": [
+      "Verify that the DPU firmware and drivers are updated to the versions supported by the DOCA SDK and check the compatibility of the ARM libraries.",
+      "Increase the memory allocation on the host server, as the DPU depends on the host server's memory for service initialization.",
+      "Reinstall the operating system on the host server and attempt to redeploy the services on the host CPU.",
+      "Ignore the initialization errors, as DOCA services automatically recover once workload traffic begins flowing through the DPU."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are managing a Dockerized AI workload that frequently writes intermediate results to a host-mounted volume during training. The application's throughput has decreased significantly, and profiling indicates the storage subsystem is the primary bottleneck. The storage system is a network-attached storage (NAS) solution. What is the most appropriate action to address this issue?",
+    "a": [
+      "Use a RAID 1 configuration on the NAS to improve data redundancy and performance.",
+      "Migrate the storage to a high-performance local NVMe SSD.",
+      "Optimize the NAS storage protocol by switching from NFS to SMB.",
+      "Configure the Docker container to use the tmpfs option for intermediate data storage."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During the deployment of DOCA services on a DPU Arm-based architecture, you encounter network communication issues between the host and the DPU. To resolve this, which of the following actions should you take?",
+    "a": [
+      "Verify and configure SR-IOV (Single Root I/O Virtualization) on the DPU.",
+      "Use a virtual machine (VM) on the host to emulate DPU functionality.",
+      "Disable hardware offloading features on the DPU to simplify networking.",
+      "Manually set up IP routing between the host and the DPU without using DOCA tools."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are implementing an edge AI application for anomaly detection in manufacturing using NVIDIA DeepStream SDK. The application must preprocess video streams, apply AI inference, and output results in a customizable format. What role does the nvinfer plugin play in this pipeline?",
+    "a": [
+      "It synchronizes multiple video streams into a single stream for batched processing.",
+      "It performs object tracking after inference.",
+      "It applies AI inference on video frames using a deep learning model.",
+      "It decodes compressed video streams into raw frames."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are deploying multiple cloud VMI containers to a Kubernetes cluster to handle an AI workload with high scalability requirements. During stress testing, some containers experience frequent restarts, and the logs show insufficient GPU resources on certain nodes. What is the most appropriate step to resolve this issue while maintaining high availability and performance?",
+    "a": [
+      "Upgrade the GPU hardware on all nodes to increase resource availability.",
+      "Use a CPU-based container for the deployment to avoid GPU-related issues.",
+      "Increase the number of GPU nodes in the cluster.",
+      "Configure GPU resource requests and limits in the container specifications."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your company is designing an AI infrastructure for high-performance training of a large-scale natural language processing model. To optimize data throughput and minimize latency, you decide to use NVIDIA InfiniBand technology. Which of the following statements about NVIDIA InfiniBand is correct?",
+    "a": [
+      "InfiniBand supports RDMA, which enables direct memory access between nodes without involving the CPU, thereby reducing latency.",
+      "InfiniBand is limited to a maximum data rate of 200 Gbps and cannot scale beyond that.",
+      "InfiniBand is primarily a storage-focused technology and not optimized for compute-intensive AI workloads.",
+      "InfiniBand requires specialized operating systems and cannot be integrated with mainstream Linux distributions."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are administering a Run:ai cluster integrated with Kubernetes in an AI development environment. The organization wants to ensure optimal resource utilization across projects while avoiding resource conflicts. Which two actions should you take to configure Run:ai for this requirement? (Choose two)",
+    "a": [
+      "Limit the number of jobs per user using Kubernetes Pod Security Policies (PSPs).",
+      "Set up virtual GPUs (vGPUs) for resource partitioning within Kubernetes.",
+      "Assign fixed GPU resources to each project using Kubernetes node affinity.",
+      "Use Run:ai's AutoScaler to dynamically adjust GPU allocations based on job demands.",
+      "Enable Run:ai's Workload Prioritization feature to prioritize jobs based on project needs."
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "An AI pipeline running in a Docker container frequently writes logs and intermediate data to a shared storage volume mounted using NFS. The system experiences intermittent write delays and sporadic application crashes. Profiling shows a high number of write retries and timeouts. Which action is most effective in optimizing storage performance and system stability?",
+    "a": [
+      "Increase the container's CPU and memory allocation.",
+      "Replace the shared NFS volume with an Amazon S3 bucket.",
+      "Use a higher-performance RAID configuration on the NFS server.",
+      "Enable asynchronous writes in the NFS mount options."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with setting up a distributed training job using NVIDIA's DeepOps and NGC containers. The model training involves large datasets, and you want to optimize GPU utilization and minimize communication overhead between nodes. Additionally, you need to ensure seamless scaling and efficient fault management. Which of the following strategies should you use to optimize your distributed training job?",
+    "a": [
+      "Disable automatic scaling to maintain resource predictability.",
+      "Run training jobs on CPU instances to minimize GPU contention.",
+      "Utilize Horovod with NCCL for multi-GPU communication within NGC containers.",
+      "Use DeepOps to statically allocate GPUs across nodes without considering workload requirements."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are troubleshooting a distributed AI workload using Magnum IO that is experiencing degraded performance despite having a properly configured InfiniBand network. Upon inspection, you discover that GPU-to-GPU communication within nodes is slower than expected. What is the most likely cause, and how can it be resolved?",
+    "a": [
+      "NVSwitch firmware is incompatible with the Magnum IO software stack.",
+      "Insufficient CPU-to-GPU PCIe bandwidth is throttling data transfer rates.",
+      "Improperly configured CUDA memory pools leading to inefficient memory usage.",
+      "Outdated NVIDIA GPU drivers causing NVLink underutilization."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A team notices that a server hosting multiple Docker containers is running out of disk space. Upon inspection, the following findings are noted:1. Several images have multiple layers with overlapping data.2. Stopped containers have not been removed for months.3. Logs from running containers are growing rapidly.What actions should the team take to resolve the disk space issue? (Choose two)",
+    "a": [
+      "Use the docker image rm command to remove images with overlapping layers.",
+      "Configure log rotation for containers to limit log file growth.",
+      "Increase the size of the Docker disk partition to accommodate additional storage.",
+      "Use the docker system prune command to remove unused images, containers, and networks.",
+      "Remove all running containers and recreate them using smaller base images."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "A team is designing an AI infrastructure to support fault-tolerant training of a large language model. The model requires significant computational resources and frequent checkpointing to ensure progress is not lost during failures. Which strategy best meets these requirements?",
+    "a": [
+      "Use a distributed deep learning framework with synchronous training and periodic checkpointing to a network file system (NFS).",
+      "Deploy the training process on a single GPU instance and use local storage for checkpoints.",
+      "Implement asynchronous training across nodes, avoiding checkpointing to save disk I/O bandwidth.",
+      "Train the model exclusively in-memory to eliminate the need for checkpointing altogether."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An organization is deploying NVIDIA DPUs (Data Processing Units) with ARM processors to accelerate networking and security tasks in its data center. The administrator needs to deploy DOCA services on the DPU. Which of the following steps is essential to ensure successful deployment?",
+    "a": [
+      "Install DOCA services directly on the x86 host machine without configuring the DPU.",
+      "Configure the DPU to operate in passthrough mode for direct host access.",
+      "Update the DPU's firmware to the latest version compatible with the DOCA SDK.",
+      "Use the default DOCA SDK settings without customizing service parameters."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are tasked with configuring a MIG-enabled GPU to support both AI model training and inference workloads. Training jobs require high memory and compute capabilities, while inference workloads require low latency but less memory. How should you configure the MIG instances? (Choose two)",
+    "a": [
+      "Configure MIG with uniform-sized instances for flexibility between training and inference.",
+      "Create a single large MIG instance for training and smaller instances for inference workloads.",
+      "Create multiple small MIG instances and assign them to both training and inference jobs.",
+      "Disable MIG and use the GPU in its full capacity for all jobs to ensure maximum performance.",
+      "Leverage MIG profiles that align closely with the specific needs of training and inference workloads."
+    ],
+    "c": [
+      1,
+      4
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "You are deploying an AI workload on a cluster using a container from the NVIDIA GPU Cloud (NGC). The container requires access to GPUs and a pre-installed CUDA library. Which of the following is the correct approach to ensure the container runs with optimal performance?",
+    "a": [
+      "Use the --runtime=nvidia flag when launching the container.",
+      "NGC containers are pre-configured with CUDA libraries. Installing them manually within the container is unnecessary and could lead to conflicts or redundancy.",
+      "Install the CUDA library inside the container after launching it.",
+      "Download the container from NGC and run it without specifying GPU access."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are managing an AI cluster, and some GPU nodes are experiencing inconsistent performance during training workloads. Which of the following actions using system management tools are correct for troubleshooting the issue? (Choose two)",
+    "a": [
+      "Use NVIDIA Nsight Systems to identify bottlenecks in GPU-accelerated applications.",
+      "Analyze system logs using tools like dmesg to check for hardware errors or driver issues.",
+      "Disable GPU throttling settings via BIOS to maximize performance during troubleshooting.",
+      "Use NVIDIA's nvidia-smi tool to monitor GPU utilization and memory usage in real time.",
+      "Inspect the training scripts for optimization issues without using system management tools."
+    ],
+    "c": [
+      0,
+      3
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "An enterprise is using the NVIDIA Base Command platform to manage its AI cluster, which includes multiple NVIDIA DGX systems. The team is preparing to onboard new users and streamline job scheduling for diverse workloads. Which feature of NVIDIA Base Command is most suitable for managing user access and optimizing workload distribution?",
+    "a": [
+      "Real-time GPU overclocking to maximize performance",
+      "Manual queue prioritization for job scheduling",
+      "Multi-tenancy with role-based access control (RBAC)",
+      "Automated container orchestration through Docker Compose"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "Your organization uses Run:AI to manage AI workloads across an NVIDIA GPU cluster. Researchers have raised concerns about unpredictable job execution times and uneven resource distribution. You suspect the current resource quotas and project configurations are misaligned with the team's requirements. Which action should you take to resolve the resource allocation issues and ensure predictable job execution times in Run:AI?",
+    "a": [
+      "Disable Dynamic Scheduling to enforce a fixed job execution order.",
+      "Use the Burst Mode feature to bypass quotas and allow unlimited resource usage.",
+      "Allocate all GPUs to a single project to ensure dedicated access.",
+      "Configure Per-Project Quotas and enable Job Preemption for low-priority workloads."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A data science team reports that their training jobs in the Run:ai cluster are taking longer than expected to complete. Upon investigation, you observe that some GPU nodes are underutilized. Which of the following steps would best address the issue?",
+    "a": [
+      "Manually assign jobs to specific GPUs to balance the workload.",
+      "Enable workload preemption to allow higher-priority jobs to utilize underused GPUs.",
+      "Use the Run:ai CLI to rebalance workloads across nodes and verify GPU allocation.",
+      "Increase the GPU quotas for all users to improve utilization."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A distributed AI training workload involves transferring large amounts of data between nodes in a GPU cluster. The organization requires a networking solution that ensures high throughput and low latency. Which configuration is the most appropriate?",
+    "a": [
+      "Utilize 10 Gbps Ethernet with TCP/IP-based data transfer.",
+      "Implement a Wi-Fi 6 network to support high-speed data transfer.",
+      "Use a standard 1 Gbps Ethernet connection between nodes.",
+      "Deploy an InfiniBand network with Remote Direct Memory Access (RDMA)."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An NVIDIA DGX cluster uses a distributed parallel file system for AI training workloads. Users report degraded performance during model training with large datasets. Upon investigation, the file system shows high metadata server utilization. Which of the following optimizations is most likely to improve performance?",
+    "a": [
+      "Reduce the replication factor of the file system to minimize data redundancy.",
+      "Add additional metadata servers to distribute the load.",
+      "Reconfigure the training jobs to use synchronous I/O operations instead of asynchronous I/O.",
+      "Disable caching on the client nodes to reduce I/O overhead."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A large-scale AI inference workload is taking significantly longer than expected to complete. You suspect resource bottlenecks in the cluster. Which of the following steps using system management tools are correct to identify the bottleneck? (Choose two)",
+    "a": [
+      "Modify batch sizes and re-run the workload without analyzing system metrics.",
+      "Rely solely on user-reported observations to identify patterns of high latency.",
+      "Use Kubernetes monitoring tools like Prometheus to track pod resource usage.",
+      "Check disk I/O metrics using system monitoring tools like iostat to assess storage performance.",
+      "Use NVIDIA DCGM (Data Center GPU Manager) to collect health and utilization metrics across the GPU cluster."
+    ],
+    "c": [
+      2,
+      4
+    ],
+    "multi": true,
+    "set": "Set 4"
+  },
+  {
+    "q": "A company is running multiple AI workloads, including training and inference, on NVIDIA GPUs in a cloud environment. The workloads exhibit varying resource utilization throughout the day, with high demand during business hours and low demand overnight. As the AI Operations engineer, you are tasked with implementing cost-optimization strategies without compromising performance. Which of the following strategies would be the most effective for minimizing costs in this scenario?",
+    "a": [
+      "Implement workload scheduling to align high-demand tasks with low-cost time slots.",
+      "Use preemptible GPU instances exclusively for inference workloads.",
+      "Leverage auto-scaling groups to adjust the number of instances based on utilization.",
+      "Use spot instances for both training and inference workloads."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "During the deployment of DOCA services on a DPU with an ARM processor, an administrator observes that certain services fail to start. After reviewing the logs, the administrator identifies missing dependencies in the environment. What is the most appropriate action to resolve this issue?",
+    "a": [
+      "Modify the DPU's bootloader configuration to enable additional features.",
+      "Disable the DPU's management interface to prevent dependency conflicts.",
+      "Reboot the host server to reset the DPU's state and retry the deployment.",
+      "Install the missing libraries and dependencies using the DOCA SDK package manager."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An AI data center is experiencing rapid growth in data volume, with petabyte-scale datasets being used for both training and inference workloads. The storage solution must ensure high scalability, fault tolerance, and performance while minimizing costs. Which approach best addresses these requirements?",
+    "a": [
+      "Implementing a hybrid storage model combining NVMe SSDs for hot data and HDDs for cold data.",
+      "Configuring all datasets to reside on a single high-capacity NAS device.",
+      "Utilizing a scale-out object storage solution with erasure coding.",
+      "Deploying a SAN (Storage Area Network) with Fibre Channel connectivity."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are responsible for administering an NVIDIA AI platform running multiple machine learning workloads. To optimize the infrastructure for cost and performance, you must monitor resource usage and dynamically scale GPU clusters as demand fluctuates. Which approach best aligns with these objectives?",
+    "a": [
+      "Implement auto-scaling policies based on workload demand metrics collected via the NVIDIA DCGM (Data Center GPU Manager).",
+      "Configure manual scaling by monitoring GPU usage logs and adjusting resources as needed.",
+      "Use static resource allocation to ensure each workload has a fixed number of GPUs.",
+      "Enable overprovisioning of GPUs to handle peak workloads without scaling down during idle periods."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "You are designing an AI infrastructure for a multinational corporation that requires a hybrid cloud approach to support its data privacy regulations and scalability requirements. Which key factor should be prioritized to ensure seamless AI workload management across on-premises and cloud environments?",
+    "a": [
+      "Implementing a unified orchestration layer with Kubernetes-based tools.",
+      "Using a single cloud vendor for all deployment needs.",
+      "Relying solely on on-premises infrastructure for sensitive data processing.",
+      "Avoiding the use of hybrid cloud models to minimize latency issues."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "An organization is setting up its AI infrastructure using the NVIDIA AI Enterprise Suite to streamline deep learning workloads. The primary goal is to optimize the deployment of AI models across hybrid cloud environments while maintaining compatibility with existing containerized workflows. Which feature of NVIDIA AI Enterprise Suite best addresses this need?",
+    "a": [
+      "Native integration with Kubernetes to orchestrate containerized AI workloads across hybrid cloud environments.",
+      "NVIDIA Triton Inference Server for low-latency inferencing on edge devices.",
+      "GPU-accelerated libraries exclusively for model training in on-premises data centers.",
+      "Exclusive support for proprietary NVIDIA GPUs, making hybrid deployments reliant solely on NVIDIA hardware."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A team is deploying an AI model to production using an NVIDIA GPU cluster. To ensure efficient resource utilization and high availability, the team must follow best practices for resource allocation. Which of the following strategies aligns with best practices for AI operations?",
+    "a": [
+      "Allocate the maximum GPU resources available for all workloads to prevent underutilization.",
+      "Disable workload isolation to allow multiple applications to share GPU resources dynamically.",
+      "Configure auto-scaling for GPU resources based on real-time workload demand.",
+      "Use static GPU allocation to ensure all models have a fixed number of GPUs at all times."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 4"
+  },
+  {
+    "q": "A Slurm cluster node is repeatedly being marked as down by the controller, and jobs assigned to the node are failing to execute. Logs show intermittent connection issues between the node and the Slurm controller. What is the most effective way to troubleshoot and resolve the issue?",
+    "a": [
+      "Increase the SlurmdTimeout value in the slurm.conf file to account for potential network latency.",
+      "Change the node's state to idle using scontrol update NodeName= State=idle.",
+      "Replace the node's network interface card (NIC) to eliminate hardware issues.",
+      "Verify and correct the node's hostname and DNS resolution settings."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a cluster with multiple GPU nodes using Base Command Manager (BCM). The cluster will handle large-scale AI training workloads requiring efficient communication between nodes. Which network configuration should you prioritize to optimize performance?",
+    "a": [
+      "Enable InfiniBand networking with RDMA (Remote Direct Memory Access).",
+      "Rely on the default networking setup provided by the operating system.",
+      "Use Wi-Fi to connect the nodes to simplify deployment.",
+      "Use a standard 1 Gbps Ethernet connection for all nodes."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "During a performance audit of a data center using Magnum IO for distributed AI workloads, you observe high latency in communication between GPUs across different nodes. Which two measures would optimize performance? (Choose two)",
+    "a": [
+      "Optimize NVLink topology to ensure efficient intra-node GPU communication",
+      "Increase the network packet size beyond the MTU to reduce fragmentation",
+      "Use a high-performance InfiniBand network with low-latency switches",
+      "Switch to TCP/IP communication for inter-node transfers",
+      "Enable GPUDirect RDMA for direct memory access across nodes"
+    ],
+    "c": [
+      2,
+      4
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "A system administrator manages a Slurm cluster with heterogeneous compute nodes. A new user requires access to specific GPU-enabled nodes for running deep learning workloads. How should the administrator configure Slurm to ensure the user can access only the GPU-enabled nodes while optimizing resource allocation?",
+    "a": [
+      "Set the QOS (Quality of Service) to high_priority and apply it to GPU-enabled nodes only.",
+      "Configure a partition with a Constraint set to gpu and assign the user to that partition.",
+      "Add the gpu constraint directly to the user's job submissions by modifying their sbatch scripts.",
+      "Assign the user to a new account and set their resource limits to GPU nodes in the slurm.conf file."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with installing and initializing Kubernetes on NVIDIA hosts to support AI workloads using BCM (Base Command Manager). The goal is to ensure the nodes are optimized for NVIDIA GPUs and AI workload execution. Which two actions are necessary to complete this task? (Choose two)",
+    "a": [
+      "Deploy NVIDIA Base Command CLI (BCL) on each node to handle GPU scheduling.",
+      "Install the NVIDIA Kubernetes device plugin on all nodes.",
+      "Enable the cri-o container runtime interface for Kubernetes nodes.",
+      "Configure the NVIDIA GPU Operator to automate GPU management.",
+      "Manually assign GPU resources to workloads using kubectl exec commands."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "A data scientist is tasked with building and deploying an end-to-end data pipeline for a financial institution using the NVIDIA AI Enterprise Suite. The pipeline involves data preprocessing, training machine learning models, and running real-time inference. The data scientist wants to leverage RAPIDS for preprocessing and Triton Inference Server for inference. Which feature of RAPIDS makes it a suitable choice for the preprocessing stage in this pipeline?",
+    "a": [
+      "Real-time data augmentation for image preprocessing.",
+      "Hardware-agnostic processing optimized for CPU workloads.",
+      "GPU-accelerated data frame operations compatible with Pandas APIs.",
+      "Integrated support for deploying trained models directly to inference servers."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "During inference deployment, a recommendation system running on NVIDIA GPUs experiences high latency. Which of the following strategies should be used to identify and resolve the bottleneck?",
+    "a": [
+      "Increase the model size to enhance prediction accuracy, thereby reducing latency.",
+      "Use only single-threaded data loading to reduce contention during inference.",
+      "Profile the inference pipeline using NVIDIA TensorRT Profiler to analyze layer execution times.",
+      "Disable CUDA streams to simplify debugging and streamline inference execution."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your organization uses an NVIDIA AI infrastructure for deep learning model training and inference. You are tasked with implementing a secure, reliable backup and restore strategy for critical models and datasets stored on the cluster to prevent data loss during hardware failures or upgrades. Which approach best ensures data integrity and minimizes downtime during backups in an NVIDIA AI infrastructure?",
+    "a": [
+      "Schedule full backups of the entire cluster daily, halting all workloads during the backup process.",
+      "Leverage NFS-mounted shared storage and perform incremental backups using a third-party tool.",
+      "Use NVIDIA GPU Operator to create snapshots of GPU memory.",
+      "Configure NVIDIA MIG (Multi-Instance GPU) to allocate backup resources dynamically."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are managing a distributed AI system where the primary workload involves training deep learning models on a petabyte-scale dataset. To ensure optimal storage and data accessibility, which of the following strategies should you prioritize?",
+    "a": [
+      "Use a distributed file system like NVIDIA Magnum IO with high-bandwidth interconnects to enable efficient data sharing.",
+      "Use RAID 0 for all storage volumes to maximize redundancy and fault tolerance.",
+      "Compress the dataset at the cost of increased I/O overhead to reduce storage space.",
+      "Store all dataset replicas on a single node to reduce synchronization overhead."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You notice degraded performance in an AI training workload running on an NVIDIA GPU cluster. Using system management tools, you want to determine if the issue is caused by GPU thermal throttling. Which of the following steps is most appropriate for diagnosing thermal issues?",
+    "a": [
+      "Lower the GPU clock speed to reduce heat generation.",
+      "Replace the GPU cooling system with a more powerful alternative.",
+      "Run a stress test on the GPUs to verify their thermal performance under load.",
+      "Use nvidia-smi to check GPU temperature and power draw metrics."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your AI operations team reports inconsistent storage performance during distributed training across multiple nodes. Each node is equipped with NVIDIA GPUs and accesses a shared NVMe over Fabric (NVMe-oF) storage system. What is the most effective action to diagnose and address the performance inconsistencies?",
+    "a": [
+      "Use a software RAID configuration to aggregate multiple NVMe devices into a single logical volume.",
+      "Enable disk compression on the NVMe-oF storage system to reduce I/O latency.",
+      "Check the network interface card (NIC) settings on all nodes to ensure they are configured for optimal NVMe-oF performance.",
+      "Increase the number of storage volumes attached to each node to distribute the storage load."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A large enterprise is setting up a high-performance AI infrastructure to support diverse workloads, including deep learning training, data preprocessing, and real-time inference. The infrastructure must minimize latency and maximize throughput for all operations. Which of the following components should be prioritized in their design?",
+    "a": [
+      "NVIDIA DGX SuperPOD architecture with NVSwitch",
+      "NVIDIA BlueField DPUs for data offloading and network acceleration",
+      "A set of NVIDIA T4 GPUs distributed across multiple servers using standard Ethernet",
+      "A high-core-count CPU cluster without GPU acceleration"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are tasked with deploying cloud VMI containers for an AI inference workload. After setting up the environment, you need to ensure that the containers can utilize GPUs efficiently. Which of the following configurations is most important to enable GPU usage within the containers?",
+    "a": [
+      "Enable autoscaling for the GPU nodes in the cloud cluster.",
+      "Deploy the containers with increased CPU and memory limits.",
+      "Set up a Kubernetes custom resource definition (CRD) for GPU workloads.",
+      "Install the NVIDIA GPU drivers on the host machine and pass-through GPUs to the containers."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your organization operates a multi-node AI training pipeline using NVIDIA GPUs in an on-premises environment. The workload involves frequent hyperparameter tuning, and GPU utilization often spikes during these experiments. Budget constraints require you to optimize resource usage and reduce operational costs while ensuring the pipeline's effectiveness. Which of the following strategies is the best approach to cost optimization in this scenario?",
+    "a": [
+      "Utilize GPU partitioning (MIG) to run multiple smaller jobs on a single GPU.",
+      "Migrate the entire pipeline to a cloud-based environment with spot instances.",
+      "Purchase additional GPUs to reduce the queue time for experiments.",
+      "Implement mixed-precision training for all training models."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A company is leveraging NVIDIA AI Enterprise Suite for their AI operations and plans to deploy an end-to-end AI pipeline for healthcare applications. The pipeline requires accelerated data preprocessing, model training, and real-time inference. Which combination of tools within the NVIDIA AI Enterprise Suite should the company prioritize?",
+    "a": [
+      "NVIDIA TensorRT for training acceleration and Triton Inference Server for distributed training.",
+      "NVIDIA Nsight Systems for pipeline debugging and Triton Inference Server for multi-cloud inference.",
+      "NVIDIA NGC for model development and RAPIDS for real-time inference acceleration.",
+      "RAPIDS for data preprocessing, TensorRT for inference optimization, and Triton Inference Server for model deployment."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a machine learning model using NVIDIA Triton Inference Server. The model requires preprocessing steps, such as image resizing and normalization, which must be executed during inference. How should these preprocessing steps be managed to optimize deployment in Triton?",
+    "a": [
+      "Configure Triton's model configuration file (config.pbtxt) to include preprocessing directives.",
+      "Install additional preprocessing plugins into the Triton server.",
+      "Use Triton's inference pipelines to chain the model with a preprocessing backend.",
+      "Embed the preprocessing steps directly into the model architecture during training."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are running a GPU-accelerated container on Docker for an AI training workload. The container starts successfully, but the application inside cannot detect the GPU. What is the most likely cause, and how can it be resolved?",
+    "a": [
+      "The container's memory limit is too low; increase the container's memory allocation to support GPU operations.",
+      "The NVIDIA Container Toolkit is not installed on the host system; install and configure it to enable GPU support.",
+      "The Docker image does not include CUDA libraries; rebuild the image with CUDA libraries installed.",
+      "The GPU is incompatible with the current version of Docker; downgrade Docker to match the GPU driver version."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your organization needs to enforce strict security policies across its Fleet Command-managed edge clusters. These policies include ensuring encrypted communication, restricted access to sensitive workloads, and compliance with regional regulations. Which of the following actions should you prioritize when administering security policies in Fleet Command?",
+    "a": [
+      "Assign a single security policy to all clusters to maintain consistency.",
+      "Enable role-based access control (RBAC) in Fleet Command to manage user permissions.",
+      "Implement manual workload encryption by modifying application code.",
+      "Disable logging to prevent sensitive data from being exposed."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your team needs to deploy a PyTorch-based container from the NVIDIA NGC catalog to train a deep learning model using multiple GPUs on a single node. Which two actions should you take to ensure optimal GPU utilization? (Choose two)",
+    "a": [
+      "Configure the container runtime as runc in the Kubernetes YAML manifest.",
+      "Install NVIDIA CUDA drivers on the host machine.",
+      "Use the --gpus all flag in the Docker run command when launching the container.",
+      "Ensure the container's Dockerfile contains a FROM ubuntu:latest base image.",
+      "Include the resources.limits.nvidia.com/gpu: \"4\" parameter in the Kubernetes YAML manifest."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "An engineer is troubleshooting a failure of the Fabric Manager service on an NVIDIA NVLink/NVSwitch system. After verifying that the service is installed, the engineer observes the following log entry:\"Failed to initialize NVSwitch communication layer: insufficient permissions.\"Which of the following is the most likely root cause and corresponding solution?",
+    "a": [
+      "The NVSwitch firmware is outdated and incompatible with the installed driver version.",
+      "The Fabric Manager service binary is corrupted and needs to be reinstalled.",
+      "The user running the service does not have the required root privileges.",
+      "The NVLink hardware is physically damaged, causing the service to fail initialization."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying AI models using Fleet Command across multiple edge clusters. Each cluster has varying resource capabilities and latencies. The requirements are as follows:1. Ensure deployments scale according to cluster capacity.2. Avoid overloading weaker clusters during peak loads.3. Optimize latency-sensitive applications by deploying them closer to end users.Which configuration strategy best meets these requirements?",
+    "a": [
+      "Configure each model with manual deployment rules for each cluster, specifying exact resource limits.",
+      "Use Fleet Command's intelligent resource-aware deployment feature to scale and allocate resources dynamically based on cluster capabilities and application requirements.",
+      "Deploy all models uniformly across all clusters to ensure equal distribution.",
+      "Use a round-robin deployment strategy to distribute models equally among clusters, ensuring no cluster is left unused."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "After deploying the NVIDIA Base Command Manager (BCM) agents in an AI data center, you notice that the agents on some compute nodes fail to communicate with the central manager. The logs on the affected nodes show the following error:Connection timed out while attempting to reach the BCM central server.Which of the following is the most likely cause of this issue?",
+    "a": [
+      "Outdated NVMe firmware causing storage bottlenecks.",
+      "API key not properly configured in the agent's configuration file.",
+      "Incorrect GPU driver version installed on the compute nodes.",
+      "Firewall rules blocking communication on the default BCM port."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "An organization is deploying NVIDIA A100 GPUs in its data center to support both AI and high-performance computing (HPC) workloads. The administrators need to configure Multi-Instance GPU (MIG) to ensure optimal resource utilization. Which of the following actions should be taken to achieve this goal?",
+    "a": [
+      "Allocate all GPU memory to a single MIG instance to maximize performance.",
+      "Disable MIG functionality to allow applications to access the GPU without restrictions.",
+      "Use the default GPU configuration without creating MIG instances for simplicity.",
+      "Create multiple MIG instances with varying sizes to match workload requirements."
+    ],
+    "c": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "You observe that certain compute nodes in an NVIDIA-powered AI cluster are not receiving jobs, and their state is marked as \"down\" in the Base Command Manager (BCM). What is the most effective way to diagnose and resolve the issue using system management tools?",
+    "a": [
+      "Use a GPU profiling tool like nvprof to identify performance bottlenecks.",
+      "Use nvidia-smi on the controller node to check for GPU availability.",
+      "Use ping to test connectivity between the BCM controller and the affected nodes.",
+      "Use dmesg on the affected nodes to check for hardware or driver-related errors."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are an AI operations professional managing multiple NVIDIA GPU clusters through Fleet Command. You are tasked with configuring role-based access control (RBAC) to ensure that specific users only have access to the resources they require. A new user, Alex, needs read-only access to monitor GPU utilization metrics without the ability to perform administrative actions. Which of the following steps should you take to achieve this goal?",
+    "a": [
+      "Assign Alex the \"Administrator\" role.",
+      "Enable auditing mode for Alex's account to track actions without restricting access.",
+      "Add Alex to the default \"Viewer\" group in Fleet Command.",
+      "Create a custom role with read-only permissions and assign it to Alex."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are provisioning an AI cluster using Base Command Manager (BCM) for a new team of researchers. The team requires rapid scalability to support varied AI workloads, including both compute-intensive training jobs and latency-sensitive inference tasks. Which cluster provisioning strategy should you implement to balance scalability, cost, and performance?",
+    "a": [
+      "Enable spot instances only for inference tasks to minimize costs.",
+      "Provision a single, large on-demand cluster with fixed resources to ensure availability.",
+      "Provision separate clusters for training and inference, each with pre-allocated resources.",
+      "Set up an auto-scaling cluster that dynamically adjusts based on workload demand."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A company uses Base Command Manager (BCM) to manage AI workflows across multiple GPU-enabled clusters. They want to optimize their job scheduling and ensure that resources are utilized efficiently. Which of the following steps will help them achieve this goal? (Choose two)",
+    "a": [
+      "Schedule all jobs to run concurrently without resource constraints.",
+      "Enable auto-scaling policies based on workload demand in BCM.",
+      "Set up resource reservations exclusively for idle GPU instances.",
+      "Configure job priorities and quotas to align with organizational objectives.",
+      "Disable GPU telemetry collection to minimize overhead."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "An organization plans to deploy its AI infrastructure across multiple cloud providers to ensure high availability and vendor independence. What is the most critical challenge to address when implementing a multi-cloud AI deployment?",
+    "a": [
+      "Reducing the need for containerized workloads.",
+      "Achieving consistent monitoring and logging across providers.",
+      "Limiting workload replication across cloud environments to reduce costs.",
+      "Maintaining completely isolated infrastructure for each cloud provider."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A new AI data center is being set up to handle large-scale machine learning training jobs. The storage system must support high throughput and low latency for GPU-accelerated workloads, with the ability to scale as the data grows. Which of the following storage solutions is most appropriate for this scenario?",
+    "a": [
+      "A single local SSD installed on the management node.",
+      "A shared tape-based archival system.",
+      "A traditional HDD-based Network Attached Storage (NAS) system.",
+      "A high-performance NVMe-over-Fabrics (NVMe-oF) storage solution."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You have been tasked with configuring Slurm accounting on a cluster to track resource utilization for billing purposes. The cluster uses a MariaDB database as the backend for Slurm accounting. Which actions should you perform to ensure proper configuration? (Choose two)",
+    "a": [
+      "Start the slurmdbd daemon after configuring slurmdbd.conf.",
+      "Manually update the Slurm accounting tables using SQL scripts to synchronize job data.",
+      "Enable the AccountingStorageEnforce option in slurm.conf.",
+      "Configure each compute node with the database connection string.",
+      "Configure the slurmdbd.conf file to connect to the MariaDB database."
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "Your organization is deploying an AI inference system requiring rapid data exchange between servers for real-time predictions. Which of the following networking configurations is best suited for this use case?",
+    "a": [
+      "Deploy a software-defined network (SDN) without hardware acceleration.",
+      "Use a traditional Ethernet switch with 1 Gbps ports for cost efficiency.",
+      "Install a 100 Gbps InfiniBand network with Quality of Service (QoS) prioritization.",
+      "Implement a 40 Gbps Ethernet connection with Data Center Bridging (DCB)."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are managing an AI cluster that utilizes Magnum IO for high-performance data movement between GPUs. Users report slow data transfer rates during training tasks that involve distributed GPUs. Which two actions would most likely resolve the issue? (Choose two)",
+    "a": [
+      "Verify RDMA network configuration for low-latency data transfers",
+      "Disable GPU Direct RDMA to reduce overhead",
+      "Reduce the number of GPUs per node to prevent network contention",
+      "Increase batch size in the AI model training configuration",
+      "Inspect GPUDirect Storage (GDS) settings for compatibility with the file system"
+    ],
+    "c": [
+      0,
+      4
+    ],
+    "multi": true,
+    "set": "Set 5"
+  },
+  {
+    "q": "A company deploys an AI model on edge devices to analyze live video feeds. The system requires real-time analysis with a high throughput rate. During performance monitoring, you notice degraded throughput under increased load. Which metric should you focus on to identify bottlenecks affecting throughput?",
+    "a": [
+      "GPU Utilization",
+      "Model Accuracy",
+      "Batch Size",
+      "Disk I/O Wait Time"
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a TensorFlow container from NVIDIA NGC to train a large neural network on an AI server equipped with multiple NVIDIA GPUs. To maximize performance, you need to ensure that the container is properly configured for multi-GPU usage. Which of the following actions best achieves this objective?",
+    "a": [
+      "Set the CUDA_VISIBLE_DEVICES environment variable inside the container to expose all GPUs to the workload.",
+      "Deploy the container with --cpu-flag to enable the container to offload computations to CPUs when GPUs are busy.",
+      "Disable NVIDIA Collective Communications Library (NCCL) to reduce overhead in multi-GPU communication.",
+      "Use the base TensorFlow image from Docker Hub and install NVIDIA CUDA extensions manually."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are an administrator tasked with ensuring the Base Command Manager (BCM) is effectively managing user workloads and resource allocation in your AI cluster. A user reports that their workload has been queued longer than expected despite other users reporting normal operation. Upon investigation, you notice that their workload has a high priority, but the resources requested exceed the default resource limits configured in BCM. What is the most appropriate action to resolve this issue while maintaining cluster efficiency and fairness?",
+    "a": [
+      "Increase the user's priority level to \"highest\" in BCM to bypass resource limitations.",
+      "Reconfigure the resource allocation policy in BCM to dedicate a fixed quota for high-priority workloads.",
+      "Manually override the resource limits for this user's workload and allocate additional resources.",
+      "Work with the user to optimize their workload resource requirements to fit within the configured limits."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are running an NVIDIA NGC container on a compute node to train a machine learning model. The container crashes shortly after starting, and you need to identify the root cause. Which of the following steps is the most appropriate first action to troubleshoot this issue?",
+    "a": [
+      "Run the container with the --privileged flag to avoid security issues.",
+      "Check the container logs using docker logs.",
+      "Update the NVIDIA GPU driver on the host machine.",
+      "Restart the Docker service to reset all running containers."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are troubleshooting storage performance issues on a GPU-accelerated system used for training deep learning models. The storage subsystem includes a parallel file system (PFS) integrated with NVIDIA GPUs. Users report slower-than-expected data loading speeds during model training. Which of the following steps is most likely to identify and resolve the performance issue?",
+    "a": [
+      "Disable RDMA to reduce network contention and ensure data is transferred using standard protocols.",
+      "Enable GPUDirect Storage and verify its configuration to ensure data transfer bypasses the CPU.",
+      "Add more GPUs to the system to distribute the training load more effectively.",
+      "Increase the batch size in the training script to reduce the number of storage I/O operations."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are managing an NVIDIA DGX system and encounter an issue where an AI workload is consuming excessive GPU memory, causing other workloads to fail. Which of the following steps is the most effective first action to troubleshoot and resolve the issue using system management tools?",
+    "a": [
+      "Increase the system swap memory allocation to handle GPU memory overflow.",
+      "Use nvidia-smi to inspect GPU memory usage and identify the process consuming excessive memory.",
+      "Limit the power consumption of the GPUs using the NVIDIA System Management Interface (nvidia-smi).",
+      "Terminate all GPU processes to reset the GPU state and free up memory."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are optimizing the storage performance of an NVIDIA DGX system used for training large AI models. The workload involves sequential reads of large datasets. After optimizing the storage system, you notice minimal improvement in performance. Which of the following could be the underlying issue?",
+    "a": [
+      "The power settings of the GPUs are limiting their performance.",
+      "The GPUs are underutilized due to insufficient GPU memory.",
+      "The storage system's RAID configuration is optimized for write performance.",
+      "The storage system is using NVMe SSDs instead of SATA SSDs."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a deep learning application in a Docker container on an NVIDIA GPU-enabled host. During runtime, the application fails to access the GPU resources, and you suspect a misconfiguration in the Docker setup. Which of the following actions should you take to troubleshoot this issue?",
+    "a": [
+      "Verify that the host machine's GPU drivers are installed inside the container.",
+      "Ensure that the --runtime=nvidia flag is used when starting the Docker container.",
+      "Restart the Docker service without checking the NVIDIA Container Toolkit installation.",
+      "Modify the container runtime configuration to use the default runc instead of nvidia."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "An AI operations team is tasked with deploying a deep learning model to production using NVIDIA's technology stack. Which NVIDIA tool is best suited for optimizing the model deployment process while ensuring compatibility across multiple hardware platforms?",
+    "a": [
+      "NVIDIA GPU Cloud (NGC)",
+      "NVIDIA DeepStream SDK",
+      "NVIDIA TensorRT",
+      "NVIDIA Nsight Systems"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are managing a Kubernetes cluster for an AI application that requires dedicated resources to ensure consistent performance. The cluster supports multiple namespaces, each with varying resource demands. To prevent resource contention, you need to define resource quotas for namespaces. Which of the following statements is correct regarding the use of resource quotas in Kubernetes?",
+    "a": [
+      "Resource quotas are defined at the namespace level and ensure that workloads within a namespace do not exceed allocated resources.",
+      "Resource quotas are optional but recommended for ensuring horizontal pod autoscaling in Kubernetes.",
+      "Resource quotas limit the total number of pods in a cluster, irrespective of the namespace.",
+      "Resource quotas are applied at the cluster level and override any namespace-level configurations."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A Docker container running an AI training workload fails intermittently, and the logs show \"Out of Memory (OOM)\" errors. The container has been allocated sufficient memory resources. Which of the following is the best step to troubleshoot this issue?",
+    "a": [
+      "Reduce the container's memory allocation to prevent overutilization.",
+      "Disable Docker's built-in memory monitoring to reduce overhead.",
+      "Check the resource limits (--memory and --memory-swap) in the container's configuration.",
+      "Use the --oom-kill-disable flag when starting the container to prevent the kernel from killing the process."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "A team is running distributed AI training jobs across multiple nodes in a cluster. They notice high communication overhead during parameter synchronization between nodes, leading to bottlenecks. Which technique would best reduce this bottleneck?",
+    "a": [
+      "Use HTTP/2 for inter-node communication to leverage multiplexing.",
+      "Increase CPU thread priority to enhance network throughput.",
+      "Enable RDMA over InfiniBand for faster data transfers.",
+      "Utilize public internet routing for inter-node communication."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your organization uses NVIDIA GPUs in AI operations to process healthcare data for machine learning applications. The organization must ensure compliance with HIPAA regulations regarding data privacy and security. Which of the following actions is most critical to maintaining HIPAA compliance in AI operations involving NVIDIA GPUs?",
+    "a": [
+      "Use GPU hardware encryption to secure data during computation.",
+      "Ensure data anonymization before uploading it to GPU-based AI workloads.",
+      "Rely on third-party software to ensure HIPAA compliance without internal auditing.",
+      "Store all training data in encrypted external hard drives."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are responsible for administering a large fleet of NVIDIA DGX servers using NVIDIA Fleet Command. A new edge node has been added, and the team needs to deploy an AI application. Which of the following steps must you perform to ensure successful deployment of the application?",
+    "a": [
+      "Verify the edge node's connectivity with the Fleet Command dashboard and confirm it appears as healthy.",
+      "Deploy the application container directly from Docker Hub without registering it in Fleet Command.",
+      "Configure the edge node in Fleet Command and assign it an appropriate profile.",
+      "Create a project in Fleet Command and associate it with the edge node for deployment."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are implementing a disaster recovery (DR) strategy for an AI training pipeline that processes critical data. The pipeline runs on NVIDIA GPUs and generates large intermediate datasets. Which of the following strategies is the most appropriate for ensuring quick recovery and minimal data loss in the event of a disaster?",
+    "a": [
+      "Store intermediate datasets on high-speed NVMe drives without any external backup.",
+      "Transfer all intermediate datasets to a remote archive once the training job completes.",
+      "Mirror the entire training environment, including GPU nodes, to a secondary data center using a synchronous replication strategy.",
+      "Use NVIDIA GPUDirect Storage to replicate data to an on-premises backup system."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "An AI operations team is tasked with designing an energy-efficient workflow for a large-scale image classification model deployed on NVIDIA GPUs. Which approach would best optimize energy usage without compromising performance?",
+    "a": [
+      "Replace the GPUs with CPUs for energy savings.",
+      "Avoid distributed training to minimize inter-device energy consumption.",
+      "Enable mixed-precision training to reduce computation energy.",
+      "Use a fixed GPU power cap of 50W for all workloads."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are administering a Kubernetes cluster deployed for an AI workload that processes large-scale image datasets. The workload exhibits uneven resource utilization across the nodes, leading to suboptimal performance. Which Kubernetes feature should you configure to ensure that pods are evenly distributed across the nodes in the cluster?",
+    "a": [
+      "Node Affinity",
+      "Resource Quotas",
+      "Pod Anti-Affinity",
+      "Default Scheduler Spread Constraints"
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are designing the storage system for an AI data center to support workloads involving large-scale datasets and high-performance training of machine learning models. Which of the following considerations is most critical for ensuring optimal performance and reliability?",
+    "a": [
+      "Using tape-based storage for training data due to its cost-effectiveness.",
+      "Relying on cloud-based object storage exclusively to minimize local hardware.",
+      "Using a single high-capacity hard disk drive (HDD) to reduce costs.",
+      "Deploying SSDs with NVMe interfaces for high-speed storage access."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are troubleshooting a fabric manager service issue on an NVIDIA NVLink/NVSwitch system. The service fails to start and logs show the error: Failed to bind to device. Which of the following is the most likely cause of this issue?",
+    "a": [
+      "Another process is using the same device or port as the fabric manager.",
+      "The NVSwitch system firmware is corrupted.",
+      "The server does not have sufficient permissions to run the fabric manager service.",
+      "The NVIDIA GPU driver is outdated."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "Your Slurm cluster is experiencing scheduling delays, and jobs are queuing longer than expected despite sufficient available resources. Upon investigation, you suspect that the issue lies in misconfigured scheduler parameters. Which of the following actions is the most effective first step in diagnosing and resolving the issue?",
+    "a": [
+      "Use the sdiag command to analyze scheduler performance and identify bottlenecks.",
+      "Set SelectType=select/cons_res in slurm.conf to ensure resource-based scheduling is active.",
+      "Enable Backfill=1 in slurm.conf to allow low-priority jobs to fill available gaps in resources.",
+      "Increase the PriorityDecayHalfLife parameter to make job priorities decay faster over time."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "An AI operations team is troubleshooting performance issues in a data pipeline for training large-scale models on a distributed GPU cluster. Despite having ample GPU resources, training times are much longer than expected. What is the most likely bottleneck causing the performance issue?",
+    "a": [
+      "Suboptimal network bandwidth between nodes",
+      "Overloaded CPU cores for data preprocessing tasks",
+      "Insufficient GPU memory for the model parameters",
+      "Limited IOPS of the underlying storage system"
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a trained machine learning model to a production environment that uses NVIDIA Triton Inference Server. The deployment process involves integrating the model with a CI/CD pipeline to ensure seamless updates while maintaining high availability. Which practice is most effective for automating the deployment process while minimizing downtime?",
+    "a": [
+      "Disable the production server during deployment to ensure consistency.",
+      "Directly replace the existing model in the production environment without versioning.",
+      "Use a blue-green deployment strategy with Triton's model repository.",
+      "Train the model on the production environment to avoid deployment overhead."
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are designing a data center for running large-scale AI workloads. The data center must ensure high GPU utilization, minimize network bottlenecks, and provide scalability for future growth. Which of the following architectural decisions best meets these requirements?",
+    "a": [
+      "Use a single centralized storage system with no distributed file system for simplicity.",
+      "Deploy high-performance InfiniBand interconnects between GPU servers for low-latency communication.",
+      "Use a traditional three-tier network architecture (core, aggregation, access) with standard Ethernet connections.",
+      "Design the data center using CPU-centric racks and allocate GPUs only to critical workloads."
+    ],
+    "c": [
+      1
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are training a deep learning model using a distributed framework on a cluster of GPUs. During the training process, the job fails with no clear error message in the logs. Which debugging tool or technique should you use first to identify the root cause?",
+    "a": [
+      "TensorBoard Profiler",
+      "AI-Specific APM (Application Performance Monitoring) Tools",
+      "NVIDIA Nsight Systems",
+      "GPU Memory Monitoring Tools"
+    ],
+    "c": [
+      2
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are deploying a container from NVIDIA NGC on a node equipped with GPUs, but the container cannot detect the GPUs. Which of the following actions will most likely resolve the issue?",
+    "a": [
+      "Rebuild the container with the GPU driver pre-installed.",
+      "Manually assign GPUs to the container using environment variables.",
+      "Use the --network=host flag when running the container.",
+      "Ensure the NVIDIA Container Toolkit is installed and configured on the host."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are running a high-performance computing (HPC) application that uses Magnum IO to manage file I/O on a distributed system. Users report that read and write operations to the shared file system have slowed significantly. You observe that the I/O throughput is consistently lower than expected and that one of the nodes in the cluster is experiencing higher-than-normal CPU utilization. What is the most likely cause of the performance degradation, and how should it be resolved?",
+    "a": [
+      "Insufficient memory allocation for caching in the Magnum IO library.",
+      "Improper alignment of data block sizes with the file system's configuration.",
+      "File permissions are incorrectly set on the shared file system.",
+      "Magnum IO is not using RDMA for data transfers between nodes."
+    ],
+    "c": [
+      3
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are troubleshooting an issue where an NVIDIA AI application deployed via Fleet Command is underperforming. The application is designed to process video feeds in real time. Which of the following steps should you take to diagnose and resolve the issue?",
+    "a": [
+      "Monitor the resource utilization of the edge node through Fleet Command and ensure GPU resources are sufficient.",
+      "Increase the resolution of the video feeds to test the application's processing limits.",
+      "Re-deploy the application container with debug mode enabled to identify potential runtime errors.",
+      "Adjust the Fleet Command deployment configuration to disable logging for performance improvements."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  },
+  {
+    "q": "You are an AI Operations specialist tasked with setting up a training pipeline for a deep learning model. The pipeline must enable smooth integration with NVIDIA Triton Inference Server for model serving after training. Which of the following steps is critical for ensuring compatibility with Triton when setting up the pipeline?",
+    "a": [
+      "Ensure the model is exported to an ONNX or TensorFlow SavedModel format that is compatible with Triton.",
+      "Configure the training pipeline to include quantization-aware training.",
+      "Use a data loader that streams real-time data from Triton during training.",
+      "Install Triton Inference Server on the same machine where training is performed."
+    ],
+    "c": [
+      0
+    ],
+    "set": "Set 5"
+  }
+];
+const SETS = ["Set 1", "Set 2", "Set 3", "Set 4", "Set 5"];
+
+const quiz = document.getElementById('quiz');
+const scoreEl = document.getElementById('score');
+let activeSet = 'all';  // 'all' or a set name like 'set1'
+
+function letter(i) { return String.fromCharCode(65 + i); }
+
+function renderQuestion(q, qi) {
+  const isMulti = !!q.multi;
+  const type = isMulti ? 'checkbox' : 'radio';
+  const opts = q.a.map((text, oi) => `
+    <li>
+      <label data-qi="${qi}" data-oi="${oi}">
+        <input type="${type}" name="q${qi}" value="${oi}">
+        <strong>${letter(oi)}.</strong> ${escapeHtml(text)}
+      </label>
+    </li>`).join('');
+  const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
+  const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
+  const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  return `
+    <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
+      <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
+      <ul class="opts">${opts}</ul>
+      <div class="actions">
+        <button data-check="${qi}">Check</button>
+        <button data-reset="${qi}">Reset</button>
+      </div>
+    </div>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  })[c]);
+}
+
+function checkQuestion(qi) {
+  const q = QUESTIONS[qi];
+  const correct = new Set(q.c);
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    const oi = +label.dataset.oi;
+    const input = label.querySelector('input');
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    if (input.checked) {
+      if (correct.has(oi)) label.classList.add('correct');
+      else label.classList.add('wrong');
+    } else if (correct.has(oi)) {
+      label.classList.add('reveal-correct');
+    }
+  });
+  updateScore();
+}
+
+function resetQuestion(qi) {
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    label.querySelector('input').checked = false;
+  });
+  updateScore();
+}
+
+function inActiveSet(q) {
+  return activeSet === 'all' || q.set === activeSet;
+}
+
+function updateScore() {
+  let answered = 0, correct = 0, total = 0;
+  QUESTIONS.forEach((q, qi) => {
+    if (!inActiveSet(q)) return;
+    total++;
+    const inputs = document.querySelectorAll(`#q${qi} input`);
+    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    if (picked.length === 0) return;
+    answered++;
+    const expected = new Set(q.c);
+    const isExactMatch =
+      picked.length === expected.size &&
+      picked.every(p => expected.has(p));
+    if (isExactMatch) correct++;
+  });
+  const label = activeSet === 'all' ? 'overall' : activeSet;
+  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+}
+
+function applyFilter() {
+  QUESTIONS.forEach((q, qi) => {
+    const el = document.getElementById(`q${qi}`);
+    if (!el) return;
+    el.classList.toggle('hidden', !inActiveSet(q));
+  });
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.set === activeSet);
+  });
+  updateScore();
+}
+
+// ── Cache: persist answers + checked state across reloads ────────────────────
+const CACHE_KEY = 'quiz-cache-ncp-aio-practice-tests';
+
+function saveCache() {
+  const answers = {};   // qi -> [oi, ...]
+  const checked = {};   // qi -> true
+  QUESTIONS.forEach((q, qi) => {
+    const picked = [...document.querySelectorAll(`#q${qi} input:checked`)]
+      .map(i => +i.value);
+    if (picked.length) answers[qi] = picked;
+    // A question is "checked" if any label has a result class.
+    const el = document.getElementById(`q${qi}`);
+    if (el && el.querySelector('.correct, .wrong, .reveal-correct')) checked[qi] = true;
+  });
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ answers, checked })); } catch(_) {}
+}
+
+function loadCache() {
+  let cache;
+  try { cache = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch(_) {}
+  if (!cache) return;
+  const { answers = {}, checked = {} } = cache;
+  // Restore selections first.
+  Object.entries(answers).forEach(([qi, ois]) => {
+    ois.forEach(oi => {
+      const input = document.querySelector(`#q${qi} input[value="${oi}"]`);
+      if (input) input.checked = true;
+    });
+  });
+  // Restore checked visual state.
+  Object.keys(checked).forEach(qi => checkQuestion(+qi));
+}
+
+quiz.innerHTML = QUESTIONS.map(renderQuestion).join('');
+
+// Restore cache after DOM is built.
+loadCache();
+
+quiz.addEventListener('click', e => {
+  const t = e.target;
+  if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
+  else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+});
+quiz.addEventListener('change', () => { updateScore(); saveCache(); });
+
+document.getElementById('checkAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) checkQuestion(qi); });
+  saveCache();
+});
+document.getElementById('resetAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  saveCache();
+});
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    activeSet = tab.dataset.set;
+    applyFilter();
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  });
+});
+
+if (SETS.length > 1) applyFilter();
+else updateScore();
+
+// Dark-mode toggle. Persists across reloads in localStorage but falls back
+// to prefers-color-scheme when no preference is stored.
+const THEME_KEY = 'quiz-theme';
+function applyTheme(theme) {
+  const html = document.documentElement;
+  if (theme === 'dark' || theme === 'light') {
+    html.setAttribute('data-theme', theme);
+  } else {
+    html.removeAttribute('data-theme');
+  }
+  const isDark = theme === 'dark'
+    || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.getElementById('themeIcon').textContent = isDark ? '☀️' : '🌙';
+  document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+}
+applyTheme(localStorage.getItem(THEME_KEY));
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const isCurrentlyDark = current === 'dark'
+    || (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const next = isCurrentlyDark ? 'light' : 'dark';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+});
+</script>
+</body>
+</html>

--- a/public/ncp-aio/index.html
+++ b/public/ncp-aio/index.html
@@ -142,7 +142,25 @@
     border-bottom: 1px solid var(--border);
     font-weight: bold;
     z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    flex-wrap: wrap;
   }
+  #scoreText .ok { color: var(--reveal); }
+  #scoreText .ko { color: var(--wrong-border); }
+  #reviewWrong {
+    font-size: .85rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  #reviewWrong.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  #reviewWrong:disabled { opacity: .5; cursor: default; }
   .multi-tag {
     font-size: .75rem;
     background: var(--multi-bg);
@@ -192,6 +210,26 @@
     align-items: center;
     gap: .35rem;
   }
+  .explanation {
+    margin-top: .85rem;
+    padding: .7rem .95rem;
+    border-left: 3px solid var(--accent);
+    background: var(--hover);
+    border-radius: 6px;
+    font-size: .9rem;
+    color: var(--fg);
+    white-space: pre-wrap;
+  }
+  .explanation[hidden] { display: none; }
+  .explanation .exp-label {
+    display: block;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: .3rem;
+    text-transform: uppercase;
+    font-size: .7rem;
+    letter-spacing: .05em;
+  }
 </style>
 </head>
 <body>
@@ -208,13 +246,16 @@
 <p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
 <div class="tabs">
 <button class="tab active" data-set="all">All</button>
-<button class="tab" data-set="Set 1">Exam 1</button>
-<button class="tab" data-set="Set 2">Exam 2</button>
-<button class="tab" data-set="Set 3">Exam 3</button>
-<button class="tab" data-set="Set 4">Exam 4</button>
-<button class="tab" data-set="Set 5">Exam 5</button>
+<button class="tab" data-set="Set 1">Set 1</button>
+<button class="tab" data-set="Set 2">Set 2</button>
+<button class="tab" data-set="Set 3">Set 3</button>
+<button class="tab" data-set="Set 4">Set 4</button>
+<button class="tab" data-set="Set 5">Set 5</button>
 </div>
-<div id="score">Score: 0 / 0 answered</div>
+<div id="score">
+  <span id="scoreText">Score: 0 / 0 answered</span>
+  <button id="reviewWrong" type="button" disabled>Review wrong (0)</button>
+</div>
 <div id="quiz"></div>
 <div class="actions" style="margin: 2rem 0;">
   <button id="checkAll" class="primary">Check all</button>
@@ -4219,8 +4260,9 @@ const QUESTIONS = [
 const SETS = ["Set 1", "Set 2", "Set 3", "Set 4", "Set 5"];
 
 const quiz = document.getElementById('quiz');
-const scoreEl = document.getElementById('score');
+const scoreEl = document.getElementById('scoreText');
 let activeSet = 'all';  // 'all' or a set name like 'set1'
+let reviewWrong = false;  // when true, show only answered-incorrectly questions
 
 function letter(i) { return String.fromCharCode(65 + i); }
 
@@ -4237,6 +4279,10 @@ function renderQuestion(q, qi) {
   const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
   const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
   const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  const expHtml = q.e
+    ? `<div class="explanation" id="exp${qi}" hidden><span class="exp-label">Explanation</span>${escapeHtml(q.e)}</div>`
+    : '';
+  const expBtn = q.e ? `<button data-explain="${qi}">Explanation</button>` : '';
   return `
     <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
       <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
@@ -4244,7 +4290,9 @@ function renderQuestion(q, qi) {
       <div class="actions">
         <button data-check="${qi}">Check</button>
         <button data-reset="${qi}">Reset</button>
+        ${expBtn}
       </div>
+      ${expHtml}
     </div>`;
 }
 
@@ -4268,6 +4316,8 @@ function checkQuestion(qi) {
       label.classList.add('reveal-correct');
     }
   });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = false;
   updateScore();
 }
 
@@ -4276,6 +4326,8 @@ function resetQuestion(qi) {
     label.classList.remove('correct', 'wrong', 'reveal-correct');
     label.querySelector('input').checked = false;
   });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = true;
   updateScore();
 }
 
@@ -4283,30 +4335,52 @@ function inActiveSet(q) {
   return activeSet === 'all' || q.set === activeSet;
 }
 
+function pickedFor(qi) {
+  return [...document.querySelectorAll(`#q${qi} input`)]
+    .filter(i => i.checked).map(i => +i.value);
+}
+
+function isExact(qi, picked) {
+  const expected = new Set(QUESTIONS[qi].c);
+  return picked.length === expected.size && picked.every(p => expected.has(p));
+}
+
+// A question counts as "wrong" once it has a selection that is not an exact match.
+function isWrongAnswered(qi) {
+  const picked = pickedFor(qi);
+  return picked.length > 0 && !isExact(qi, picked);
+}
+
 function updateScore() {
   let answered = 0, correct = 0, total = 0;
   QUESTIONS.forEach((q, qi) => {
     if (!inActiveSet(q)) return;
     total++;
-    const inputs = document.querySelectorAll(`#q${qi} input`);
-    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    const picked = pickedFor(qi);
     if (picked.length === 0) return;
     answered++;
-    const expected = new Set(q.c);
-    const isExactMatch =
-      picked.length === expected.size &&
-      picked.every(p => expected.has(p));
-    if (isExactMatch) correct++;
+    if (isExact(qi, picked)) correct++;
   });
+  const wrong = answered - correct;
   const label = activeSet === 'all' ? 'overall' : activeSet;
-  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+  scoreEl.innerHTML =
+    `<span class="ok">${correct} correct</span> · ` +
+    `<span class="ko">${wrong} wrong</span> · ` +
+    `${answered}/${total} answered (${label})`;
+  const reviewBtn = document.getElementById('reviewWrong');
+  if (reviewBtn) {
+    reviewBtn.textContent = reviewWrong ? `Show all (${wrong} wrong)` : `Review wrong (${wrong})`;
+    reviewBtn.classList.toggle('active', reviewWrong);
+    reviewBtn.disabled = wrong === 0 && !reviewWrong;
+  }
 }
 
 function applyFilter() {
   QUESTIONS.forEach((q, qi) => {
     const el = document.getElementById(`q${qi}`);
     if (!el) return;
-    el.classList.toggle('hidden', !inActiveSet(q));
+    const visible = inActiveSet(q) && (!reviewWrong || isWrongAnswered(qi));
+    el.classList.toggle('hidden', !visible);
   });
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.set === activeSet);
@@ -4356,6 +4430,10 @@ quiz.addEventListener('click', e => {
   const t = e.target;
   if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
   else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+  else if (t.matches('[data-explain]')) {
+    const ex = document.getElementById(`exp${t.dataset.explain}`);
+    if (ex) ex.hidden = !ex.hidden;
+  }
 });
 quiz.addEventListener('change', () => { updateScore(); saveCache(); });
 
@@ -4365,7 +4443,20 @@ document.getElementById('checkAll').addEventListener('click', () => {
 });
 document.getElementById('resetAll').addEventListener('click', () => {
   QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  reviewWrong = false;
+  applyFilter();
   saveCache();
+});
+
+document.getElementById('reviewWrong').addEventListener('click', () => {
+  reviewWrong = !reviewWrong;
+  if (reviewWrong) {
+    // Reveal correct answers on the wrong questions so they can be reviewed.
+    QUESTIONS.forEach((q, qi) => { if (inActiveSet(q) && isWrongAnswered(qi)) checkQuestion(qi); });
+    saveCache();
+  }
+  applyFilter();
+  window.scrollTo({ top: 0, behavior: 'instant' });
 });
 
 document.querySelectorAll('.tab').forEach(tab => {

--- a/public/ncp-ousd/index.html
+++ b/public/ncp-ousd/index.html
@@ -1,0 +1,1388 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NCP-OUSD Practice Test</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --border: #ddd;
+    --hover: rgba(0, 0, 0, 0.04);
+    --card: #fafafa;
+    --accent: #2563eb;
+    --correct-bg: #16a34a;
+    --correct-fg: #ffffff;
+    --correct-border: #15803d;
+    --wrong-bg: #dc2626;
+    --wrong-fg: #ffffff;
+    --wrong-border: #b91c1c;
+    --reveal: #16a34a;
+    --multi-bg: #2563eb;
+  }
+  html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --fg: #e7e9ee;
+    --muted: #9aa3b2;
+    --border: #2a2f3a;
+    --hover: rgba(255, 255, 255, 0.05);
+    --card: #161a21;
+    --accent: #60a5fa;
+    --correct-bg: #166534;
+    --correct-fg: #ecfdf5;
+    --correct-border: #22c55e;
+    --wrong-bg: #7f1d1d;
+    --wrong-fg: #fee2e2;
+    --wrong-border: #ef4444;
+    --reveal: #22c55e;
+    --multi-bg: #3b82f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme]) {
+      color-scheme: dark;
+      --bg: #0f1115;
+      --fg: #e7e9ee;
+      --muted: #9aa3b2;
+      --border: #2a2f3a;
+      --hover: rgba(255, 255, 255, 0.05);
+      --card: #161a21;
+      --accent: #60a5fa;
+      --correct-bg: #166534;
+      --correct-fg: #ecfdf5;
+      --correct-border: #22c55e;
+      --wrong-bg: #7f1d1d;
+      --wrong-fg: #fee2e2;
+      --wrong-border: #ef4444;
+      --reveal: #22c55e;
+      --multi-bg: #3b82f6;
+    }
+  }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    max-width: 880px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .subtitle { color: var(--muted); margin: 0 0 1rem; }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .q {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    background: var(--card);
+  }
+  .q h2 { font-size: 1rem; margin: 0 0 .75rem; }
+  .opts { list-style: none; padding: 0; margin: 0; }
+  .opts li { margin: .35rem 0; }
+  .opts label {
+    display: block;
+    padding: .5rem .75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    color: var(--fg);
+  }
+  .opts label:hover { background: var(--hover); }
+  .opts input { margin-right: .5rem; }
+  .opts label.correct {
+    background: var(--correct-bg);
+    color: var(--correct-fg);
+    border-color: var(--correct-border);
+  }
+  .opts label.wrong {
+    background: var(--wrong-bg);
+    color: var(--wrong-fg);
+    border-color: var(--wrong-border);
+  }
+  .opts label.reveal-correct { outline: 2px dashed var(--reveal); }
+  .actions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+    margin-top: .75rem;
+  }
+  button {
+    padding: .4rem .8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--fg);
+    cursor: pointer;
+    font: inherit;
+  }
+  button:hover { background: var(--hover); }
+  button.primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  button.primary:hover { filter: brightness(1.1); }
+  .note { font-size: .85rem; color: var(--muted); }
+  #score {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: .5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-weight: bold;
+    z-index: 10;
+  }
+  .multi-tag {
+    font-size: .75rem;
+    background: var(--multi-bg);
+    color: white;
+    padding: .1rem .4rem;
+    border-radius: 3px;
+    margin-left: .5rem;
+    vertical-align: middle;
+  }
+  .set-tag {
+    font-size: .7rem;
+    color: var(--muted);
+    margin-left: .5rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+  }
+  .tabs {
+    display: flex;
+    gap: .25rem;
+    flex-wrap: wrap;
+    margin: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: .5rem;
+  }
+  .tab {
+    padding: .35rem .7rem;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: .9rem;
+  }
+  .tab:hover { background: var(--hover); color: var(--fg); }
+  .tab.active {
+    background: var(--card);
+    border-color: var(--border);
+    border-bottom-color: var(--card);
+    color: var(--fg);
+    font-weight: 600;
+  }
+  .q.hidden { display: none; }
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+  .explanation {
+    margin-top: .85rem;
+    padding: .7rem .95rem;
+    border-left: 3px solid var(--accent);
+    background: var(--hover);
+    border-radius: 6px;
+    font-size: .9rem;
+    color: var(--fg);
+    white-space: pre-wrap;
+  }
+  .explanation[hidden] { display: none; }
+  .explanation .exp-label {
+    display: block;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: .3rem;
+    text-transform: uppercase;
+    font-size: .7rem;
+    letter-spacing: .05em;
+  }
+</style>
+</head>
+<body>
+<div class="toolbar">
+  <div>
+    <h1>NCP-OUSD Practice Test</h1>
+    <p class="subtitle">NVIDIA OpenUSD Development Exam - 71 questions with explanations</p>
+  </div>
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">
+    <span id="themeIcon">🌙</span>
+    <span id="themeLabel">Dark</span>
+  </button>
+</div>
+<p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
+
+<div id="score">Score: 0 / 0 answered</div>
+<div id="quiz"></div>
+<div class="actions" style="margin: 2rem 0;">
+  <button id="checkAll" class="primary">Check all</button>
+  <button id="resetAll">Reset</button>
+</div>
+
+<script>
+const QUESTIONS = [
+  {
+    "q": "Which of the following statements best describes the purpose of OpenUSD file format plugins?",
+    "a": [
+      "They extend OpenUSD's functionality by allowing it to read and write from various file formats.",
+      "They are only used for visualizing OpenUSD data and geometry in 3D applications.",
+      "They convert OpenUSD files to other formats without any loss of data or information.",
+      "They are designed to compress OpenUSD asset files for faster loading times."
+    ],
+    "c": [
+      0
+    ],
+    "e": "OpenUSD file format plugins belong under the Data Exchange topic because they expand how USD participates in interchange workflows. Their purpose is to allow OpenUSD to read, interpret, and in some cases write data using formats beyond the native USD file types such as .usd, .usda, .usdc, and .usdz. Through these plugins, external file formats can be exposed to USD as layers and can participate in composition arcs such as references, payloads, and sublayers. This allows pipelines to integrate heterogeneous asset sources while still using USD’s scene description model, composition engine, and layer-based workflows. Option A is correct because it directly identifies the function of file format plugins: extending OpenUSD functionality for reading and writing various file formats. Option B is incorrect because visualization is only one possible downstream use of exchanged data, not the purpose of the plugin system. Option C is incorrect because translation between formats does not inherently guarantee lossless preservation of every schema, opinion, or semantic construct. Option D is incorrect because compression is not the primary role of file format plugins. This aligns with the NVIDIA OpenUSD Development Study Guide topic Data Exchange, especially file formats, connectors, and plugin-based interoperability."
+  },
+  {
+    "q": "You are a developer creating an OpenUSD exporter for an application that also supports import of USD assets. To enable collaborative workflows, you're adding an \"export as overrides\" option. Which approach correctly describes which structure your exporter should generate?",
+    "a": [
+      "Overs of the prims and properties that have been modified or added, omitting unchanged data.",
+      "Export each prim separately into multiple layers, and reference them individually to maintain sparsity.",
+      "Include explicit definitions of all prims, properties, and relationships exactly matching the imported asset to ensure consistency."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The correct exporter behavior is to generate sparse overrides that represent only the authored contribution of the current workstream. In OpenUSD data exchange workflows, an exporter should not blindly rewrite the full imported asset when the intent is to preserve collaborative, non- destructive editing. Instead, the exporter should author only the changes required to express the current application’s contribution: modified prims, newly added prims, changed attributes, relationships, metadata, or other authored opinions. Option A is correct because an over is specifically used to contribute opinions to an existing prim without redefining the entire prim structure. This allows the exported layer to sit above the source asset in a layer stack and override only the relevant data. Option B incorrectly equates sparsity with splitting each prim into separate referenced layers; USD sparsity is achieved by authoring minimal opinions, not by unnecessary layer fragmentation. Option C is incorrect because exporting full definitions for every prim and property would duplicate unchanged data, reduce clarity, and undermine USD’s composition-based collaboration model. This maps to the NVIDIA OpenUSD Development Study Guide topics Data Exchange, especially exporter design, data transformation, sparse authoring, and collaborative layer-based workflows."
+  },
+  {
+    "q": "In what way do variant sets in OpenUSD enhance flexibility in scene descriptions?",
+    "a": [
+      "By allowing runtime selection among alternative representations of a prim.",
+      "By permanently embedding multiple scene configurations within a single prim.",
+      "By enabling automatic resolution of conflicting opinions across layers.",
+      "By statically merging all possible variants into one combined representation."
+    ],
+    "c": [
+      0
+    ],
+    "e": "Variant sets enhance flexibility by allowing a prim to expose named alternatives, where one variant selection contributes its authored opinions to the composed result. NVIDIA’s Learn OpenUSD material describes variant sets as a way to define “alternative representations for a prim and switch between them without duplicating data.” It also explains that a prim may have one or more named variant sets, each containing variant choices, and that the selected variant composes the opinions authored for that choice. Option A is correct because variant sets support selectable alternatives such as different model shapes, material looks, levels of detail, configurations, or composition arcs. This gives downstream tools or stronger layers the ability to choose a representation non-destructively without rewriting the asset. Option B is inaccurate because variants are not permanently merged into the prim; only the selected variant participates in the composed scene. Option C is incorrect because conflict resolution is handled by USD’s composition and value-resolution rules, not automatically by variant sets themselves. Option D is also incorrect because USD does not statically combine every variant into a single representation. This aligns with the NVIDIA OpenUSD Development Study Guide topics Composition → Variant Sets, Composition Arcs, and LIVERPS strength ordering."
+  },
+  {
+    "q": "In OpenUSD, which USDA snippet correctly uses a payload to reference an external asset while allowing deferred loading?",
+    "a": [
+      "def \"Character\" (prepend payload = @character .usda@){ }",
+      "def \"Character\" { prepend payloads = @character .usd@}",
+      "def Xform \"Character\" (reference = @character .usda@){ }",
+      "def Xform \"Character\" (payload = @character .usd@){ }"
+    ],
+    "c": [
+      0
+    ],
+    "e": "Option A is the correct USDA pattern because a payload is authored as prim metadata using the singular payload keyword with a list-editing operation such as prepend. NVIDIA’s Learn OpenUSD payload exercise shows the canonical USDA form: prepend payload = @./red_cube.usd@, authored on the prim declaration. It further explains that payloads are similar to references in USDA, with the important distinction that the keyword is payload rather than references. The key technical purpose of a payload is deferred loading. NVIDIA explains that payloads can compose scene description when loaded, or unload the targeted scene description beneath the payloaded prim. It also contrasts this with references, which are always composed and present on the stage, while payloads can be opened unloaded and selectively loaded later . Option B is incorrect because payloads is not the USDA keyword and it is not authored as a property inside the prim body. Option C uses a reference, not a payload, so it does not provide payload load/unload behavior .Option D is not the canonical list-op form expected here. This aligns with Composition → Reference and Payloads → Working With Payloads."
+  },
+  {
+    "q": "Which of these are valid types for custom attributes in OpenUSD? (Choose two.)",
+    "a": [
+      "structs",
+      "assset paths",
+      "string arrays",
+      "dictionaries"
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "e": "Custom attributes in OpenUSD are user-defined properties authored on prims to store additional typed data beyond predefined schema attributes. NVIDIA’s Learn OpenUSD material states that custom attributes can hold “numeric values, strings, or arrays,” and that custom attributes are created with UsdPrim::CreateAttribute(), where Sdf.ValueTypeNamesrepresents the attribute type. NVIDIA’s OpenUSD data type reference lists Asset with the USDA value type token asset, and StringArray with the USDA token string[], making asset paths and string arrays valid attribute value types. Option B is correct because asset path values are represented through the asset value type and are commonly used for resource references such as textures or external asset identifiers. Option C is correct because string[] is a valid array value type. Option A is incorrect because USD does not have a native struct attribute type; NVIDIA recommends namespace-prefixed attributes for mapping grouped or compound fields. Option D is incorrect in this context because dictionaries are associated with metadata/customData patterns, not ordinary typed custom attributes. This aligns with Customizing USD → Custom Properties, Sdf.ValueTypeNames, Namespaced Attributes."
+  },
+  {
+    "q": "What is the primary purpose of asset structure in OpenUSD?",
+    "a": [
+      "To simplify version control through standardized asset management and tracking",
+      "To maximize rendering performance through optimized data organization and caching",
+      "To empower the scalability of an organization and ecosystem and promote collaboration",
+      "To reduce storage requirements through efficient resource sharing and deduplication"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The primary purpose of asset structure in OpenUSD is to make content scalable, collaborative, reusable, and understandable across teams and ecosystems. NVIDIA’s Learn OpenUSD guide defines an asset as a “named, versioned, and structured container” that may include composable OpenUSD layers, textures, volumetric data, and other resources. It further states that asset structure facilitates reuse of persistent data and plays an important role in scaling pipelines and ecosystems. The guide emphasizes content flow, seamless collaboration, consistent conventions, parallel and modular workflows, and balancing openness with resilience to change. Option C is correct because it captures the broad organizational goal of asset structure: enabling scalability and collaboration across multiple contributors, workstreams, and downstream consumers. Option A is too narrow; versioning and tracking may be supported by asset metadata or asset management systems, but they are not the central purpose of asset structure. Option B is also too narrow because performance is one principle of scalable structure, not the whole purpose. Option D describes a possible benefit of modularity and reuse, but storage reduction is secondary. This aligns with Content Aggregation → Asset Structure Principles → Why Asset Structure Is Necessary → Legibility, Modularity, Performance, Navigability."
+  },
+  {
+    "q": "When prioritizing ease of interchange and reducing dependencies between different applications in a pipeline, why might codeless schemas, schemas defined purely in .usda files, be preferred over codeful schemas, schemas with generated classes using usdGenSchema?",
+    "a": [
+      "Codeless schemas enable interchange by loading .usda definitions directly, avoiding the need to compile or link against custom schema code libraries.",
+      "Codeless schemas provide more convenient, strongly-typed C++ and Python APIs for property access compared to code generated via usdGenSchema.",
+      "Generated schemas cannot define fallback attribute values within their .usda definition, making interchange less consistent across applications.",
+      "Only codeless schemas are added to the schema registry, allowing them to participate in property value resolution correctly."
+    ],
+    "c": [
+      0
+    ],
+    "e": "Codeless schemas are preferred when the pipeline goal is portability, easy distribution, and reduced application coupling. NVIDIA’s Learn OpenUSD schema guidance states that schemas define data models and optional APIs for encoding and interchanging 3D and non-3D concepts, and notes a trend toward codeless schemas for easier distribution, with schemas becoming more focused on data modeling rather than behavior implementation. Option A is correct because a codeless schema can be distributed as schema data and plugin metadata without requiring every consuming application to compile, link, or ship custom generated C++/Python schema classes. OpenUSD’s schema-generation documentation identifies codeless schemas as schemas produced without corresponding C++ classes, where only generatedSchema.usda and plugInfo.json are essential for runtime registration. Option B is incorrect because strongly typed convenience APIs are the advantage of codeful generated schemas. Option C is incorrect because fallback values are authored in schema definitions. Option D is incorrect because codeful and codeless schemas can both participate in schema registration and value interpretation. This aligns with Customizing USD → Schemas, API Schemas, Codeless Schemas, Schema Registry, Data Modeling for Interchange."
+  },
+  {
+    "q": "You and your colleague open the same USD layer but one of you observes missing geometry. What could be the reason why?",
+    "a": [
+      "USD automatically adjusts composition based on available system memory.",
+      "Instance prototypes are composing to different identifiers.",
+      "Differently configured asset resolvers are resolving to different versions of the asset."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The most plausible cause is that the two environments are resolving asset identifiers differently. NVIDIA’s Learn OpenUSD glossary defines asset resolution as the process of translating an asset path into the actual location of a consumable resource, and identifies ArResolver as the plugin point that can be customized to resolve assets through site logic, databases, or version-control systems. Option C is correct because the same authored USD layer can contain references, payloads, textures, or other asset-valued paths that are resolved at runtime. If one user’s resolver context maps @character .usd@to version 12 while another maps it to version 15, or if one environment cannot resolve a dependency at all, the composed stage can differ .This can manifest as missing geometry, stale geometry, missing materials, or unresolved payloads. Reference and payloads are composition arcs that bring external scene description into the stage, so resolution differences directly affect what data is available for composition. Option A is incorrect because USD does not change composition semantics based on available memory. Option B is not the primary explanation here; instance prototypes are derived from composed instance data, but the root problem described is inconsistent asset resolution. This aligns with Debugging and Troubleshooting → Asset Resolution, Reference, Payloads, Resolver Contexts, Missing Dependencies."
+  },
+  {
+    "q": "Which of these is a viable approach for mapping or grouping compound types from other data sources to OpenUSD?",
+    "a": [
+      "arrays",
+      "namespace-prefixed attributes",
+      "structs"
+    ],
+    "c": [
+      1
+    ],
+    "e": "Namespace-prefixed attributes are the correct approach for representing grouped or compound source data in OpenUSD. NVIDIA’s Learn OpenUSD data extraction guidance states that when source formats contain compound or grouped data types, such as structs, records, or grouped fields, namespace-prefixed attributes provide the convention for grouping related properties together in USD. It also states that USD does not have a native struct type, so namespace-prefixed attributes serve as the standard approach for representing this kind of grouped data. Option B is correct because attributes such as acme:sensor:temperature, acme:sensor:humidity, and acme:sensor:pressure can express ownership and logical grouping while remaining ordinary USD attributes with valid scalar or array value types. NVIDIA’s custom properties lesson reinforces this pattern, explaining that namespace prefixes logically group related properties on a single prim and are especially useful when mapping structured data types from other formats into USD. Option A is incomplete because arrays represent repeated values, not named compound fields. Option C is incorrect because USD does not provide a native struct attribute type. This aligns with Data Exchange → Data Extraction, Conceptual Data Mapping, Custom Properties, Namespace- Prefixed Attributes."
+  },
+  {
+    "q": "What is the only reliable way in OpenUSD of encoding the motion of primitives whose topology is varying over time?",
+    "a": [
+      "positions",
+      "velocities",
+      "orientations"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The reliable encoding mechanism is velocities. OpenUSD attributes may vary over time through time samples, but position interpolation assumes correspondence between sampled array elements. When topology changes over time, adjacent samples may not contain the same number of points, and even matching indices may no longer identify the same physical point. NVIDIA’s Learn OpenUSD glossary defines variability as whether a property can change over time, with varying attributes supporting time samples and interpolation behavior .(docs.nvidia.com) The OpenUSD geometry specification is explicit: “Using velocities is the only reliable way of encoding the motion of primitives whose topology is varying over time,” because neighboring sample indices may be unrelated or may not have the same element count. (openusd.org) Option B is therefore correct. Positions alone are insufficient when topology changes, because linear interpolation between position arrays depends on stable point correspondence. Orientations describe rotational state, commonly relevant to transforms or instancing, but they do not solve topology-varying point motion. This maps to Data Modeling → Time Samples, Attribute Variability, UsdGeom Point-Based Motion, Velocities, and Animated Geometry."
+  },
+  {
+    "q": "Which of the following statements about OpenUSD plugin development are true? Choose two.",
+    "a": [
+      "File format plugins are responsible for translating foreign file formats into OpenUSD-compatible data.",
+      "Custom plugins can extend OpenUSD by adding new data types and behaviors.",
+      "OpenUSD plugins can be developed as Python-only plugins for faster, iterative development.",
+      "All plugins require recompiling USD so that they can be used and recognized by USD."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "e": "OpenUSD’s plugin architecture is a major customization mechanism. Option A is correct because NVIDIA’s Learn OpenUSD Data Exchange material states that file format plugins allow OpenUSD to compose with additional file formats and non-file-based sources, translating the source format on the fly as a USD layer .It also notes that file format plugins may be bidirectional, supporting both reading and writing. (docs.nvidia.com) Option B is also correct because custom plugins can extend OpenUSD beyond built-in behavior . NVIDIA’s OpenUSD plugin samples include schemas, both codeful and codeless, file format plugins, dynamic payloads, and Hydra scene indices, demonstrating plugin-based extension of data models and runtime behavior .(github.com) Option C is not the best general statement for OpenUSD development certification in this context. Some tooling-level plugin systems can use Python, but core extensibility such as schema libraries and file format plugins commonly depends on plugin metadata and compiled libraries or generated schema artifacts. Option D is false because plugins are discovered through plugin registration metadata, such as plugInfo.json, and do not require recompiling USD itself. This aligns with Customizing USD → Plugins, Schemas, File Format Plugins, plugInfo.json, and Extensibility."
+  },
+  {
+    "q": "Which of the following values are valid for imageable purpose? Choose three.",
+    "a": [
+      "guide, for prims that should be included for guides or reference",
+      "light, for prims that should be included for lighting and shadows",
+      "render, for prims that should be included for \"final\" quality renders",
+      "material, for prims that should be included for shading geometry",
+      "proxy, for prims that should be included for proxy representation"
+    ],
+    "c": [
+      0,
+      2,
+      4
+    ],
+    "multi": true,
+    "e": "The valid imageable purpose values among the options are guide, render, and proxy. NVIDIA’s Learn OpenUSD glossary describes purpose as a UsdGeomImageable attribute used to classify geometry into visibility categories that can gate traversals such as rendering or bounding-box computation. It lists purpose values including default, render, proxy, and guide. (docs.nvidia.com) Option A is correct because guide is used for guide or helper geometry that should generally appear only when an interactive application has been asked to display guides. Option C is correct because render identifies final-quality render geometry. Option E is correct because proxy identifies lightweight preview or proxy representation. OpenUSD’s UsdGeomImageable documentation confirms the allowed values as default, render, proxy, and guide. (openusd.org) Option B is incorrect because lights are represented through lighting schemas, not as an imageable purpose token. Option D is incorrect because materials and shading assignments are represented through UsdShade schemas and relationships, not through imageable purpose. This maps to Visualization → Imageable Purpose, Render/Proxy/Guide Geometry, Hydra Traversal, and Display Filtering."
+  },
+  {
+    "q": "How does the concept of an edit target (Usd.EditTarget) interact with the stage in OpenUSD?",
+    "a": [
+      "It merges edits across all layers automatically for simplified editing of a stage.",
+      "It overrides all layers, forcing every change to be written to the root layer .",
+      "It specifies the destination layer for authoring changes in a composed stage.",
+      "It temporarily disables all sublayer compositions during editing."
+    ],
+    "c": [
+      2
+    ],
+    "e": "An edit target determines where authored opinions are written while working through the composed view of a stage. NVIDIA’s Learn OpenUSD stage material emphasizes that a stage is not simply a file; it is a unified scenegraph populated from multiple data sources called layers. (docs.nvidia.com) In that layered environment, a developer often edits a composed prim while needing the resulting opinion to land in a specific contributing layer, variant, or composition context. OpenUSD defines this role through UsdEditTarget: edit targets allow work on the composed stage and its UsdPrim objects while specifying which contributing site in the composition network should receive the authored opinions. (openusd.org) Option C is correct because the edit target is the authoring destination, not a composition override mechanism. Option A is incorrect because USD does not automatically merge edits into all layers. Option B is incorrect because edits are not forced to the root layer; developers can target other valid layers or edit contexts. Option D is incorrect because setting an edit target does not disable sublayers or composition arcs. This aligns with Pipeline Development → Layer Authoring, Edit Targets, Non- Destructive Editing, Stage Workflows, and Collaborative Layer Stacks."
+  },
+  {
+    "q": "Which statement correctly describes how UsdGeomSubsets can be used to organize geometry for specific material assignments or rendering attributes in OpenUSD?",
+    "a": [
+      "They partition a single UsdGeomMesh into distinct groups that can have materials independently bound to them.",
+      "They can provide finer-grained control of UsdGeomImageable properties, e.g. visibility or purpose, on subsets of faces.",
+      "They force a mesh to be tessellated at the boundary of each subset for improved visual quality.",
+      "They must be defined at the root OpenUSD stage level for them to apply to any mesh."
+    ],
+    "c": [
+      0
+    ],
+    "e": "UsdGeomSubset is used to identify subsets of a geometric primitive, most commonly groups of mesh faces, so that those groups can receive independent material bindings or other subset-level organization. The OpenUSD API states that materials are bound to GeomSubsets using the same UsdShade material-binding mechanisms used for regular geometry. It also states that a GeomSubset must be a direct child of the geometric prim it applies to, making discovery efficient and clearly scoped to that geometry. Option A is correct because a single mesh can be partitioned into face groups, and each subset can be assigned a different material. Option B is incorrect because UsdGeomSubset is not a UsdGeomImageable; therefore, imageable properties such as visibility or purpose cannot be authored on it. Option C is incorrect because subsets classify elements; they do not force tessellation or modify mesh topology. Option D is incorrect because subsets are authored below the relevant geometric primitive, not at the root stage level. This aligns with Data Modeling → Geometry Organization, Mesh Face Subsets, UsdGeomSubset, and UsdShade Material Binding."
+  },
+  {
+    "q": "You are a developer creating an OpenUSD exporter for an application that also supports import of USD assets. To enable collaborative workflows, you're adding an “export as overrides” option. Which approach correctly describes which structure your exporter should generate?",
+    "a": [
+      "Overs of the prims and properties that have been modified or added, omitting unchanged data.",
+      "Export each prim separately into multiple layers, and reference them individually to maintain sparsity.",
+      "Include explicit definitions of all prims, properties, and relationships exactly matching the imported asset to ensure consistency."
+    ],
+    "c": [
+      0
+    ],
+    "e": "For an “export as overrides” workflow, the exporter should generate sparse authored opinions that represent only the modified or added contributions of the current workstream. NVIDIA’s Learn OpenUSD Data Transformation guidance explicitly describes this pattern: third-party developers can use the stage from raw extraction to export data as sparse overrides for multi-workstream workflows. It also explains that if an export represents one workstream within a larger asset structure, it may define new prims, apply overrides on existing prims, or both, and should distill the data down to the workstream’s unique contributions. Option A is correct because over specs and sparse property opinions preserve USD’s non-destructive composition model. They allow a stronger layer to modify the composed result without duplicating unchanged source data. Option B is incorrect because splitting each prim into separate layers is not required for sparsity and would add unnecessary composition complexity. Option C is incorrect because re-exporting the entire imported asset as full definitions would duplicate unchanged data and obscure the actual edits. This aligns with Data Exchange → Data Transformation, Export Options, Sparse Overrides, Round-Trip Exchange, and Multi-Workstream Workflows."
+  },
+  {
+    "q": "If you have a Usd.Prim object named my_prim and you want to specifically retrieve an attribute named \"size\", which method would you typically use?",
+    "a": [
+      "my_prim.GetAttribute(\"size\")",
+      "my_prim.GetRelationship(\"size\")",
+      "my_prim.GetProperty(\"size\")",
+      "my_prim.GetPrimvar(\"size\")"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The correct method is my_prim.GetAttribute(\"size\") because the question asks for a specific attribute, not a relationship or generic property. NVIDIA’s Learn OpenUSD material defines properties as the data-bearing namespace objects on prims and distinguishes two property categories: attributes and relationships. Attributes hold typed values, while relationships point to other objects in the scene description. NVIDIA’s Omniverse developer reference also states that Usd.Prim.GetAttribute() returns a Usd.Attribute, after which Usd.Attribute.Get() is used to resolve the actual authored or composed value. Option A is therefore the precise API call. Option B is incorrect because GetRelationship() retrieves relationship properties, not value-bearing attributes. Option C is less specific: GetProperty(\"size\") can retrieve either an attribute or relationship as a generic UsdProperty, requiring additional type handling. Option D is incorrect because primvars are accessed through schema-specific APIs such as UsdGeom.PrimvarsAPI, not directly as a general Usd.Prim method. This aligns with Pipeline Development → USD Python API, Property Access, Attributes, Relationships, and Scenegraph Authoring."
+  },
+  {
+    "q": "When USD computes the position of a PointInstancer instance, what additional position-related information is used beyond the position information for a given instance?",
+    "a": [
+      "USD also uses the transform of the PointInstancer prim, if present, but ignores any transforms set on the prototype root.",
+      "USD also uses the transform of the root of the prototype and the transform of the PointInstancer prim itself, if present.",
+      "USD uses position information for the instance, and ignores any position information in the prototype root, or the PointInstancer prim itself."
+    ],
+    "c": [
+      1
+    ],
+    "e": "A PointInstancer instance position is not computed from the per-instance positions array alone. NVIDIA’s Learn OpenUSD point-instancing lesson explains that authored positions are in the local coordinate space of the PointInstancer .For the final world-space transform, USD combines multiple transforms: first the prototype root transform, then the instance-specific transform components such as scales[i], orientations[i], and positions[i], and finally the transform authored on the PointInstancer prim itself. Option B is correct because it includes both additional transform sources that affect the resulting placement: the prototype root’s transform and the PointInstancer prim’s transform. This matters in production asset aggregation because prototypes may carry their own local placement or orientation, while the instancer prim may be moved, rotated, or scaled as a whole. Option A is incomplete because it incorrectly discards the prototype root transform. Option C is incorrect because it treats instance positions as isolated data and ignores the composed transform stack. This aligns with Content Aggregation → Asset Modularity and Instancing → PointInstancer, Prototype Roots, Instance Transforms, and Transform Composition."
+  },
+  {
+    "q": "What is the correct prim type in UsdShade for sharing reusable portions of shading networks, allowing for parameterization?",
+    "a": [
+      "SubNetwork",
+      "Custom Schema",
+      "NodeGraph"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The correct UsdShade prim type is NodeGraph. NVIDIA’s Learn OpenUSD material introduces UsdShade as the schema family used for creating and binding materials, where materials store renderer-facing shading definitions. The OpenUSD UsdShade specification defines UsdShadeNodeGraph as the mechanism for packaging shading networks into reusable units. A node graph can contain shader nodes and nested node graphs, expose public inputs as an interface, provide outputs, and be referenced into larger networks as a reusable building block. Option C is correct because NodeGraph is explicitly designed for reusable and parameterized shading-network structure. It allows a pipeline to encapsulate repeated shading logic while exposing only selected parameters to consuming materials or larger graphs. Option A is incorrect because SubNetwork is not the correct UsdShade prim type in OpenUSD. Option B is incorrect because a custom schema could theoretically define new data models, but it is not the standard UsdShade construct for reusable shader-network packaging. This aligns with Visualization → UsdShade, Materials, Shading Networks, NodeGraph Interfaces, Parameterization, and Reusable Material Components."
+  },
+  {
+    "q": "What key capability distinguishes an IsA schema from an API schema?",
+    "a": [
+      "An IsA schema can impart a typeName to a prim, whereas an API schema cannot.",
+      "API schemas can have relationships, while IsA schemas cannot.",
+      "IsA schemas are always concrete, while API schemas are always non-concrete."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The key distinction is that an IsA schema, also called a typed schema, defines the fundamental type of a prim through its typeName metadata. NVIDIA’s Learn OpenUSD glossary states that IsA schemas define a prim’s fundamental type through typeName, and that each prim has only one IsA schema determining its core nature, such as Mesh, Camera, or Light. NVIDIA’s schemas lesson also states that, unlike IsA schemas, API schemas do not assign a typeName; instead, they are list-edited in the apiSchemas metadata and queried using HasAPI. (NVIDIA Docs) Option A is correct because it directly identifies the defining capability of an IsA schema: imparting a prim type. API schemas instead augment already-typed prims with additional properties or behavior . Option B is incorrect because both IsA and API schemas may define attributes and relationships. Option C is incorrect because IsA schemas are not always concrete; for example, OpenUSD includes abstract typed schemas such as imageable base classes, while concrete typed schemas are instantiable prim types. This aligns with Customizing USD → Schemas, IsA Schemas, API Schemas, Schema Registry, typeName, and apiSchemas Metadata."
+  },
+  {
+    "q": "Consider the following prim hierarchies. Each prim hierarchy is represented by nested unordered lists and each list item represents a prim with the following format: PRIM_NAME (KIND). No text within the parentheses means that the kind is unset for that prim. Only evaluate model kind hierarchy correctness and the structural choices. Which prim hierarchies represent valid model kind hierarchies? Choose three.",
+    "a": [
+      "CarA (component) Interior () SteeringWheel () Chasis () Wheels () Wheel_FR () Wheel_RL ()",
+      "CarA (assembly) Interior (group) SteeringWheel (component) Chasis () Wheels (group) Wheel_FR (component) Wheel_RL (component)",
+      "CarA (component) Interior () SteeringWheel (component) Chasis () Wheels () Wheel_FR (component) Wheel_RL (component)",
+      "CarA (component) Interior () SteeringWheel (subcomponent) Chasis () Wheels (group) Wheel_FR (subcomponent) Wheel_RL (subcomponent)",
+      "CarA (component) Interior () SteeringWheel (subcomponent) Chasis () Wheels () Wheel_FR (subcomponent) Wheel_RL (subcomponent)"
+    ],
+    "c": [
+      0,
+      1,
+      4
+    ],
+    "multi": true,
+    "e": "The valid model kind hierarchies are A, B, and E. NVIDIA’s Learn OpenUSD material defines group, assembly, and component as model kinds, while subcomponent is explicitly outside the model hierarchy. The hierarchy rule is that all ancestors of a component must be group or a subkind of group, such as assembly, and a component acts as a leaf or pruning point in the model hierarchy; therefore, it cannot contain descendant model kinds such as another component, group, or assembly. (NVIDIA Docs) A is valid because CarA is a component and every descendant has unset kind, so no nested model violates the component boundary. B is valid because CarA is an assembly, organizational containers use group, and the leaf model assets are component prims. E is valid because CarA is a component, and internal important parts are marked as subcomponent, which is permitted inside a component and does not count as a model kind. C is invalid because a component contains descendant component prims. D is invalid because Wheels (group) appears under a component, placing a model kind below a component boundary. This aligns with Content Aggregation → Asset Structure → Model Hierarchy → Model Kinds."
+  },
+  {
+    "q": "Why would you not see a sphere when opening this scene? #usda 1.0 ( defaultPrim = \"wall_a_inst\" upAxis = \"Z\" ) def Xform \"wall_a_inst\" ( instanceable = true variants = { string Emissive = \"Default\" } prepend variantSets = \"Emissive\" ) { def Sphere \"Sphere\" { } variantSet \"Emissive\" = { \"Daytime\" { } \"Default\" { } } }",
+    "a": [
+      "Sphere are guide geometry that are invisible by default.",
+      "The \"Emissive\" variant set is missing the material bindings for both \"Daytime\" and \"Default\".",
+      "Because \"wall_a_inst\" has instanceable=true and a composition arc, variants, the sphere that is inside of \"wall_a_inst\" but outside of its variantset is not part of the instanced scenegraph."
+    ],
+    "c": [
+      2
+    ],
+    "e": "The sphere is not visible because the prim wall_a_inst is marked instanceable = true and also has a variant set, which is a composition arc. NVIDIA’s Learn OpenUSD instancing module states that “Instancing is driven by your composition arcs,” and explains that instanceable prims generate implicit prototypes from composed scenegraph content provided through those arcs. It also states that variant sets participate in composition and that variant selections are evaluated when OpenUSD determines which implicit prototypes to create. In this layer, the Sphere is authored as a local child of the instanceable prim, but it is outside the selected \"Emissive\" variant. Since the selected variants \"Default\" and \"Daytime\" contain no sphere definition, the composed prototype for the instance contains no visible sphere. This is an instancing/composition issue, not a visibility-purpose issue and not a material-binding issue. Option A is incorrect because the USDA does not mark the sphere as guide geometry. Option B is incorrect because missing materials would not remove the sphere from the scenegraph. Option C correctly identifies that local child opinions outside the relevant composition arc are not contributing to the instanced scenegraph. This aligns with Content Aggregation → Asset Modularity and Instancing → Scenegraph Instancing, Variant Set Refinement, and Composition Arcs."
+  },
+  {
+    "q": "Why is extract, transform, load (ETL) a useful design pattern for USD data exchange? Choose two.",
+    "a": [
+      "It guarantees that all data converted to OpenUSD is lossless and identical to the original format.",
+      "It separates concerns, making it easier to maintain and adapt data exchange pipelines for different needs.",
+      "It ensures that all OpenUSD workflows use a standardized data structure, regardless of the original format.",
+      "It helps preserve the integrity of the original data format while allowing tailoring for different use cases."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "ETL is useful for USD data exchange because it separates the problem into disciplined phases instead of forcing extraction, interpretation, optimization, and client-specific restructuring into one converter step. NVIDIA’s Learn OpenUSD data exchange guidance describes a two-phase approach, extract and transform, inspired by ETL. The extract phase should translate source data to OpenUSD as directly as possible, mapping source concepts to USD concepts to preserve the integrity and structure of the original data. The transform phase then applies optional changes such as user export options, content-structure changes, and optimizations for workflow or client performance. Option B is correct because this separation of concerns makes converters easier to maintain, test, and adapt. Option D is correct because the pattern preserves source fidelity first, then permits controlled tailoring for specific downstream needs. Option A is incorrect because NVIDIA explicitly notes that data exchange is typically lossy and not every data model maps directly. Option C is incorrect because the guide states there is no single content structure suitable for every organization or workflow. This aligns with Data Exchange → Two-Phase Data Exchange, Data Extraction, Data Transformation, Export Options, and Pipeline Adaptability."
+  },
+  {
+    "q": "In what way do variant sets in OpenUSD enhance flexibility in scene descriptions?",
+    "a": [
+      "By allowing runtime selection among alternative representations of a prim.",
+      "By permanently embedding multiple scene configurations within a single prim.",
+      "By enabling automatic resolution of conflicting opinions across layers.",
+      "By statically merging all possible variants into one combined representation."
+    ],
+    "c": [
+      0
+    ],
+    "e": "Variant sets enhance flexibility by allowing a prim to expose named alternatives, where a selected variant contributes its authored opinions into the composed scene. NVIDIA’s Learn OpenUSD guide states that variant sets define alternative representations for a prim and allow switching between them without duplicating data. Typical uses include model shapes, looks, materials, and levels of detail. It further explains that a prim can have one or more named variant sets, each containing variant choices, and that the selected variant composes the opinions authored for that variant at the prim where the variant set is defined. Option A is correct because applications, stronger layers, or session layers can select among alternatives non-destructively. Option B is misleading because variants are not permanently embedded as a single active configuration; only the selected variant participates in composition. Option C is incorrect because conflict resolution is governed by USD composition and value- resolution rules, not by variant sets alone. Option D is incorrect because USD does not merge every possible variant into one representation. This aligns with Composition → Variant Sets, Variant Selections, Composition Arcs, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "Which of the following methods allows you to edit the color of an instanceProxy mesh in OpenUSD while keeping the prim instanced?",
+    "a": [
+      "Directly modifying the instance's geometry properties.",
+      "Using primvars to change the color of the mesh or assigned material.",
+      "Creating a relationship targeting the mesh's color attribute.",
+      "Replacing the entire instance with a new mesh that has the desired color ."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The correct method is to use primvars to drive shading variation while preserving instancing. NVIDIA’s Learn OpenUSD scenegraph instance refinement guidance states that prototypes are runtime data and are not editable, instance proxies are not editable, and local opinions on instance proxies are discarded. It then identifies hierarchical refinement as the appropriate strategy for non- destructive instance variation, including inherited primvars. Primvars can drive material properties such as color, inherit down the prim hierarchy, and be authored on the instanceable prim or an ancestor so materials inside the instance subgraph can read the inherited value. Option B is correct because it changes the effective appearance without directly editing the instance proxy mesh and without disabling instancing. Option A is incorrect because directly modifying an instance proxy’s geometry properties is not allowed. Option C is incorrect because a relationship targeting a color attribute is not the standard mechanism for material color variation. Option D is incorrect because replacing the mesh defeats the purpose of preserving the instanced asset structure. This aligns with Content Aggregation → Asset Modularity and Instancing → Refining Scenegraph Instances, Hierarchical Refinement, Primvars, and Instance Editability."
+  },
+  {
+    "q": "When constructing an OpenUSD scene, in which scenario is it most appropriate to use a payload instead of a reference?",
+    "a": [
+      "When an asset requires frequent updates, but the asset should default to the latest version.",
+      "When deferring the loading of heavy assets until they are needed, thereby improving initial load performance.",
+      "When the asset is small and inexpensive to load to ensure efficient transfer over web protocols.",
+      "When it's important to ensure that all referenced data is immediately available on stage load."
+    ],
+    "c": [
+      1
+    ],
+    "e": "A payload is most appropriate when the scene contains heavy assets that should not be fully composed and loaded until needed. NVIDIA’s Learn OpenUSD payload lesson describes payloads as similar to references, but with the added ability to load and unload them on demand. It gives the example of opening a large city scene with all payloads unloaded so the stage loads quickly, then selectively loading only the city block or asset of interest. When loaded, the payloaded layers and their composed dependencies are brought into the scene. Option B is correct because payloads are designed for deferred loading, scalable working sets, reduced initial load time, and lower memory cost. Option A describes versioning or asset-resolution policy, not the primary distinction between payloads and references. Option C does not justify a payload; small inexpensive assets are often fine as references. Option D describes the opposite of payload behavior, because references are composed immediately, while payload traversal can be deferred. This aligns with Composition → Reference and Payloads, Load/Unload Behavior, Composition Arcs, Scalability, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "What geometric attribute should be kept in sync when updating point position values on an object?",
+    "a": [
+      "purpose",
+      "xformOps",
+      "extent",
+      "faceVertexIndices"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The geometric attribute that should be kept in sync is extent. In OpenUSD, point position values describe the authored point locations for point-based geometry, while extent represents the local- space geometric range or bounding box of a boundable primitive. The OpenUSD UsdGeomBoundable specification describes extent as a three-dimensional range measuring the authored gprim in its own local space, and states that if extent is authored, it should be authored at every time sample where geometry-affecting properties are authored to ensure correct evaluation. Option C is correct because changing point positions can change the object’s local bounds. If the authored extent is not updated, downstream systems may compute incorrect framing, culling, selection bounds, or bounding-box display. Option A is incorrect because purpose classifies geometry for render, proxy, guide, or default visibility categories. Option B is incorrect because xformOps describe transform operations on the prim, not the local geometric bounds derived from point positions. Option D is incorrect because faceVertexIndices describes mesh topology, not the bounding range. This aligns with Data Modeling → Geometry Attributes, Point-Based Geometry, Boundable Prims, Extent, and Time-Sampled Geometry."
+  },
+  {
+    "q": "What fundamental data type in USD is most suitable for representing texture files?",
+    "a": [
+      "tokens",
+      "strings",
+      "asset paths"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The most suitable USD data type for representing texture files is an asset path. NVIDIA’s Learn OpenUSD glossary defines an asset as a named reusable resource and explicitly includes textures among asset examples. It also explains that USD provides a specialized string type called asset so that attributes and metadata referring to external resources can be identified robustly. In USDA syntax, asset-valued strings are delimited with @, such as @textures/albedo.png@. Option C is correct because texture files are external resources that should participate in USD’s asset- resolution system. Using an asset path allows the resolver to map the authored identifier to an actual file location, versioned asset, package member, or site-specific storage location. Option A is incorrect because tokens are compact identifiers best suited to enumerated values such as purpose, interpolation, or role-like names. Option B is less appropriate because ordinary strings do not communicate that the value is an external asset dependency requiring resolution. This distinction is essential for interchange, packaging, relocation, and pipeline portability. This aligns with Data Exchange → Asset Paths, Asset Resolution, Texture Dependencies, Sdf Value Types, and External Resource Reference."
+  },
+  {
+    "q": "What is the fundamental data type in USD that enables API schemas to be non-destructively removed in stronger layers?",
+    "a": [
+      "list ops",
+      "arrays",
+      "booleans"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The correct answer is list ops. API schemas are not encoded as a simple boolean flag on a prim. Instead, applied API schemas are stored in the apiSchemas metadata as token-valued listOp data. OpenUSD’s UsdPrim::ApplyAPI() documentation states that applying an API schema stores the schema name by adding it to the token-valued listOp metadata apiSchemas. Its RemoveAPI() documentation states that removing an API schema authors an explicit deletion of that schema name from the same listOp metadata. This is what enables non-destructive removal in stronger layers. A weaker layer may apply an API schema, while a stronger layer can delete that schema token from the composed list without modifying the weaker source layer .NVIDIA’s OpenUSD glossary describes list editing as sparse ordered-list composition using operations such as prepend, append, delete, and explicit replacement, allowing stronger layers to modify lists contributed by weaker layers. Option B is incorrect because arrays store values but do not provide list-edit composition semantics. Option C is incorrect because booleans cannot represent ordered additive and subtractive composition. This aligns with Customizing USD → API Schemas, apiSchemas Metadata, List Editing, and Non-Destructive Layering."
+  },
+  {
+    "q": "Which is the most appropriate combination of OpenUSD features to consider when trying to solve problems related to artists interaction with LODs, Material variations and Asset Versions?",
+    "a": [
+      "VariantSets, Purposes and AssetResolvers",
+      "PrimAdapters, SceneIndex plugins and Reference",
+      "Inherits, Specializes and MaterialX"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The most appropriate combination is VariantSets, Purposes, and AssetResolvers because each feature addresses one of the stated production problems at the correct abstraction level. Variant sets provide artist-facing switches for alternative representations of the same asset, including material variations, geometric variations, and LOD-style alternatives. NVIDIA’s Learn OpenUSD guide states that variant sets define alternative representations that can be switched at runtime, and that variants may override properties, define descendant prims, or author composition arcs. Purposes help separate representation classes such as proxy, render, and guide. NVIDIA’s glossary describes purpose as a UsdGeomImageable attribute used to classify geometry into selective visibility categories, allowing clients to include or exclude categories during rendering, bounding, or interactive traversal. Asset resolvers address asset versioning and storage indirection. NVIDIA’s asset-structure guidance specifically recommends keeping instances within a specific version and leveraging storage and asset-resolver capabilities to keep assets atomic. Option B is more renderer/Hydra-infrastructure focused and does not directly solve artist-facing variation and versioning. Option C contains useful composition and shading tools, but it is not the best combined solution for LODs, material options, and asset versions. This aligns with Pipeline Development → Artist Workflows, Variant Sets, Purpose, Asset Resolution, and Asset Versioning."
+  },
+  {
+    "q": "As part of a data exchange workflow, you have exported the following file from your DCC tool, and notice that the displayed extents box of the sphere is too large: #usda 1.0 ( defaultPrim = \"Model1\" ) def Sphere \"MySphere\" { double radius = 0.5 float3[] extent = [(-3.0, -3.0, -3.0), (3.0, 3.0, 3.0)] } Your tool, and also the final consumer of the scene data, would like best-fit correct extents. Which of the following could the export process do to address this problem for any exported boundable prim?",
+    "a": [
+      "Remove any authored \"extent\" values - USD will automatically calculate the correct extents for you.",
+      "Check and, if necessary, fix any authored extent values on all boundable prims.",
+      "Add an \"extentsHint\" attribute to all boundable prims with the correct bounds.",
+      "Create a Scope prim for each boundable prim and make it a parent of the boundable prim."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The exporter should validate and correct authored extent values on every exported UsdGeomBoundable prim. The extent attribute is the local-space bounding range of the authored geometric primitive, and if it is authored incorrectly, clients that trust the authored extent can display oversized or inaccurate bounds. NVIDIA’s asset-requirements documentation states that “Boundable geometry primitives should have valid extent values,” and its compliance guidance says to author extent for boundable geometry and compute it at time samples where geometry-affecting attributes change. (docs.omniverse.nvidia.com) Option B is correct because it preserves the intended best-fit bounds and works consistently for any exported boundable prim. Option A is unreliable as an export strategy: OpenUSD may compute extent through registered compute functions when no extent is authored, but this can be expensive and is not a substitute for correct exported data. The OpenUSD UsdGeomBoundable documentation strongly encourages proper authoring of extent. (openusd.org) Option C is incorrect because extentsHint is not the replacement for per-primitive boundable extent. Option D is unrelated to geometric bounds. This aligns with Data Exchange → Validation, Geometry Export, Boundable Extents, and Data Quality."
+  },
+  {
+    "q": "In OpenUSD, a composed stage aggregates opinions from multiple sublayers. Why might an opinion in one layer not take effect in the final composed stage?",
+    "a": [
+      "Opinions in a layer only affect the composed stage if the layer is explicitly referenced in every other layer .",
+      "The opinion is authored using the weaker keyword, which explicitly lowers its priority.",
+      "OpenUSD prevents opinions from taking effect unless they originate from the root layer .",
+      "The layer containing the opinion has a weaker strength in the stage’s layer stack than other layers that override it."
+    ],
+    "c": [
+      3
+    ],
+    "e": "An opinion may not appear in the final composed stage because USD resolves competing opinions according to composition strength. NVIDIA’s Learn OpenUSD material explains that a layer stack is the ordered set of a layer and its recursively gathered sublayers, with the root layer considered strongest, followed by sublayers according to their composed order .It also states that strength ordering determines which opinion is composed into the final stage when multiple layer stacks or layers contribute data for the same prim or property. (docs.nvidia.com) Option D is correct because a weaker layer can author a valid opinion, but that opinion can be hidden by a stronger authored opinion on the same target. Option A is incorrect because sublayers do not need to be referenced by every other layer to affect a stage. Option B is incorrect because there is no general “weaker keyword” that lowers priority. Option C is incorrect because opinions from sublayers, references, payloads, variants, inherits, and specializes can all contribute to composition. This aligns with Composition → Sublayers, Layer Stacks, Opinion Strength, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "What is the primary purpose of a conceptual data mapping document?",
+    "a": [
+      "To define the requirements for an end-to-end 3D workflow.",
+      "To document the content structure of a 3D scene.",
+      "To specify the data storage requirements for USD data.",
+      "To document data translation between OpenUSD and other formats."
+    ],
+    "c": [
+      3
+    ],
+    "e": "A conceptual data mapping document primarily records how concepts and data from a source format map into OpenUSD concepts, schemas, prims, properties, and authored scene description. NVIDIA’s Learn OpenUSD Data Extraction lesson states that producing such a document is valuable because it serves as a data specification for extraction implementation, helps stakeholders set requirements and expectations, and helps developers understand which features are supported between two formats and what to expect from the extraction phase. (docs.nvidia.com) Option D is correct because the document is specifically about translation between OpenUSD and another data representation, such as a DCC format, interchange format, or custom application model. Option A is broader than the purpose of the document; an end-to-end workflow specification may include tools, review, publishing, validation, and delivery, while conceptual mapping focuses on data correspondence. Option B is also too narrow because content structure is only one possible mapped concept. Option C is incorrect because storage requirements are not the core concern. This aligns with Data Exchange → Data Extraction, Conceptual Data Mapping, Format Translation, and Converter Design."
+  },
+  {
+    "q": "Which of these is the most essential composition arc to put onto the components of a model hierarchy?",
+    "a": [
+      "payloads",
+      "inherits",
+      "variant sets",
+      "specializes"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The most essential composition arc for components in a model hierarchy is the payload. NVIDIA’s Learn OpenUSD glossary describes payloads as composition arcs similar to references, but with deferred loading for scalability, and specifically notes that payloads are typically added to component asset root prims for efficient scalable composition. (docs.nvidia.com) Option A is correct because component models act as the leaf or pruning boundary of the model hierarchy. NVIDIA’s model-kind guidance explains that the model hierarchy is designed to prune traversal at the component boundary, and that component models cannot contain other component models as descendants. (docs.nvidia.com) Payloads reinforce that design by allowing large component contents to remain unloaded until needed, improving stage-opening performance and enabling scalable aggregation of large scenes. Option B is incorrect because inherits are mainly for reusable class-style opinions. Option C is useful for alternatives such as LODs or looks, but it is not the essential component-loading mechanism. Option D is a weaker composition mechanism used for specialization and fallback-style refinement. This aligns with Content Aggregation → Asset Structure, Model Hierarchy, Components, Payloads, and Scalable Scene Assembly."
+  },
+  {
+    "q": "What sort of plugin implements logic to locate resources such as @mycompany://path/to/my/resource@?",
+    "a": [
+      "Custom schema plugin",
+      "Hydra plugin",
+      "Asset resolver plugin",
+      "Custom metadata plugin"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The correct plugin type is an asset resolver plugin. In OpenUSD, asset paths such as @mycompany://path/to/my/resource@ are not interpreted as ordinary strings; they are asset identifiers that must be resolved into concrete resources that USD can consume. NVIDIA’s Learn OpenUSD glossary defines asset resolution as the process of translating an asset path into the actual location of a usable resource and states that USD provides the ArResolver plugin point for custom resolution logic, including external databases, custom storage systems, version-control systems, or studio-specific URI schemes. Option C is correct because a custom asset resolver is precisely where pipeline-specific resource lookup logic belongs. Option A is incorrect because a custom schema plugin defines prim types, API schemas, and properties, not asset-location behavior .Option B is incorrect because Hydra plugins are concerned with imaging, rendering, and scene-index/render-delegate behavior .Option D is incorrect because custom metadata may store extra data, but it does not implement resolution of asset identifiers. This aligns with Pipeline Development → Asset Resolution, ArResolver, Resource Location, Versioned Assets, and Pipeline Integration."
+  },
+  {
+    "q": "Which of the following sentences are correct when converting between .usda, .usdc, .usd and .usdz files? Choose two.",
+    "a": [
+      "A .usda file can be converted to a .usdz file using usdcat.",
+      "A .usda file can be converted to a .usdc file using usdcat.",
+      "A .usda file can be converted to a .usd file by simply renaming it.",
+      "A .usda file can be converted to a .usdc file by simply renaming it."
+    ],
+    "c": [
+      1,
+      2
+    ],
+    "multi": true,
+    "e": "Options B and C are correct. The official OpenUSD layer-format conversion tutorial states that usdcat can convert between layer formats using the -o option and an output filename with the desired extension. For example, converting text .usda to binary .usdc is performed with a command such as usdcat -o NewSphere.usdc Sphere.usda. Option C is also correct because .usd is an extension that can hold either text or binary USD data. The same OpenUSD tutorial explains that a .usda or .usdc file can be converted to .usd without changing the underlying format by simply renaming the file; USD detects the actual format when opening it. Option A is not correct in this context because .usdz is a package/archive format, and the OpenUSD toolset identifies usdzip, not usdcat, as the utility for creating .usdz packages containing USD assets. Option D is incorrect because renaming a text .usda file to .usdc does not convert it into USD’s binary crate representation. This aligns with Data Exchange → USD File Formats, usdcat, usdzip, USDA, USDC, USD, and USDZ Packaging."
+  },
+  {
+    "q": "Why is a well-designed model kind hierarchy important for an efficient pipeline?",
+    "a": [
+      "Tools can rely on the model kind hierarchy for efficient stage traversal.",
+      "The composition engine can optimize based on the model kind hierarchy.",
+      "The model kind hierarchy helps avoid duplication of pipeline data."
+    ],
+    "c": [
+      0
+    ],
+    "e": "A well-designed model kind hierarchy is important because it gives tools a reliable, high-level “table of contents” for a complex stage. NVIDIA’s Learn OpenUSD guide explains that model hierarchy is designed to prune traversal at a relatively shallow point in the scenegraph. Without model hierarchy, traversal may need to pass through all prims in a scene, which can be costly. The key pruning point is the component model boundary: ancestors of components participate in the model hierarchy, while descendants are outside the model hierarchy. Option A is correct because pipeline tools can use kind metadata to find meaningful asset boundaries, traverse assemblies and groups efficiently, and avoid descending into every geometric or implementation-level prim. Option B is inaccurate because kind metadata is not primarily a composition-engine optimization mechanism; USD composition resolves scene description based on composition arcs and strength ordering. Option C is also not the primary purpose. Avoiding duplication is addressed more directly by references, payloads, instancing, inherits, specializes, and asset-structure reuse. This aligns with Content Aggregation → Asset Structure → Model Hierarchy → Model Kinds, Components, Assemblies, Groups, and Efficient Traversal."
+  },
+  {
+    "q": "Consider a task where a Mesh prim needs to have its points property subdivided to achieve a higher quality of deformation. Which of the following is correct?",
+    "a": [
+      "It is impossible to override the points property of the Mesh, since subdivision can only happen at rendertime through the subdivisionScheme attribute of the Mesh schema.",
+      "Non-constant primvars like displayColor and UVs from the Mesh need to be updated as well, since it is responsibility of the process overriding the points to also provide valid values for other primvars.",
+      "Non-constant primvars like displayColor and UVs from the Mesh can be left unchanged, since USD handles the resize of the array values to match the points property automatically during composition."
+    ],
+    "c": [
+      1
+    ],
+    "e": "When a process changes the topology or point count of a mesh, it must also update dependent geometric data whose interpolation depends on the mesh’s element counts. OpenUSD primvars are not arbitrary side data; their array sizes and ordering are tied to interpolation mode. For mesh vertex interpolation, the primvar array provides one element for each point, in the same order as the mesh points array. For faceVarying interpolation, the primvar array follows the flattened faceVertexIndices order . Option B is correct because subdividing or replacing points changes the data contract for non- constant primvars such as display color, UVs, normals, or other interpolated values. The process authoring the stronger points opinion must ensure that related primvars remain valid for the resulting geometry. Option A is incorrect because points is an attribute and can be overridden by stronger opinions; render-time subdivision through subdivisionScheme is a separate mechanism. Option C is incorrect because USD composition does not automatically resize or reinterpret primvar arrays to match newly authored points. This aligns with Data Modeling → Meshes, Points, Primvars, Interpolation, Topology, and Geometry Validity."
+  },
+  {
+    "q": "Which of these operations are likely to be slower when switching variants? Choose two.",
+    "a": [
+      "Changing reference paths",
+      "Changing visibility",
+      "Changing activation opinions",
+      "Changing attribute values"
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The slower operations are those that change the composed structure of the stage rather than merely changing resolved property values. NVIDIA’s Learn OpenUSD variant-set guidance separates lightweight and heavyweight variant switches. Lightweight switches include changing attribute values and visibility because they affect value resolution or rendering state without requiring USD to rebuild the composed scene structure. In contrast, heavyweight switches include changing reference paths and changing activation opinions because these alter what content is composed onto the stage. Option A is correct because changing a reference path swaps which external layer or asset contributes scene description, requiring recomputation of affected composition indexes. Option C is correct because activation controls whether prims are composed at all; changing active state can add or remove composed scenegraph structure. Option B is incorrect because visibility is a rendering/imageability opinion and does not remove prims from composition. Option D is incorrect because ordinary attribute-value changes are typically lightweight value-resolution changes. This aligns with Composition → Variant Sets → Variant Design Considerations, Lightweight Variant Switches, Heavyweight Variant Switches, Reference, Activation, Visibility, and Attribute Opinions."
+  },
+  {
+    "q": "Which of the following are valid reasons for choosing to use or develop a standalone converter instead of an importer/exporter for a digital content creation (DCC) application? Choose two.",
+    "a": [
+      "Standalone converters are the only way to convert proprietary formats.",
+      "A converter always produces higher-fidelity results compared to an importer/exporter .",
+      "You don't have access to an SDK to develop a native exporter for the DCC.",
+      "Your workflow requires batch conversion that is not suitable within the DCC."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "A standalone converter is appropriate when the conversion workflow should operate outside the DCC application. NVIDIA’s Learn OpenUSD Data Exchange lesson defines a standalone converter as a script, executable, or microservice dedicated to translating to and from another file format. It contrasts this with importers and exporters, which are implemented as part of a DCC application’s runtime or plugin system. (docs.nvidia.com) Option C is correct because if a developer cannot access the DCC’s SDK, plugin API, or runtime integration path, a native importer/exporter may not be feasible. A separate converter can still be built around accessible file-level data, command-line tools, services, or external APIs. Option D is also correct because standalone converters are well suited for automation, headless processing, farm execution, and batch conversion pipelines that do not belong inside an artist-facing DCC session. NVIDIA’s OpenUSD guidance also notes that data exchange implementations must account for different client needs, workflow performance, and content structures rather than assuming one implementation pattern fits all. (docs.nvidia.com) Option A is false because proprietary formats can also be supported by native plugins or file format plugins when appropriate access exists. Option B is false because fidelity depends on data mapping and implementation quality, not on whether the tool is standalone. This aligns with Data Exchange → Importers, Exporters, Standalone Converters, File Format Plugins, and Workflow Requirements."
+  },
+  {
+    "q": "When a user is trying to change the drawMode of an element to bounds, and it doesn't work, what should you look into?",
+    "a": [
+      "Kinds and GeomModelAPI schema are properly applied.",
+      "UsdPhysicsCollisionAPI schema is applied and extents are correct.",
+      "UsdVolVolume schema is applied and extents are correct.",
+      "UsdShadeMaterialBindingAPI schema is applied and a material is bound."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The correct troubleshooting path is to verify the prim’s kind and whether UsdGeomModelAPI behavior is properly applied. OpenUSD’s UsdGeomModelAPI documentation states that draw modes provide alternate imaging behavior for USD subtrees with kind model. The attributes model:drawMode and model:applyDrawMode are resolved to decide whether traversal should stop at a model boundary and replace the subtree with proxy geometry. For bounds, the replacement is the model-space bounding box of the replaced prim. (openusd.org) Option A is correct because drawMode = \"bounds\" is not a generic visibility toggle for arbitrary prims. It is a model-level imaging mechanism. The prim must participate correctly in the model hierarchy, and the relevant UsdGeomModelAPI attributes must be authored or inherited in a way that causes draw mode application. The documentation also notes that component models are automatically treated as if model:applyDrawMode were true unless explicitly disabled. (openusd.org) Options B, C, and D are unrelated to model draw-mode activation. Physics collision APIs, volume schemas, and material binding APIs can affect simulation, volume representation, or shading, but they do not control whether model draw modes are applied. This aligns with Visualization → Model Draw Modes, UsdGeomModelAPI, Kinds, Bounds, and Imaging Substitution."
+  },
+  {
+    "q": "Consider the following HelloWorld.usda OpenUSD layer: #usda 1.0 ( defaultPrim = \"hello\" ) def Xform \"hello\" { double3 xformOp:translate = (4, 5, 6) uniform token[] xformOpOrder = [\"xformOp:translate\"] def Sphere \"world\" { float3[] extent = [(-2, -2, -2), (2, 2, 2)] color3f[] primvars:displayColor = [(0, 0, 1)] double radius = 2 } } What would be the output of the following Python snippet? from pxr import Usd refStage = Usd.Stage.CreateInMemory() refSphere = refStage.OverridePrim(\"/refSphere\") refSphere.GetReference().AddReference(\"./HelloWorld.usda\") print(refStage.GetRootLayer().ExportToString())",
+    "a": [
+      "#usda 1.0 over \"hello\" { over \"refSphere\" ( prepend references = @./HelloWorld.usda@ ) { } }",
+      "#usda 1.0 over \"refSphere\" { }",
+      "#usda 1.0 over \"refSphere\" ( prepend references = @./HelloWorld.usda@ ) { }"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The Python snippet authors a reference opinion directly on the prim /refSphere in a new anonymous root layer .Usd.Stage.CreateInMemory() creates an empty stage, and OverridePrim(\"/refSphere\") authors an over prim spec because no concrete type is being defined. The call refSphere.GetReference().AddReference(\"./HelloWorld.usda\") adds a reference composition arc to that same prim, so the root layer serializes the opinion as prepend references = @./HelloWorld.usda@. Option C is correct because ExportToString() prints the authored contents of the root layer, not the fully expanded composed result of the referenced asset. The referenced HelloWorld.usda layer has defaultPrim = \"hello\", so omitting a prim path in AddReference() targets the referenced layer’s default prim. NVIDIA’s reference documentation explains that a reference may omit the prim path when the referenced layer has a default prim, and the target prim will be resolved from that metadat a. (docs.nvidia.com) Option A is incorrect because the reference is not authored under /hello; /hello exists only inside the referenced file. Option B is incomplete because it omits the reference metadata. This aligns with Composition → Reference, Default Prim, Layer Authoring, and Exported Layer Opinions."
+  },
+  {
+    "q": "Another department at your company has provided layer1.usda that has a Sphere Gprim with animated timeValues that translate the sphere along the Y-axis: #usda 1.0 ( endTimeCode = 60 startTimeCode = 1 ) def Xform \"Asset\" { def Sphere \"Sphere\" { double3 xformOp:translate.timeSamples = { 1: (0, 5.0, 0) 30: (0, -5.0, 0) 60: (0, 5.0, 0) } uniform token[] xformOpOrder = [\"xformOp:translate\"] } } You’ve been given rootLayer .usdathat references Sphere from layer1.usda as follows: #usda 1.0 ( endTimeCode = 60 startTimeCode = 1 ) def Xform \"World\" { def Sphere \"Sphere\" ( prepend references = @./layer1.usda@</Asset/Sphere> ) { } } For testing purposes, you want to check what Sphere would look like if it was at (0, -5.0, 0) at timeCode = 45. Which of the following changes in rootLayer .usdawould place Sphere at -5.0 in the Y- axis at timeCode 45? Note that it is okay if the position of Sphere at other timeCodes is changed. Choose two.",
+    "a": [
+      "Add a (0, -5, 0) translate xformOp timeValue to \"World\" at timeCode 45: def Xform \"World\" { double3 xformOp:translate.timeSamples = { 45: (0, -5.0, 0), } uniform token[] xformOpOrder = [\"xformOp:translate\"] }",
+      "Change the layer metadata endTimeCode from 60 to 45: #usda 1.0 ( endTimeCode = 45 startTimeCode = 1 )",
+      "Add a 15 timeCode frame layer offset to the Sphere reference: def Sphere \"Sphere\" ( prepend references = @./layer1.usda@</Asset/Sphere> (offset = 15) ) { }",
+      "Add the following xformOp overrides to \"Sphere\": double3 xformOp:translate.timeSamples = { 1: (0, 5.0, 0), 30: (0, -2.5, 0), 60: (0, -5.0, 0) } uniform token[] xformOpOrder = [\"xformOp:translate\"]"
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "At timeCode 45, the referenced animation from layer1.usda interpolates between the samples at 30 and 60. Since the Y values are -5.0 at frame 30 and 5.0 at frame 60, the interpolated local translate at frame 45 is 0.0. Option A works because adding a parent transform on /World at frame 45 contributes an additional Y translation of -5.0; combined with the sphere’s interpolated local value of 0.0, the resulting placement is Y = -5.0. Option C also works because a layer offset retimes animation across a reference. NVIDIA defines a layer offset as an adjustment to time values when composing layers through references, payloads, or sublayers, using offset and scale to retime animated data non-destructively. With offset = 15, the source sample at frame 30 is composed at frame 45, so the referenced sphere evaluates to Y = -5.0 at root time 45. Value resolution accounts for layer offsets and interpolation of time samples. Option B only changes timeline metadata and does not retime or override the animation. Option D interpolates between -2.5 at frame 30 and -5.0 at frame 60, producing -3.75 at frame 45, not -5.0. This aligns with Composition → Reference, Layer Offsets, Time Samples, and Value Resolution."
+  },
+  {
+    "q": "Which of the following best defines the primary function of a specialize composition arc in OpenUSD?",
+    "a": [
+      "It provides a strong overriding mechanism since opinions expressed by the specialize arc always win.",
+      "To broadcast specs from a source prim to destination prims as fallback values if no other opinion exists.",
+      "When used additively, these arcs make a prim more functionally and descriptively specialized.",
+      "To uniformly broadcast stronger specs from a source prim to destination prims."
+    ],
+    "c": [
+      1
+    ],
+    "e": "A specialize composition arc broadcasts fallback opinions from a source prim to one or more specializing destination prims. NVIDIA’s Learn OpenUSD glossary defines specializes as a composition arc that broadcasts fallback values from a source prim and applies only when the specializing prim does not already have its own authored opinion. It further explains that specializes is similar to inherits in its broadcast behavior, but differs because specializes contributes fallback values rather than stronger reusable opinions. (docs.nvidia.com) Option B is correct because it captures the essential behavior: source specs are supplied as fallback data. Option A is incorrect because specializes is the weakest composition arc in LIVERPS ordering; it does not always win. NVIDIA’s strength-ordering guide states that specializes acts as a new fallback value, winning only when stronger composition choices provide no value. (docs.nvidia.com) Option C describes the conceptual naming idea of specialization but not the primary functional mechanism. Option D is incorrect because “stronger specs” describes a different strength behavior .This aligns with Composition → Inherits and Specializes, Fallback Opinions, LIVERPS Strength Ordering."
+  },
+  {
+    "q": "Consider a USD that has a root Xform, that has a child Sphere, that in turn has a child Cube. Xform - Sphere -- Cube When you open the USD, you see the sphere and the cube. But when you author the Sphere to be invisible, the sphere disappears, but the Cube is still visible. What could be causing this behavior?",
+    "a": [
+      "Visibility is explicit in OpenUSD, so the Cube must be explicitly authored as invisible.",
+      "Nested gprims are illegal in OpenUSD, and their imaging behavior is undefined.",
+      "Visibility is hierarchical in OpenUSD, so the root Xform must be made invisible in order for all of its descendants to be invisible."
+    ],
+    "c": [
+      1
+    ],
+    "e": "The issue is caused by an invalid scenegraph structure: a Cube gprim is nested below a Sphere gprim. OpenUSD considers nesting gprims under other gprims invalid, and usdchecker warns on this construct because important USD features such as activation and visibility are hierarchical and pruning. The OpenUSD glossary states that when an ancestor gprim is deactivated or made invisible, there should be no way for a descendant gprim to remain active or visible. (openusd.org) Option B is correct because the authored hierarchy violates the expected gprim organization. The correct structure is to place geometry prims under transform or organizational prims, such as Xform or Scope, rather than directly under other gprims. Option A is incorrect because USD visibility is not purely explicit per prim. NVIDIA’s Omniverse visibility guide states that setting a prim’s visibility to invisible makes the prim and all children invisible. (docs.omniverse.nvidia.com) Option C is also incorrect because setting the Sphere invisible should hierarchically affect descendants in a valid hierarchy. This aligns with Visualization → Visibility, Imageable Prims, Gprim Structure, and Valid Scenegraph Organization."
+  },
+  {
+    "q": "Which of the following are valid principles of asset structure? Choose three.",
+    "a": [
+      "Legibility",
+      "Redundancy",
+      "Navigability",
+      "Modularity",
+      "Compressability"
+    ],
+    "c": [
+      0,
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "The valid asset-structure principles are Legibility, Navigability, and Modularity. NVIDIA’s Learn OpenUSD asset-structure guide identifies four principles of scalable asset structure: Legibility, Modularity, Performance, and Navigability. It defines legibility as making an asset structure easy to understand and interpret, modularity as enabling flexibility and reuse, and navigability as making it easy for users to find and access the features and properties they need. (docs.nvidia.com) Option A is correct because clear names, organization, and intent make assets easier to troubleshoot, exchange, and maintain. Option C is correct because downstream users and tools must be able to locate meaningful prims, properties, variants, payloads, and interfaces efficiently. Option D is correct because reusable modular components support parallel workstreams and scalable aggregation. Option B is incorrect because redundancy is generally discouraged; NVIDIA’s modularity guidance emphasizes reuse and avoiding duplicated data. Option E is incorrect because “compressability” is not one of the stated principles. This aligns with Content Aggregation → Asset Structure Principles → Legibility, Modularity, Performance, Navigability."
+  },
+  {
+    "q": "What is a key difference between referencing and sublayering?",
+    "a": [
+      "Reference cannot be reordered like sublayers.",
+      "Reference have a stronger strength ordering than sublayers.",
+      "A prim can have many sublayers, but only one reference.",
+      "Referencing brings in a hierarchy rooted at a single prim, while sublayering brings in all of a layer's content."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The key distinction is the scope of what each composition arc contributes. Sublayering composes the contents of one layer into another layer stack, bringing in the layer’s scene description as a whole. It is commonly used to combine broad workstream layers such as modeling, layout, animation, lighting, or shot overrides. Referencing, by contrast, is authored on a prim and brings scene description from an external layer, typically rooted at a selected prim or the referenced layer’s default prim. This makes references ideal for asset composition, where a model, prop, environment element, or component is introduced at a specific namespace location. Option D is correct because it precisely captures this namespace behavior: references target and compose a prim hierarchy, while sublayers contribute all layer contents into the layer stack. Option A is incorrect because reference list operations can also be ordered and edited. Option B is misleading because composition strength is governed by USD’s LIVERPS ordering and layer-stack strength, not a simple statement that references are always stronger .Option C is incorrect because a prim can have multiple references through list editing. This aligns with Composition → Sublayers, Reference, Layer Stacks, Namespace Composition, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "To make only the sphere visible given the following scene, which prims need their visibility opinions updated? Choose three. #usda 1.0 def Xform \"World\" { token visibility = \"invisible\" def Xform \"Xform\" { def Scope \"Scope\" { token visibility = \"invisible\" def Sphere \"Sphere\" { } def Cube \"Cube\" { } } } }",
+    "a": [
+      "Scope",
+      "Xform",
+      "World",
+      "Sphere",
+      "Cube"
+    ],
+    "c": [
+      0,
+      2,
+      4
+    ],
+    "multi": true,
+    "e": "The visibility opinions that must be updated are on World, Scope, and Cube. In OpenUSD, visibility is hierarchical and pruning. UsdGeomImageable defines the visibility attribute with allowed values inherited and invisible; effective visibility is computed from the most ancestral authored invisible opinion. The OpenUSD API further states that MakeVisible() may need to override ancestor visibility and hide sibling branches to preserve the intended result. (openusd.org) In the given scene, /World is explicitly invisible, so the entire subtree is invisible regardless of descendants. /World must therefore be changed to visible behavior, typically visibility = \"inherited\". /World/Xform/Scope is also explicitly invisible, so Scope must also be changed to inherited to allow its children to be evaluated as visible. Once those ancestor invisibility opinions are removed, both Sphere and Cube would become visible by inheritance. To make only the sphere visible, the Cube must receive an explicit visibility = \"invisible\" opinion. The sphere does not require an authored visibility opinion because it becomes visible through inheritance. This aligns with Visualization → UsdGeomImageable, Visibility, Hierarchical Pruning, and Effective Visibility Computation."
+  },
+  {
+    "q": "You are debugging a complex scene composed of multiple layers. You notice that a property on a prim has an unexpected value. To understand where this value is coming from, you need to inspect the composition arcs affecting this prim. Which API would be most helpful in visualizing and analyzing the composition arcs for a specific prim?",
+    "a": [
+      "Usd.Stage.Traverse()",
+      "UsdUtils.ComputeUsdStageStats()",
+      "Usd.Property.GetPropertyStack()",
+      "Usd.Stage.Export()"
+    ],
+    "c": [
+      2
+    ],
+    "e": "Usd.Property.GetPropertyStack() is the most appropriate choice because the debugging goal is to determine where a composed property value is coming from. In USD, a final property value can be affected by multiple authored opinions across sublayers, references, payloads, variants, inherits, specializes, and local overrides. NVIDIA’s Learn OpenUSD glossary defines a property stack as the ordered list of property specs that contribute values or metadata for a composed property, and notes that UsdProperty::GetPropertyStack() is specifically useful for debugging, not as the primary value- resolution mechanism. It also explains that USD resolves values by traversing composition information in strength order . Option C is therefore correct because it exposes the contributing property specs and their layer origins, helping identify why a stronger opinion produced an unexpected result. Option A only traverses prims on the composed stage and does not explain value provenance. Option B reports aggregate stage statistics, not composition-source details. Option D exports the stage or layer contents but does not provide targeted diagnostic ordering for a property. This aligns with Debugging and Troubleshooting → Value Resolution, Property Stack, Composition Debugging, and Layer Opinion Inspection."
+  },
+  {
+    "q": "Why is usdchecker an important part of data exchange?",
+    "a": [
+      "It provides the best assurance that an asset will be consumable downstream.",
+      "It verifies that all USD files are in binary format for max efficiency.",
+      "It optimizes USD files for faster loading and rendering.",
+      "It verifies asset URIs are correctly formed for portability."
+    ],
+    "c": [
+      0
+    ],
+    "e": "usdchecker is important in data exchange because it validates whether exported USD or USDZ assets comply with rules that make them more likely to be interchangeable, renderable, and usable by downstream consumers. NVIDIA’s Learn OpenUSD Asset Validation lesson states that usdchecker validates a USD stage or USDZ package using defined rules to provide the best assurance that an asset will be properly interchangeable and renderable by Hydra. It is presented as part of the data exchange workflow for testing converter output and improving exporter quality. Option A is correct because asset validation directly supports downstream consumption, which is the core goal of data exchange. A converter may write syntactically valid USD but still omit important metadata, invalid extents, default prims, unresolved dependencies, or other requirements that reduce interoperability. Option B is incorrect because usdchecker does not require binary .usdc output. Option C is incorrect because validation is not optimization. Option D is too narrow; URI and asset-path checks may be part of validation, but they are not the primary purpose. This aligns with Data Exchange → Asset Validation, usdchecker, Converter Testing, USDZ Compliance, and Downstream Interoperability."
+  },
+  {
+    "q": "Considering the following scene description: def \"ParkingLot\" { def \"Car_1\" ( instanceable = true references = @Car .usd@ ) { } def \"Car_2\" ( instanceable = true references = @Car .usd@ ) { } } Disabling the instanceable metadata on the prim at path /ParkingLot/Car_2 by setting it to false has the following effects: Choose two.",
+    "a": [
+      "Other prims using the same prototype, such as /ParkingLot/Car_2, will also get their instanceable metadata disabled.",
+      "Existing opinions in a local layer from the root LayerStack targeting a child of /ParkingLot/Car_1 will take effect.",
+      "Existing opinions in a local layer from the root LayerStack targeting a child of /ParkingLot/Car_1 will be ignored.",
+      "Recomposition will be triggered from the hierarchy starting at /ParkingLot/Car_1."
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "Setting instanceable = false on an instance root is a deinstancing operation. NVIDIA’s Learn OpenUSD instancing material explains that instanceable prims share composed data through implicit prototypes, and that scenegraph instances restrict sparse descendant overrides because instance proxies are not directly editable. In NVIDIA’s instance-refinement guidance, the three practical rules are: prototypes are not editable, instance proxies are not editable and local opinions are discarded, while the instanceable prim itself remains editable. (docs.nvidia.com) Therefore, when the targeted instance root is deinstanced, local opinions authored under that prim’s descendant paths can become effective because the subtree is no longer represented only through the shared prototype. USD must also recompose that hierarchy because changing instanceable changes whether the prim contributes to prototype sharing or composes its own local subtree. Option A is incorrect because disabling instanceable on one prim does not mutate metadata on other prims that previously shared the prototype. Option C describes the still-instanced behavior, not the deinstanced result. In the screenshot, the stem names /ParkingLot/Car_2 while options B and D name /ParkingLot/Car_1; the correct effects apply to the prim whose instanceable metadata is disabled. This aligns with Content Aggregation → Scenegraph Instancing, Instance Refinement, Deinstancing, and Recomposition."
+  },
+  {
+    "q": "Considering the two files cars.usda and parkingLot.usda in the exhibit. When opening a stage with parkingLot.usda as the root layer, you observed this prim hierarchy: ParkingLot car01 You expected this: ParkingLot car01 chassis parkingLot.usda: #usda 1.0 ( upAxis = \"Y\" ) def Xform \"ParkingLot\" (kind = \"group\") { def \"car01\" (references = @cars.usda@) {} } cars.usda: #usda 1.0 ( upAxis = \"Y\" ) def Xform \"redCar\" (kind = \"component\") { def Mesh \"chassis\" {} } def Xform \"blueCar\" (kind = \"component\") { def Mesh \"chassis\" {} } What are ways to fix this issue?",
+    "a": [
+      "Set the defaultPrim in cars.usda",
+      "Explicitly set the prim type for car01 in parkingLot.usda",
+      "Add a target prim to the reference in parkingLot.usda",
+      "Make the ParkingLot prim in parkingLot.usda an assembly kind"
+    ],
+    "c": [
+      0,
+      2
+    ],
+    "multi": true,
+    "e": "The missing chassis is caused by an unresolved reference target. In parkingLot.usda, the reference is authored as @cars.usda@ without a target prim path. When a reference omits the target prim path, USD uses the referenced layer’s defaultPrim as the entry point. NVIDIA’s Learn OpenUSD guide states that if no defaultPrim is set, bringing that layer in as a reference or payload resolves as an empty layer and emits a warning. It also identifies defaultPrim as layer metadata and a best practice for stages intended to be referenced or payloaded. Option A fixes the issue by setting, for example, defaultPrim = \"redCar\" in cars.usda, allowing @cars.usda@ to resolve to /redCar and bring in its chassis. Option C also fixes it by making the reference explicit, for example references = @cars.usda@</redCar>. NVIDIA’s data-transformation guidance similarly notes that without defaultPrim, a stage cannot be referenced without specifying a target prim. Option B does not solve reference resolution; assigning a type to car01 would not identify which car to compose. Option D changes model-kind semantics only and does not affect the reference target. This aligns with Composition → Reference, Default Prim, Target Prim Paths, and Asset Entry Points."
+  },
+  {
+    "q": "When developing a custom USD schema, what statements are true regarding API schemas versus typed schemas? Choose two.",
+    "a": [
+      "API schemas can be applied to multiple prim types while typed schemas define a specific prim type.",
+      "Multiple API schemas can be applied to a single prim, but a prim can only have one typed schema.",
+      "API schemas are more strict than typed and cannot define their own attributes or relationships.",
+      "API schemas require Python bindings while typed schemas can be implemented to only support C++."
+    ],
+    "c": [
+      0,
+      1
+    ],
+    "multi": true,
+    "e": "API schemas and typed schemas serve different modeling roles in OpenUSD. NVIDIA’s Learn OpenUSD schema guidance states that IsA, or typed, schemas define what a prim fundamentally is by assigning a typeName, while API schemas define what capabilities a prim has by adding optional properties or behaviors to an already-typed prim. API schemas do not assign a typeName; instead, they are list-edited through the apiSchemas metadata and queried with HasAPI. (docs.nvidia.com) Option A is correct because API schemas can be applied across different prim types, while a typed schema defines a specific prim type such as Mesh, Camera, or Xform. Option B is also correct because one prim has a single typed schema identity, but multiple API schemas can be applied to enrich that prim with additional behaviors. NVIDIA further notes that API schemas may be single- apply or multiple-apply, where multiple-apply schemas can be applied more than once to the same prim using different instance names. (docs.nvidia.com) Option C is incorrect because API schemas can define attributes and relationships. Option D is incorrect because Python binding policy is not the distinguishing factor between API and typed schemas. This aligns with Customizing USD → Schemas, IsA Schemas, API Schemas, typeName, apiSchemas Metadata."
+  },
+  {
+    "q": "What is a way to utilize both USDA and USDC as part of a scene?",
+    "a": [
+      "Use USDC for prims related to shading and USDA for all other prim types.",
+      "Use USDA for non-geometric prims and USDC for geometric and animation data.",
+      "Use USDA entirely as USDC is most helpful for when debugging issues with scenes."
+    ],
+    "c": [
+      1
+    ],
+    "e": "A practical mixed-format strategy is to use human-readable USDA for lighter, structural, or non- geometric layers, while using binary USDC for heavier geometry and animation data. NVIDIA’s Learn OpenUSD layer guidance identifies .usd, .usda, and .usdc as USD layer formats, where each layer is a modular source of scene description that can participate in composition. (docs.nvidia.com) This means a scene can compose different layers with different encodings through sublayers, references, payloads, and other arcs. Option B is correct because it reflects the common pipeline division: USDA is convenient for inspection, debugging, review, and hand-authored structural opinions, while USDC is better suited for dense numeric data such as meshes, point caches, and time-sampled animation because it is compact and efficient for machine consumption. The official OpenUSD toolset also supports conversion between formats using tools such as usdcat, allowing pipelines to choose the representation that best fits each layer’s purpose. (openusd.org) Option A is too rigid; shading data does not require USDC. Option C reverses the usual debugging distinction because USDA is the readable format commonly preferred when inspecting scene text. This aligns with Data Exchange → USD File Formats, Layer Composition, USDA, USDC, and Pipeline File Strategy."
+  },
+  {
+    "q": "You are debugging a stage where a prim is expected to have opinions from a referenced asset, but those opinions are not appearing in the composed scene. Which of the following are logical things to check to troubleshoot this issue?",
+    "a": [
+      "Whether a payload has opinions that may be overriding the opinions from the referenced asset.",
+      "Whether the referenced asset has the valid model kind set to maintain a proper model kind hierarchy.",
+      "Whether the prim has any variant selections active that might be hiding or overriding the referenced content.",
+      "Whether the reference path is correct and the referenced asset exists at that location."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "The first logical checks are the reference target and any variant selections affecting the prim. Option D is correct because if the referenced asset path is wrong, the asset cannot be resolved, or the referenced layer lacks the expected target prim or defaultPrim, the referenced opinions will not appear .NVIDIA’s default-prim guidance explains that a reference without a prim path relies on the referenced layer’s defaultPrim; without it, the reference can compose as empty. (docs.nvidia.com) Option C is also correct because variant selections can alter what scene description is composed. NVIDIA’s variant-set material explains that variants may change attributes, visibility, activation, or even reference paths; when variants change references or activation, USD recomputes the composed structure. (docs.nvidia.com) Option A is generally not the right diagnosis because payload arcs are weaker than reference arcs in standard LIVERPS ordering, so they are not the first candidate for overriding a reference at the same site. Option B is unrelated to whether a reference composes; model kind affects organization and traversal, not basic reference resolution. This aligns with Debugging and Troubleshooting → Reference, Asset Resolution, defaultPrim, Variant Selections, and Composition Diagnostics."
+  },
+  {
+    "q": "Review the following code for creating 1000 sphere instances. When this code is executed, why will the authored prims not yield any instancing efficiencies? for i in range(1000): xform = UsdGeom.Xform.Define(stage, f\"/test_{i}\") sphere_path = xform.GetPath().AppendPath(\"sphere\") UsdGeom.Sphere.Define(stage, sphere_path) xform.GetPrim().SetInstanceable(True) xform.AddTranslateOp().Set((i * 2, 0, 0))",
+    "a": [
+      "There are no composition arcs so the instanceable metadata is ignored.",
+      "Every sphere has a different position so the instanceable metadata is ignored.",
+      "You must also call Usd.Prim.SetInstanceable(True) for each sphere prim that is created."
+    ],
+    "c": [
+      0
+    ],
+    "e": "The authored prims do not produce scenegraph-instancing efficiencies because the code authors local prim hierarchies directly under each /test_i prim rather than composing shared content through references, payloads, inherits, specializes, or variant arcs. NVIDIA’s Learn OpenUSD scenegraph instancing guidance states that “Instancing is driven by your composition arcs” and explains that if there are no composition arcs on the instanceable prims, there is nothing from which OpenUSD can generate shared prototypes. (docs.nvidia.com) Option A is correct because instanceable = true alone is not sufficient. OpenUSD scenegraph instancing works by sharing composed subgraphs brought in through composition arcs; in this code, every sphere is authored as a unique local child in the same layer stack. NVIDIA’s Omniverse instancing guide states that if no composition arcs are directly authored on an instanceable prim, the prim behaves as if instanceable were false. (docs.omniverse.nvidia.com) Option B is incorrect because instance roots may vary by transform, primvars, and other root-level data while still sharing prototypes. Option C is incorrect because the child sphere is not the instance root; marking it instanceable would still not create shared prototypes without composition arcs. This aligns with Content Aggregation → Asset Modularity and Instancing → Scenegraph Instancing, Composition Arcs, Instance Roots, and Implicit Prototypes."
+  },
+  {
+    "q": "In a complex scene with multiple composition arcs, which of the following could cause unexpected property values? Choose two.",
+    "a": [
+      "Using too many attribute connections",
+      "Using incorrect layer offsets",
+      "Using different file formats for layers, e.g. .usda and .usdc",
+      "Multiple opinions on the same property in different layers"
+    ],
+    "c": [
+      1,
+      3
+    ],
+    "multi": true,
+    "e": "Unexpected property values usually come from value resolution, time remapping, or competing authored opinions. NVIDIA’s Learn OpenUSD value-resolution guidance explains that OpenUSD determines the final value of a property by looking through the ordered sources that contribute information, from strongest to weakest, and resolving the relevant authored data according to property type. (docs.nvidia.com) Option B is correct because layer offsets retime animated data across composition arcs such as references, payloads, and sublayers. If an offset or scale is wrong, a time-sampled property can evaluate at an unexpected source time, producing an apparently incorrect value. Option D is correct because multiple layers can author opinions on the same property, and the stronger opinion wins according to composition and value-resolution rules. NVIDIA’s strength-ordering guidance emphasizes that LIVERPS and layer-stack ordering determine which opinions are considered strongest. (docs.nvidia.com) Option A is not a primary cause by itself; connections may affect shader or node-network behavior, but “too many” connections does not inherently change USD property resolution. Option C is incorrect because .usda, .usdc, and .usd are storage encodings for layers, not different composition semantics. This aligns with Debugging and Troubleshooting → Value Resolution, Layer Offsets, Composition Strength, and Property Stacks."
+  },
+  {
+    "q": "Which option best describes the primary function of an inherit composition arc in OpenUSD?",
+    "a": [
+      "Inherit arcs are a replacement for reference arcs when you have an opinion that needs to be stronger than opinions from a variant set.",
+      "Modifications to the inherited prim in stronger layer stacks allow for those overrides to be uniformly broadcast to all inheriting prims.",
+      "It provides a mechanism for implementing object-oriented programming (OOP) design patterns in your scene description design."
+    ],
+    "c": [
+      1
+    ],
+    "e": "An inherit arc lets prims receive scene description from a source prim, commonly a class prim, and enables modifications to that inherited source to broadcast to all inheriting prims in the relevant composition context. NVIDIA’s Learn OpenUSD inherits lesson states that after an inherit arc is established, the source prim and its descendants can be modified in a stronger layer, including across references, and those modifications are broadcast and applied to all prims that inherit it. (docs.nvidia.com) Option B is correct because it captures the defining production use: central refinement of many related prims without editing every instance individually and without modifying the original referenced asset globally. NVIDIA’s strength-ordering lesson also describes inherits as the arc that allows opinions on one source prim to affect all prims that author an inherit arc to that source. (docs.nvidia.com) Option A is incorrect because inherits are not simply a replacement for references; they solve broadcast refinement and reusable opinion-sharing problems. Option C is conceptually adjacent but imprecise: inherits may resemble inheritance patterns, but USD inherit arcs are composition mechanisms, not an object-oriented programming system. This aligns with Composition → Inherits, Class Prims, Broadcast Refinement, Encapsulation, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "Referring to dining_room.usda, which of the following best describes the role of the references composition arc on the /Root/Chair prim? #usda 1.0 def Xform \"Root\" { def Xform \"Chair\" ( references = @chair .usda@ ) { float3 xformOp:scale = (1.5, 1.5, 1.5) } }",
+    "a": [
+      "It creates a bidirectional link between the local /Root/chair prim and chair .usdaso that any changes in one are automatically reflected in the other .",
+      "It is used to import variant sets from chair .usdainto the local /Root/chair prim.",
+      "It completely replaces the local /Root/chair prim with the contents of chair .usda,ignoring any local attribute definitions such as scale.",
+      "It composes the definition from chair .usdawith the local /Root/Chair .The local xformOp:scale overrides corresponding referenced opinions."
+    ],
+    "c": [
+      3
+    ],
+    "e": "A reference composition arc brings scene description from another asset into the prim where the reference is authored, then combines that referenced data with local opinions on the destination prim. NVIDIA’s Learn OpenUSD references guide states that when a prim is composed through a reference arc, USD first composes the layer stack of the referenced prim, adds the resulting prim spec to the destination prim, and then applies overrides or additional composition arcs from the destination prim. Option D is correct because /Root/Chair receives the composed contents of chair .usda,while the locally authored xformOp:scale = (1.5, 1.5, 1.5) remains part of the destination prim’s stronger local opinions. If the referenced chair asset also authored a corresponding scale opinion on the same property, the local opinion would win by standard USD strength ordering, where stronger opinions override weaker ones non-destructively. Option A is incorrect because references are not bidirectional synchronization links; editing the referencing layer does not automatically modify chair .usda.Option B is too narrow because references compose all targeted scene description, not only variant sets. Option C is incorrect because a reference does not discard local opinions. This aligns with Composition → Reference, Local Opinions, Layer Strength, and Non-Destructive Overrides."
+  },
+  {
+    "q": "Which of these data is lost when flattening a stage?",
+    "a": [
+      "prim metadata",
+      "scenegraph instancing",
+      "variant sets",
+      "class prims"
+    ],
+    "c": [
+      2
+    ],
+    "e": "Flattening a stage resolves the composed result into a single merged layer, baking the effects of composition into authored scene description. The critical loss here is variant-set structure. OpenUSD’s UsdStage::Flatten() documentation states that flattening removes most composition metadata and that “all VariantSets are removed and only the currently selected variants will be present in the resulting layer .”This means the flattened output preserves the currently selected representation, but the ability to switch among alternate variants is lost. Option C is therefore correct. Option A is not the best answer because flattening authors resolved values and can preserve relevant composed metadata, although composition metadata is removed. Option B is incorrect because modern OpenUSD flattening preserves native scenegraph instancing by flattening prototypes and adding internal references from instances to their corresponding prototypes. Option D is incorrect because class prims still exist after flattening, although inherit arcs are removed and inherited data is copied onto consuming prims. This aligns with Composition → Flattening, Variant Sets, Composition Metadata, Inherits, and Scenegraph Instancing."
+  },
+  {
+    "q": "When designing a scalable asset structure, which two aspects should be primarily considered? Choose two.",
+    "a": [
+      "Innovation and future-proofing",
+      "File formats and compression methods",
+      "Clients and collaborators",
+      "Modularity and performance"
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "A scalable asset structure should be designed around the needs of clients and collaborators and around structural principles such as modularity and performance. NVIDIA’s Learn OpenUSD asset- structure guidance states that a well-designed scalable asset structure should always be tailored to the needs of clients and collaborators. It also emphasizes that collaboration is core to OpenUSD and that scalable structures should support parallel workstreams across multiple dimensions. Option C is correct because asset structure is not created in isolation; it must serve the downstream consumers, artists, tools, departments, and delivery requirements that will interact with the asset. Option D is correct because NVIDIA identifies the four principles of scalable asset structure as Legibility, Modularity, Performance, and Navigability. Modularity enables reuse and flexible composition, while performance ensures efficient reads, writes, loading, and interaction at production scale. Option A is too vague and not one of the named primary design aspects. Option B can matter tactically, but file formats and compression are implementation choices, not the primary asset- structure design drivers. This aligns with Content Aggregation → Asset Structure Principles → Clients, Collaborators, Modularity, Performance, and Scalability."
+  },
+  {
+    "q": "Which of the following statements about debugging complex LIVRPS scenarios are correct?",
+    "a": [
+      "Local opinions should be checked first when debugging composition issues.",
+      "Specialize arcs cannot be overridden, so they can be ignored during debugging.",
+      "Payload arcs should be checked before Reference arcs for more efficient debugging."
+    ],
+    "c": [
+      0
+    ],
+    "e": "Option A is correct because local opinions are the strongest opinions in USD composition strength ordering. NVIDIA’s Learn OpenUSD strength-ordering guide describes LIVRPS, now also written as LIVERPS with relocates included, as the ordered set of composition operations used to determine which opinions win. The order is strongest to weakest: local, inherits, variant sets, relocates, references, payloads, and specializes. When debugging an unexpected value, local opinions should be inspected first because a directly authored opinion in the local layer stack can override opinions arriving through other composition arcs. NVIDIA’s tracing guidance also highlights how complex composition debugging becomes when many prims, properties, layers, and arcs contribute competing opinions. Option B is false because specializes arcs are not unoverrideable; they are the weakest fallback-style opinions in the composition order .Option C is false because references are stronger than payloads in LIVRPS/LIVERPS ordering, so checking payloads before references reverses the standard diagnostic priority. This aligns with Debugging and Troubleshooting → LIVERPS Strength Ordering, Local Opinions, Reference, Payloads, Specializes, and Composition Diagnostics."
+  },
+  {
+    "q": "Which of the following are immutable once a USD Stage has been opened? Choose two.",
+    "a": [
+      "Rules for loading payloads from prims in the stage.",
+      "Layers that are muted or unmuted in the stage.",
+      "The path resolver context that is bound to the stage.",
+      "Variant fallbacks for prims without variant selection in the stage."
+    ],
+    "c": [
+      2,
+      3
+    ],
+    "multi": true,
+    "e": "The immutable stage-opening concerns are the path resolver context and the variant fallback configuration used for unselected variants. The resolver context is bound when the stage is created or opened and is used for future asset-path resolution on that stage, regardless of what other resolver context may be bound elsewhere. The OpenUSD UsdStage API documentation describes this binding behavior during stage creation, making option C correct. Option D is also correct because global variant fallback preferences are defined as preferences “used in new UsdStages.” Once a stage has been composed with its fallback preferences, changing global fallback settings affects newly opened stages, not the already-opened stage’s established fallback behavior . Option A is incorrect because payload loading is mutable: Load(), Unload(), LoadAndUnload(), and SetLoadRules() modify the stage’s payload working set after opening. Option B is incorrect because layers can be muted and unmuted on an existing stage through MuteLayer(), UnmuteLayer(), and MuteAndUnmuteLayers(). This aligns with Pipeline Development → Stage Opening, Asset Resolution, Variant Fallbacks, Load Rules, and Layer Muting."
+  },
+  {
+    "q": "A key responsibility of the pipeline is to assemble content that may have divergent stage metadata across layer stacks. Which of these metadata is automatically handled by composition when they diverge across layer stacks?",
+    "a": [
+      "timeCodesPerSecond",
+      "upAxis",
+      "kilogramsPerUnit",
+      "metersPerUnit"
+    ],
+    "c": [
+      0
+    ],
+    "e": "The metadata automatically handled by composition is timeCodesPerSecond. NVIDIA’s Learn OpenUSD units guidance states the distinction directly: timeCodesPerSecond is automatically reconciled during composition, while metersPerUnit, kilogramsPerUnit, and upAxis are not. Pipelines must therefore explicitly handle geometric orientation, spatial scale, and physics mass-unit mismatches when assembling assets from different sources. Option A is correct because OpenUSD can automatically scale time-sampled values across sublayer, reference, and payload arcs when source and target layer stacks use different timeCodesPerSecond values. OpenUSD’s time-value documentation explains that when a targeted layer specifies timeCodesPerSecond, TimeCode coordinates and animated value coordinates are automatically scaled into the time frame defined by the source layer’s timeCodesPerSecond. Options B, C, and D are incorrect because USD does not automatically rotate geometry for different upAxis, scale geometry for different metersPerUnit, or convert physics mass semantics for different kilogramsPerUnit. Those require pipeline conventions, validation, or corrective transforms. This aligns with Pipeline Development → Stage Metadata, Units, TimeCode Scaling, Asset Assembly, and Pipeline Validation."
+  },
+  {
+    "q": "Suppose you had the following layer: #usda 1.0 ( defaultPrim = \"ParentXform\" ) def Xform \"ParentXform\" { def Mesh \"ChildMesh\" { } } If you wanted to add a property to \"ParentXform\" such that it would automatically propagate to \"ChildMesh\" without having to add the same property to \"ChildMesh\", which of the following changes to \"ParentXform\" would make this work?",
+    "a": [
+      "Add the property as a custom attribute: custom string myProperty = \"TestValue\"",
+      "Add the property as a relationship to </ParentXform/ChildMesh>: rel myProperty = </ParentXform/ChildMesh>",
+      "Add the property as a primvar, with \"constant\" interpolation: string primvars:myProperty = \"TestValue\"( interpolation = \"constant\" )"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The correct mechanism is a constant-interpolation primvar .NVIDIA’s Learn OpenUSD glossary defines primvars as primitive variables authored using the primvars: namespace and interpolation metadata such as constant, uniform, vertex, and faceVarying. Primvars are designed to carry geometric or shading-related data in a way that consumers can discover through UsdGeomPrimvarsAPI and UsdGeomPrimvar .(docs.nvidia.com) Option C is correct because constant primvars can inherit down the namespace hierarchy. The OpenUSD UsdGeomPrimvar documentation states that constant interpolation primvar values can be inherited by child prims unless those children author their own opinion for the same primvar . (openusd.org) This allows primvars:myProperty authored on /ParentXform to be discovered on /ParentXform/ChildMesh without duplicating the property on the mesh. Option A is incorrect because ordinary custom attributes do not automatically propagate to descendant prims. Option B is incorrect because a relationship targets another object; it does not create inherited property data on that target. This aligns with Data Modeling → Primvars, Constant Interpolation, Namespace Inheritance, and Geometric Property Authoring."
+  },
+  {
+    "q": "You are setting up an outdoor scene with realistic lighting and want to simulate the effect of the sun. Which UsdLux light type is most appropriate for this purpose, providing a directional light source with parallel rays?",
+    "a": [
+      "RectLight",
+      "DomeLight",
+      "DistantLight",
+      "SphereLight"
+    ],
+    "c": [
+      2
+    ],
+    "e": "The correct UsdLux light type is DistantLight. NVIDIA’s Learn OpenUSD lighting guide identifies UsdLux.DistantLight as a schema where light is emitted from a distant source along the negative Z axis, commonly known as a directional light. This makes it the most appropriate light type for representing sunlight in an outdoor scene. Option C is correct because sunlight is effectively modeled as coming from an extremely distant source, so its rays are treated as broadly parallel across the scene. The OpenUSD DistantLight schema documentation explicitly describes it as typically used for distant, broad light sources like sunlight, where rays affect the entire scene and are roughly parallel. It also notes that the inputs:angle attribute controls angular diameter; the fallback value approximates the Sun’s apparent angular size from Earth. Option A, RectLight, is better suited for rectangular area emitters such as panels or windows. Option B, DomeLight, is commonly used for environment or HDRI lighting. Option D, SphereLight, represents local emission from a spherical source, such as a bulb. This aligns with Visualization → UsdLux, Lighting Schemas, DistantLight, Directional Lighting, and Outdoor Illumination."
+  },
+  {
+    "q": "What will be the composed value of /World/Tree/Canopy.primvars:displayColor when you open stage.usda? #usda 1.0 ( defaultPrim = \"World\" metersPerUnit = 1.0 upAxis = \"Z\" ) def Xform \"World\" { def Xform \"Tree\" ( variantSets = [\"foliage_color\"] variants = { string foliage_color = \"default\" } ) { def Cone \"Canopy\" ( references = [</_base_foliage_color>] ) { double3 xformOp:translate = (0, 0, 1.3) token[] xformOpOrder = [\"xformOp:translate\"] } def Cylinder \"Trunk\" { color3f[] primvars:displayColor = [(0.2, 0.1, 0.05)] double3 xformOp:scale = (0.4, 0.4, 0.4) token[] xformOpOrder = [\"xformOp:scale\"] } variantSet \"foliage_color\" = { \"default\" { } \"evergreen\" { over \"Canopy\" { color3f[] primvars:displayColor = [(0.05, 0.15, 0.05)] } } \"orange\" { over \"Canopy\" { color3f[] primvars:displayColor = [(0.5, 0.3, 0.05)] } } } } } class \"_base_foliage_color\" { color3f[] primvars:displayColor = [(0.2, 0.75, 0.1)] }",
+    "a": [
+      "[(0.5, 0.3, 0.05)]",
+      "[(0.2, 0.75, 0.1)]",
+      "unset",
+      "[(0.05, 0.15, 0.05)]"
+    ],
+    "c": [
+      1
+    ],
+    "e": "The composed value is [(0.2, 0.75, 0.1)]. The active variant selection on /World/Tree is foliage_color = \"default\", and the \"default\" variant contains no authored opinion for Canopy.primvars:displayColor . Therefore, the \"evergreen\" and \"orange\" variant opinions are not active and cannot contribute their color values. NVIDIA’s Learn OpenUSD variant-set guidance explains that a variant set provides alternative authored representations, but only the selected variant contributes to the composed result. The remaining contributing opinion is the reference on def Cone \"Canopy\": references = [</_base_foliage_color>]. Reference are composition arcs that bring scene description from a targeted prim into the destination prim without copying it. The referenced class prim /_base_foliage_color authors color3f[] primvars:displayColor = [(0.2, 0.75, 0.1)], so that value composes onto /World/Tree/Canopy. No stronger local or selected-variant opinion overrides it. This follows USD strength ordering, where opinions are resolved through composition arcs and the strongest applicable opinion wins. This aligns with Composition → Reference, Variant Sets, Selected Variants, and LIVERPS Strength Ordering."
+  },
+  {
+    "q": "Which of the following are true for SdfChangeBlocks? Choose two.",
+    "a": [
+      "Notifications are muted for changes done within the block, even after the block exits",
+      "Existing metadata and properties can be changed using USD APIs within the same block",
+      "It is unsafe to query Prims that are mutating within the same block",
+      "It is unsafe to delete or create new PrimSpec hierarchies using Sdf APIs"
+    ],
+    "c": [
+      2
+    ],
+    "e": "Strictly evaluated against the OpenUSD API contract, C is the only fully correct statement as written. SdfChangeBlock groups multiple low-level Sdf edits so that change processing can be delayed and handled efficiently as one batch. The official API documentation states that opening a change block causes Sdf to delay notifications until the outermost block exits; notifications are queued, not permanently muted. Therefore, A is incorrect. The same documentation gives a strong warning that it is not safe to use Usd or other downstream APIs while a change block is open, because those representations may be stale or may hold expired handles to Sdf objects. Therefore, querying mutating prims during the block is unsafe, making C correct. Option B is incorrect because it explicitly says to use USD APIs inside the block, which the official guidance warns against. Option D is also incorrect because the intended safe authoring pattern is to gather required edits first, then apply them directly through the Sdf API inside the change block. This aligns with Pipeline Development → Efficient Authoring, Sdf Layers, SdfChangeBlock, Change Notification, and Bulk Scene Description Mutation."
+  },
+  {
+    "q": "Which statement accurately describes a key difference between native instancing and point instancing?",
+    "a": [
+      "Point instancing generates prototypes dynamically, while native instancing uses statically defined prims.",
+      "Native instancing can only use a single prototype per scene, while point instancing can use multiple prototypes.",
+      "Native instancing requires prototypes to be defined in separate files, while point instancing requires them in the same layer .",
+      "Native instances are individually addressable prims in the scene hierarchy after composition, while point instances are not."
+    ],
+    "c": [
+      3
+    ],
+    "e": "The key distinction is addressability and representation. Native, or scenegraph, instancing preserves each instance as a prim in the composed scene hierarchy. Each instance root can have its own path, transform, metadata, and root-level refinements while sharing an implicit prototype generated from matching instanceable composition. OpenUSD’s scenegraph instancing documentation explains that prims bringing in common scene description through composition arcs can share those composed subgraphs rather than duplicating them per prim. Point instancing, by contrast, is a vectorized representation. NVIDIA’s instancing guide states that point instancing represents repeated instances through array attributes such as positions, orientations, scales, prototype indices, and prototype relationships. It is more compact because it does not require a prim for each instance, but this comes with reduced flexibility and addressability. Option D is correct because native instances remain individually addressable scenegraph prims, while point instances are addressed through array elements and IDs rather than unique prim paths. A reverses prototype behavior: native instancing uses implicit prototypes, while point instancing uses explicit prototype relationships. B and C impose restrictions that do not exist. This aligns with Content Aggregation → Scenegraph Instancing, PointInstancer, Prototypes, Addressability, and Scalable Repetition."
+  },
+  {
+    "q": "In the context of UsdGeomMesh, which statement is true about mesh normals?",
+    "a": [
+      "The number of authored normals must be equal to the number of points in a polygonal mesh.",
+      "vertex normals are used for subdivision meshes and faceVarying normals are used only for polygonal meshes.",
+      "faceVarying normals are specified per face corner, while vertex normals specify a single normal per point."
+    ],
+    "c": [
+      2
+    ],
+    "e": "Option C correctly describes the relationship between interpolation and element counts for mesh normals and normal-like primvars. In UsdGeomMesh, vertex interpolation provides one value per mesh point, while faceVarying interpolation provides one value for each face-vertex, meaning each corner of each face can carry its own value. This distinction is essential for representing smooth normals, hard edges, UV seams, and other discontinuities across faces. OpenUSD’s UsdGeomMesh documentation defines vertex interpolation as one element per point and faceVarying interpolation as one element for each face-vertex that defines the mesh topology. Option A is incorrect because authored normals do not always have to match the number of points; the required count depends on the normals interpolation. Face-varying normals, for example, require one value per face corner rather than one per point. Option B is incorrect because normals should generally not be authored on subdivision meshes; subdivision algorithms define their own normals. OpenUSD notes that authored normals should only be used for polygonal meshes where subdivisionScheme = \"none\". This aligns with Data Modeling → UsdGeomMesh, Normals, Primvar Interpolation, Vertex Data, Face-Varying Data, and Polygonal Mesh Representation."
+  },
+  {
+    "q": "In OpenUSD, when composing a stage, why might opinions from one layer not take effect in the final composed stage?",
+    "a": [
+      "The opinions are in a non-editable layer that does not allow modifications during composition.",
+      "The layer containing the opinion does not use the correct schema for the data.",
+      "The layer is not referenced properly, so its opinions are ignored.",
+      "The layer containing the opinion has a lower strength than other layers, and its changes are overridden."
+    ],
+    "c": [
+      3
+    ],
+    "e": "An authored opinion may be valid and still not appear in the final composed stage because USD resolves competing opinions by strength ordering. NVIDIA’s Learn OpenUSD strength-ordering guide explains that, for each prim and property, the composition engine evaluates opinions from contributing layers and composition arcs using LIVRPS, giving precedence to stronger opinions when conflicts occur .It also states that stronger layers can override or add to data defined in weaker layers, enabling non-destructive edits and overrides. Option D is correct because a weaker layer’s opinion can be hidden by a stronger opinion authored elsewhere in the layer stack or through a stronger composition context. This is a normal result of USD composition, not an error .Option A is incorrect because editability controls whether a layer can be modified, not whether its authored opinions can contribute during composition. Option B may indicate invalid or poorly modeled data, but schema choice alone is not the general reason an opinion loses. Option C can be a troubleshooting case for missing referenced content, but the question asks why opinions from a composed layer may not take effect. This aligns with Composition → Layer Stacks, Opinion Strength, LIVRPS, Value Resolution, and Non-Destructive Overrides."
+  },
+  {
+    "q": "You have the following layers: cone1.usda: #usda 1.0 ( upAxis = \"Y\" defaultPrim = \"Cone\" ) def Cone \"Cone\" { uniform token axis = \"Z\" double radius = 2 double height = 3 } cone2.usda: #usda 1.0 ( upAxis = \"Z\" defaultPrim = \"Cone\" ) def Cone \"Cone\" { uniform token axis = \"Z\" double radius = 2 double height = 3 } The following root layer references these two layers and is opened by a DCC tool that does not apply any sort of corrective transformations to any layer data: coneScene.usda: #usda 1.0 ( upAxis = \"Z\" ) def Cone \"Cone1\" ( prepend references = @./cone1.usda@</Cone> ) { double3 xformOp:translate = (-5, 0, 0) uniform token[] xformOpOrder = [\"xformOp:translate\", \"xformOp:rotateXYZ\", \"xformOp:scale\"] } def Cone \"Cone2\" ( prepend references = @./cone2.usda@</Cone> ) { double3 xformOp:translate = (5, 0, 0) uniform token[] xformOpOrder = [\"xformOp:translate\", \"xformOp:rotateXYZ\", \"xformOp:scale\"] } When viewing the scene in the DCC tool, in a view/camera orientation that matches the scene upAxis, what should the orientations of the two cones be?",
+    "a": [
+      "Both Cone1 and Cone2 are pointed along the Z-axis.",
+      "Cone1 pointed along the Y-axis, Cone2 pointed along the Z-axis.",
+      "Both Cone1 and Cone2 are pointed along the Y-axis.",
+      "Cone1 pointed along the Z-axis, Cone2 pointed along the Y-axis."
+    ],
+    "c": [
+      0
+    ],
+    "e": "Both cones should point along the Z-axis. The decisive authored property on each Cone prim is uniform token axis = \"Z\", which defines the cone’s local geometric axis. The differing upAxis metadata in cone1.usda and cone2.usda does not automatically rotate referenced geometry when those assets are composed into coneScene.usda. NVIDIA’s Learn OpenUSD units guidance states that upAxis, metersPerUnit, and kilogramsPerUnit are manually handled metadata during composition, while only timeCodesPerSecond is automatically reconciled. It specifically explains that USD does not automatically reconcile geometric unit metadata across composed layer stacks. Option A is correct because the root stage is Z-up, the DCC applies no corrective transform, and both referenced cone prims explicitly author their primitive axis as Z. Option B incorrectly assumes that the source layer’s upAxis = \"Y\" causes automatic conversion into the root stage’s coordinate system. Option C and D likewise invent orientation changes that are not authored. In production, pipelines must validate or explicitly correct up-axis mismatches through transforms or import/export policy. This aligns with Pipeline Development → Stage Metadata, upAxis, Asset Assembly, Reference, and Manual Unit Reconciliation. Thank you for your visit. To try more exams, please visit below link"
+  }
+];
+const SETS = [];
+
+const quiz = document.getElementById('quiz');
+const scoreEl = document.getElementById('score');
+let activeSet = 'all';  // 'all' or a set name like 'set1'
+
+function letter(i) { return String.fromCharCode(65 + i); }
+
+function renderQuestion(q, qi) {
+  const isMulti = !!q.multi;
+  const type = isMulti ? 'checkbox' : 'radio';
+  const opts = q.a.map((text, oi) => `
+    <li>
+      <label data-qi="${qi}" data-oi="${oi}">
+        <input type="${type}" name="q${qi}" value="${oi}">
+        <strong>${letter(oi)}.</strong> ${escapeHtml(text)}
+      </label>
+    </li>`).join('');
+  const setTag = q.set ? `<span class="set-tag">${escapeHtml(q.set)}</span>` : '';
+  const multiTag = isMulti ? ' <span class="multi-tag">multi</span>' : '';
+  const setAttr = q.set ? `data-set="${escapeHtml(q.set)}"` : '';
+  const expHtml = q.e
+    ? `<div class="explanation" id="exp${qi}" hidden><span class="exp-label">Explanation</span>${escapeHtml(q.e)}</div>`
+    : '';
+  const expBtn = q.e ? `<button data-explain="${qi}">Explanation</button>` : '';
+  return `
+    <div class="q" id="q${qi}" data-qi="${qi}" ${setAttr}>
+      <h2>${qi + 1}. ${escapeHtml(q.q)}${multiTag}${setTag}</h2>
+      <ul class="opts">${opts}</ul>
+      <div class="actions">
+        <button data-check="${qi}">Check</button>
+        <button data-reset="${qi}">Reset</button>
+        ${expBtn}
+      </div>
+      ${expHtml}
+    </div>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  })[c]);
+}
+
+function checkQuestion(qi) {
+  const q = QUESTIONS[qi];
+  const correct = new Set(q.c);
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    const oi = +label.dataset.oi;
+    const input = label.querySelector('input');
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    if (input.checked) {
+      if (correct.has(oi)) label.classList.add('correct');
+      else label.classList.add('wrong');
+    } else if (correct.has(oi)) {
+      label.classList.add('reveal-correct');
+    }
+  });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = false;
+  updateScore();
+}
+
+function resetQuestion(qi) {
+  document.querySelectorAll(`#q${qi} .opts label`).forEach(label => {
+    label.classList.remove('correct', 'wrong', 'reveal-correct');
+    label.querySelector('input').checked = false;
+  });
+  const exp = document.getElementById(`exp${qi}`);
+  if (exp) exp.hidden = true;
+  updateScore();
+}
+
+function inActiveSet(q) {
+  return activeSet === 'all' || q.set === activeSet;
+}
+
+function updateScore() {
+  let answered = 0, correct = 0, total = 0;
+  QUESTIONS.forEach((q, qi) => {
+    if (!inActiveSet(q)) return;
+    total++;
+    const inputs = document.querySelectorAll(`#q${qi} input`);
+    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    if (picked.length === 0) return;
+    answered++;
+    const expected = new Set(q.c);
+    const isExactMatch =
+      picked.length === expected.size &&
+      picked.every(p => expected.has(p));
+    if (isExactMatch) correct++;
+  });
+  const label = activeSet === 'all' ? 'overall' : activeSet;
+  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+}
+
+function applyFilter() {
+  QUESTIONS.forEach((q, qi) => {
+    const el = document.getElementById(`q${qi}`);
+    if (!el) return;
+    el.classList.toggle('hidden', !inActiveSet(q));
+  });
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.set === activeSet);
+  });
+  updateScore();
+}
+
+// ── Cache: persist answers + checked state across reloads ────────────────────
+const CACHE_KEY = 'quiz-cache-ncp-ousd-practice-test';
+
+function saveCache() {
+  const answers = {};   // qi -> [oi, ...]
+  const checked = {};   // qi -> true
+  QUESTIONS.forEach((q, qi) => {
+    const picked = [...document.querySelectorAll(`#q${qi} input:checked`)]
+      .map(i => +i.value);
+    if (picked.length) answers[qi] = picked;
+    // A question is "checked" if any label has a result class.
+    const el = document.getElementById(`q${qi}`);
+    if (el && el.querySelector('.correct, .wrong, .reveal-correct')) checked[qi] = true;
+  });
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ answers, checked })); } catch(_) {}
+}
+
+function loadCache() {
+  let cache;
+  try { cache = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch(_) {}
+  if (!cache) return;
+  const { answers = {}, checked = {} } = cache;
+  // Restore selections first.
+  Object.entries(answers).forEach(([qi, ois]) => {
+    ois.forEach(oi => {
+      const input = document.querySelector(`#q${qi} input[value="${oi}"]`);
+      if (input) input.checked = true;
+    });
+  });
+  // Restore checked visual state.
+  Object.keys(checked).forEach(qi => checkQuestion(+qi));
+}
+
+quiz.innerHTML = QUESTIONS.map(renderQuestion).join('');
+
+// Restore cache after DOM is built.
+loadCache();
+
+quiz.addEventListener('click', e => {
+  const t = e.target;
+  if (t.matches('[data-check]')) { checkQuestion(+t.dataset.check); saveCache(); }
+  else if (t.matches('[data-reset]')) { resetQuestion(+t.dataset.reset); saveCache(); }
+  else if (t.matches('[data-explain]')) {
+    const ex = document.getElementById(`exp${t.dataset.explain}`);
+    if (ex) ex.hidden = !ex.hidden;
+  }
+});
+quiz.addEventListener('change', () => { updateScore(); saveCache(); });
+
+document.getElementById('checkAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) checkQuestion(qi); });
+  saveCache();
+});
+document.getElementById('resetAll').addEventListener('click', () => {
+  QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  saveCache();
+});
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    activeSet = tab.dataset.set;
+    applyFilter();
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  });
+});
+
+if (SETS.length > 1) applyFilter();
+else updateScore();
+
+// Dark-mode toggle. Persists across reloads in localStorage but falls back
+// to prefers-color-scheme when no preference is stored.
+const THEME_KEY = 'quiz-theme';
+function applyTheme(theme) {
+  const html = document.documentElement;
+  if (theme === 'dark' || theme === 'light') {
+    html.setAttribute('data-theme', theme);
+  } else {
+    html.removeAttribute('data-theme');
+  }
+  const isDark = theme === 'dark'
+    || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.getElementById('themeIcon').textContent = isDark ? '☀️' : '🌙';
+  document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+}
+applyTheme(localStorage.getItem(THEME_KEY));
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const isCurrentlyDark = current === 'dark'
+    || (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const next = isCurrentlyDark ? 'light' : 'dark';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+});
+</script>
+</body>
+</html>

--- a/public/ncp-ousd/index.html
+++ b/public/ncp-ousd/index.html
@@ -142,7 +142,25 @@
     border-bottom: 1px solid var(--border);
     font-weight: bold;
     z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    flex-wrap: wrap;
   }
+  #scoreText .ok { color: var(--reveal); }
+  #scoreText .ko { color: var(--wrong-border); }
+  #reviewWrong {
+    font-size: .85rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  #reviewWrong.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  #reviewWrong:disabled { opacity: .5; cursor: default; }
   .multi-tag {
     font-size: .75rem;
     background: var(--multi-bg);
@@ -227,7 +245,10 @@
 </div>
 <p class="note">Select an answer per question (or multiple where tagged <span class="multi-tag">multi</span>). Use <em>Check</em> to reveal the correct option, or <em>Check all</em> at the bottom.</p>
 
-<div id="score">Score: 0 / 0 answered</div>
+<div id="score">
+  <span id="scoreText">Score: 0 / 0 answered</span>
+  <button id="reviewWrong" type="button" disabled>Review wrong (0)</button>
+</div>
 <div id="quiz"></div>
 <div class="actions" style="margin: 2rem 0;">
   <button id="checkAll" class="primary">Check all</button>
@@ -1185,8 +1206,9 @@ const QUESTIONS = [
 const SETS = [];
 
 const quiz = document.getElementById('quiz');
-const scoreEl = document.getElementById('score');
+const scoreEl = document.getElementById('scoreText');
 let activeSet = 'all';  // 'all' or a set name like 'set1'
+let reviewWrong = false;  // when true, show only answered-incorrectly questions
 
 function letter(i) { return String.fromCharCode(65 + i); }
 
@@ -1259,30 +1281,52 @@ function inActiveSet(q) {
   return activeSet === 'all' || q.set === activeSet;
 }
 
+function pickedFor(qi) {
+  return [...document.querySelectorAll(`#q${qi} input`)]
+    .filter(i => i.checked).map(i => +i.value);
+}
+
+function isExact(qi, picked) {
+  const expected = new Set(QUESTIONS[qi].c);
+  return picked.length === expected.size && picked.every(p => expected.has(p));
+}
+
+// A question counts as "wrong" once it has a selection that is not an exact match.
+function isWrongAnswered(qi) {
+  const picked = pickedFor(qi);
+  return picked.length > 0 && !isExact(qi, picked);
+}
+
 function updateScore() {
   let answered = 0, correct = 0, total = 0;
   QUESTIONS.forEach((q, qi) => {
     if (!inActiveSet(q)) return;
     total++;
-    const inputs = document.querySelectorAll(`#q${qi} input`);
-    const picked = [...inputs].filter(i => i.checked).map(i => +i.value);
+    const picked = pickedFor(qi);
     if (picked.length === 0) return;
     answered++;
-    const expected = new Set(q.c);
-    const isExactMatch =
-      picked.length === expected.size &&
-      picked.every(p => expected.has(p));
-    if (isExactMatch) correct++;
+    if (isExact(qi, picked)) correct++;
   });
+  const wrong = answered - correct;
   const label = activeSet === 'all' ? 'overall' : activeSet;
-  scoreEl.textContent = `Score: ${correct} / ${answered} answered (of ${total}, ${label})`;
+  scoreEl.innerHTML =
+    `<span class="ok">${correct} correct</span> · ` +
+    `<span class="ko">${wrong} wrong</span> · ` +
+    `${answered}/${total} answered (${label})`;
+  const reviewBtn = document.getElementById('reviewWrong');
+  if (reviewBtn) {
+    reviewBtn.textContent = reviewWrong ? `Show all (${wrong} wrong)` : `Review wrong (${wrong})`;
+    reviewBtn.classList.toggle('active', reviewWrong);
+    reviewBtn.disabled = wrong === 0 && !reviewWrong;
+  }
 }
 
 function applyFilter() {
   QUESTIONS.forEach((q, qi) => {
     const el = document.getElementById(`q${qi}`);
     if (!el) return;
-    el.classList.toggle('hidden', !inActiveSet(q));
+    const visible = inActiveSet(q) && (!reviewWrong || isWrongAnswered(qi));
+    el.classList.toggle('hidden', !visible);
   });
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.set === activeSet);
@@ -1345,7 +1389,20 @@ document.getElementById('checkAll').addEventListener('click', () => {
 });
 document.getElementById('resetAll').addEventListener('click', () => {
   QUESTIONS.forEach((q, qi) => { if (inActiveSet(q)) resetQuestion(qi); });
+  reviewWrong = false;
+  applyFilter();
   saveCache();
+});
+
+document.getElementById('reviewWrong').addEventListener('click', () => {
+  reviewWrong = !reviewWrong;
+  if (reviewWrong) {
+    // Reveal correct answers on the wrong questions so they can be reviewed.
+    QUESTIONS.forEach((q, qi) => { if (inActiveSet(q) && isWrongAnswered(qi)) checkQuestion(qi); });
+    saveCache();
+  }
+  applyFilter();
+  window.scrollTo({ top: 0, behavior: 'instant' });
 });
 
 document.querySelectorAll('.tab').forEach(tab => {


### PR DESCRIPTION
Adds four self-contained practice-quiz pages under public/ so they deploy at memorable, **unlinked** routes (not referenced in nav and absent from the sitemap — reachable only by direct URL):

| Route | Exam | Questions |
|-------|------|-----------|
| /ncp-aai | NCP-AAI Agentic AI | 121 (20 multi) |
| /ncp-ousd | NCP-OUSD OpenUSD Development | 71 (18 multi) |
| /ncp-aio | NCP-AIO (existing) | — |
| /nca-genm | Generative AI Multimodal (existing) | — |

- AAI/OUSD pages include a **per-question explanation** revealed on *Check* (plus an explicit Explanation toggle).
- Each page is a single static HTML file (inline CSS/JS), dark/light theme, localStorage progress — same template family as the existing quizzes.
- `astro build` passes; all four emit to `dist/<route>/index.html`; sitemap contains 0 references to them.

Source generators live in `dev/html/` (`_parse_exam.py`, `_build_html.py`).