### PR TITLE
fix(hero): preserve spacing in localized tagline

### DIFF
--- a/e2e/portfolio-smoke.spec.ts
+++ b/e2e/portfolio-smoke.spec.ts
@@ -50,6 +50,18 @@ test.describe('portfolio homepage smoke', () => {
     });
   }
 
+  for (const { route, tagline } of [
+    { route: '/', tagline: 'I like building things with AI & data.' },
+    { route: '/es/', tagline: 'Me gusta construir cosas con IA y datos.' },
+    { route: '/ca/', tagline: "M'agrada construir coses amb IA i dades." },
+  ]) {
+    test(`${route} keeps spacing between hero tagline segments`, async ({ page }) => {
+      await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+      await expect(page.locator('.hero-tagline')).toHaveText(tagline);
+    });
+  }
+
   test('mobile menu opens, navigates, and unlocks body scroll', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/', { waitUntil: 'domcontentloaded' });

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,7 +15,7 @@ const t = useTranslations(lang);
     <p class="hero-greeting">{t('hero.greeting')}</p>
     <h1 class="hero-name">Pol Casacuberta</h1>
     <p class="hero-tagline">
-      {t('hero.tagline_1')}
+      {t('hero.tagline_1')}{' '}
       <span class="gradient-text">{t('hero.tagline_2')}</span>
     </p>
     <p class="hero-description">


### PR DESCRIPTION
## Summary
- render an explicit space between the localized hero tagline segments
- add smoke coverage for English, Spanish, and Catalan

## Validation
- npm run test:e2e:smoke
- npm test
- npm run lint
- npm run format:check
- npm run check
- npm run build